### PR TITLE
• feat: add head/tail/find/grep/cut/which/env and doc updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,5 @@ scripts/manager.py
 .vs/
 
 /testing
+
+/CMakeSettings.json

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,7 +21,7 @@ option(USE_HARDLINKS "Use hardlinks for commands instead of separate executables
 # Option to enable UPX compression
 option(ENABLE_UPX "Enable UPX compression for executables" OFF)
 # Generate the map info(For the developers to collect binary information)
-option(GENERATE_MAP_INFO "Generate_MAP_INFO" OFF)
+option(GENERATE_MAP_INFO "Generate_MAP_INFO" ON)
 
 if (USE_STATIC_CRT)
     set(CMAKE_MSVC_RUNTIME_LIBRARY "MultiThreaded")
@@ -41,7 +41,7 @@ endif ()
 include(cmake/enable_import_std.cmake)
 
 project(WinuxCmd
-        VERSION 0.2.0
+        VERSION 0.3.0
         DESCRIPTION "Windows Compatible Linux Command Set"
         LANGUAGES CXX
 )

--- a/README-zh.md
+++ b/README-zh.md
@@ -19,17 +19,29 @@ irm https://dl.caomengxuan666.com/install.ps1 | iex
 2. 解压到任意目录
 3. 运行设置脚本：`winux-activate.ps1`
 
-## 📦 已实现的命令 (v0.1.0)
+## 📦 已实现的命令 (v0.1.x)
 
-| 命令 | 描述 | 支持的参数 |
-|------|------|------------|
-| ls | 列出目录内容 | -l, -a, -h, -r, -t -n, --color |
+| 命令 | 描述 | 支持的参数（标记 [NOT SUPPORT] 的参数会被解析但未实现） |
+|------|------|------------------------------------------------|
+| ls | 列出目录内容 | -l, -a, -h, -r, -t, -n, --color |
 | cat | 显示文件内容 | -n, -E, -s, -T |
 | cp | 复制文件/目录 | -r, -v, -f, -i |
 | mv | 移动/重命名文件 | -v, -f, -i, -n |
 | rm | 删除文件/目录 | -r, -f, -v, -i |
 | mkdir | 创建目录 | -p, -v, -m MODE |
+| rmdir | 删除空目录 | --ignore-fail-on-non-empty, -p/--parents, -v |
+| touch | 更新时间戳/创建文件 | -a, -c/--no-create, -d/--date, -h/--no-dereference, -m, -r/--reference, -t, --time |
 | echo | 显示文本 | -n, -e, -E |
+| head | 输出文件前部 | -n/--lines, -c/--bytes, -q/--quiet/--silent, -v/--verbose, -z/--zero-terminated |
+| tail | 输出文件尾部 | -n/--lines, -c/--bytes, -z/--zero-terminated, -f/--follow [NOT SUPPORT], -F [NOT SUPPORT], --pid [NOT SUPPORT], --sleep-interval [NOT SUPPORT] |
+| find | 查找文件 | -name, -iname, -type(d/f/l), -mindepth, -maxdepth, -print, -print0, -P, -quit；-L/-H/-delete/-exec/-ok/-printf/-prune 为 [NOT SUPPORT] |
+| grep | 文本搜索 | -E/-F/-G, -e, -f, -i/--no-ignore-case, -w, -x, -z, -s, -v, -m NUM, -b, -n, --line-buffered, -H/-h, --label, --binary-files, -r/-R, --include/--exclude/--exclude-dir, -L/-l, -c, -T, -Z, --color；-P 为 [NOT SUPPORT] |
+| sort | 排序 | -b, -f, -n, -r, -u, -z, -o FILE, -t SEP, -k KEY；-d/-g/-i/-h/-M/-m/-R/-s 为 [NOT SUPPORT] |
+| uniq | 去重 | -c, -d, -f NUM, -i, -s NUM, -u, -w NUM, -z；-D、--group 为 [NOT SUPPORT] |
+| cut | 按列截取 | -d 分隔符, -f 列表, -s, -z；-b/-c/--output-delimiter 为 [NOT SUPPORT] |
+| which | 查找可执行文件 | -a；--skip-dot/--skip-tilde/--show-dot/--show-tilde 为 [NOT SUPPORT] |
+| env | 查看/修改环境变量 | -i/--ignore-environment, -u 名称, -0/--null；-S/--split-string、-C/--chdir、执行 COMMAND 为 [NOT SUPPORT] |
+| wc | 统计行/词/字节 | -c, -l, -w, -m, -L |
 
 ## 🎯 为什么选择 WinuxCmd？
 

--- a/README.md
+++ b/README.md
@@ -19,17 +19,29 @@ irm https://dl.caomengxuan666.com/install.ps1 | iex
 2. Extract to any directory
 3. Run the setup script: `winux-activate.ps1`
 
-## 📦 Currently Implemented Commands (v0.1.0)
+## 📦 Currently Implemented Commands (v0.1.x)
 
-| Command | Description | Supported Flags |
-|---------|-------------|-----------------|
-| ls | List directory contents | -l, -a, -h, -r, -t -n, --color |
+| Command | Description | Supported Flags ( [NOT SUPPORT] = parsed but not implemented ) |
+|---------|-------------|---------------------------------------------------------------|
+| ls | List directory contents | -l, -a, -h, -r, -t, -n, --color |
 | cat | Concatenate and display files | -n, -E, -s, -T |
 | cp | Copy files and directories | -r, -v, -f, -i |
 | mv | Move/rename files | -v, -f, -i, -n |
 | rm | Remove files/directories | -r, -f, -v, -i |
 | mkdir | Create directories | -p, -v, -m MODE |
+| rmdir | Remove empty directories | --ignore-fail-on-non-empty, -p/--parents, -v |
+| touch | Update file timestamps / create | -a, -c/--no-create, -d/--date, -h/--no-dereference, -m, -r/--reference, -t, --time |
 | echo | Display text | -n, -e, -E |
+| head | Output first part of files | -n/--lines, -c/--bytes, -q/--quiet/--silent, -v/--verbose, -z/--zero-terminated |
+| tail | Output last part of files | -n/--lines, -c/--bytes, -z/--zero-terminated, -f/--follow [NOT SUPPORT], -F [NOT SUPPORT], --pid [NOT SUPPORT], --sleep-interval [NOT SUPPORT] |
+| find | Search for files | -name, -iname, -type (d/f/l), -mindepth, -maxdepth, -print, -print0, -P, -quit; -L/-H/-delete/-exec/-ok/-printf/-prune [NOT SUPPORT] |
+| grep | Print lines matching patterns | -E/-F/-G, -e, -f, -i/--no-ignore-case, -w, -x, -z, -s, -v, -m NUM, -b, -n, --line-buffered, -H/-h, --label, --binary-files, -r/-R, --include/--exclude/--exclude-dir, -L/-l, -c, -T, -Z, --color; -P [NOT SUPPORT] |
+| sort | Sort lines | -b, -f, -n, -r, -u, -z, -o FILE, -t SEP, -k KEY; -d/-g/-i/-h/-M/-m/-R/-s [NOT SUPPORT] |
+| uniq | Report or omit repeated lines | -c, -d, -f NUM, -i, -s NUM, -u, -w NUM, -z; -D, --group [NOT SUPPORT] |
+| cut | Cut fields from lines | -d DELIM, -f LIST, -s, -z; -b/-c/--output-delimiter [NOT SUPPORT] |
+| which | Locate a command in PATH/PATHEXT | -a; --skip-dot/--skip-tilde/--show-dot/--show-tilde [NOT SUPPORT] |
+| env | Print/modify environment | -i/--ignore-environment, -u NAME, -0/--null; -S/--split-string, -C/--chdir, running COMMAND [NOT SUPPORT] |
+| wc | Count lines/words/bytes | -c, -l, -w, -m, -L |
 
 ## 🎯 Why WinuxCmd?
 

--- a/scripts/map_analizer.py
+++ b/scripts/map_analizer.py
@@ -1,0 +1,946 @@
+#!/usr/bin/env python3
+"""
+MSVC Map File Profiler
+==========================================
+Complete analysis tool for MSVC .map files with visualization and deep inspection.
+
+Features:
+    - Precise symbol size calculation using section table
+    - 18-category classification with no double counting
+    - Template instantiation hotspot analysis
+    - COMDAT folding estimation (/OPT:ICF)
+    - STL overhead attribution per object file
+    - Console output with ASCII progress bars
+    - CSV export for all symbols
+    - JSON export with summary and optional full symbol list
+    - Matplotlib charts (pie chart, bar chart)
+    - Standalone HTML report with ECharts
+    - Multi-file comparison
+"""
+
+import re
+import sys
+import os
+import argparse
+import json
+import csv
+from collections import defaultdict
+from pathlib import Path
+
+# ============================================================================
+# Optional dependencies
+# ============================================================================
+try:
+    import matplotlib.pyplot as plt
+    HAS_MATPLOTLIB = True
+except ImportError:
+    HAS_MATPLOTLIB = False
+
+try:
+    import colorama
+    from colorama import Fore, Style
+    colorama.init()
+    HAS_COLORAMA = True
+except ImportError:
+    HAS_COLORAMA = False
+
+
+# ============================================================================
+# Constants & Classification Rules
+# ============================================================================
+
+# Category priority: symbols are only assigned to the FIRST matching category
+CATEGORY_PRIORITY = [
+    ("exception",           ["throw", "catch", "ehstate", "xthrow", "uncaught",
+                             "_tls", "seh_", "CxxFrameHandler"]),
+    ("rtti_vtable",        ["??_7", "UEAA", "RTTI", "type_info", "`vftable'",
+                            "`RTTI Complete Object Locator'"]),
+    ("std_function",       ["_Func_impl", "lambda", "operator()", "?R", "?A0x"]),
+    ("unordered_map",      ["unordered_map", "_Hash", "_Umap", "registry", "_HashMap"]),
+    ("stl_string",         ["?$basic_string", "?$char_traits", "?$allocator"]),
+    ("stl_vector",         ["?$vector", "?$_Vector", "?$_Reallocate"]),
+    ("stl_other",          ["?$list", "?$deque", "?$set", "?$map", "?$_Tree", "?$_List"]),
+    ("module_metadata",    ["?__CxxModule", "cppm.obj"]),
+    ("crt_startup",        ["_crt_", "__scrt_", "mainCRTStartup", "WinMainCRTStartup"]),
+    ("thread_local",       ["_tls_", "TLS", "thread_local"]),
+    ("guard",             ["_guard", "__guard", "___guard"]),
+    ("global_ctor",       ["`dynamic initializer'", "`dynamic atexit destructor'"]),
+    ("virtual_inline",    ["*::`vcall'", "*::`scalar deleting destructor'"]),
+    ("code_my",           []),  # Business logic - matched after excluding libs
+    ("code_lib",          []),  # Static library code (CRT, etc)
+    ("data",             ["?g_", "?s_", "?_"]),
+    ("other",            []),
+]
+
+CATEGORY_NAMES = [c[0] for c in CATEGORY_PRIORITY]
+CATEGORY_PATTERNS = [c[1] for c in CATEGORY_PRIORITY]
+
+# Object files that are considered part of the C/C++ runtime
+LIB_OBJ_KEYWORDS = ["libc", "libvcruntime", "libucrt", "msvcrt", "crt"]
+
+
+# ============================================================================
+# Core Parser
+# ============================================================================
+class MapParser:
+    """MSVC .map file parser with section table and symbol resolution."""
+
+    SECTION_LINE_RE = re.compile(
+        r'^\s*([0-9A-F]{4}):([0-9A-F]{8})\s+([0-9A-F]{6,8}H?)\s+(\S+)\s+(\S+)',
+        re.IGNORECASE
+    )
+
+    SYMBOL_LINE_RE = re.compile(
+        r'^\s*([0-9A-F]{4}):([0-9A-F]{8})\s+(\S+?)(?:\s+([0-9A-F]{8,16}|\S+))?\s+f?\s+([i\s])?\s*(.*?\.(?:obj|lib|o|a))?',
+        re.IGNORECASE
+    )
+
+    def __init__(self, map_path):
+        self.map_path = Path(map_path)
+        self.sections = {}        # (section_index, start_offset) -> {length, name, class}
+        self.symbols = []         # Raw symbols without size
+        self.symbols_with_size = []  # Symbols with calculated size
+
+    def parse(self):
+        """Parse map file and calculate symbol sizes."""
+        with open(self.map_path, 'r', encoding='utf-8', errors='ignore') as f:
+            content = f.read()
+
+        self._parse_sections(content)
+        self._parse_publics(content)
+        self._calculate_sizes()
+        return self
+
+    def _parse_sections(self, content):
+        """Extract section table information."""
+        lines = content.splitlines()
+        in_section_table = False
+
+        for line in lines:
+            if line.startswith(" Start         Length     Name                   Class"):
+                in_section_table = True
+                continue
+            if not in_section_table:
+                continue
+            if not line.strip() or line.startswith(" ---"):
+                continue
+
+            m = self.SECTION_LINE_RE.match(line)
+            if m:
+                section = m.group(1)
+                start = m.group(2)
+                length_str = m.group(3).rstrip('H')
+                length = int(length_str, 16)
+                name = m.group(4)
+                key = (section, start)
+                self.sections[key] = {
+                    'length': length,
+                    'name': name,
+                    'class': m.group(5)
+                }
+            else:
+                if line and not line[0].isspace():
+                    in_section_table = False
+
+    def _parse_publics(self, content):
+        """Extract public symbols from 'Publics by Value' section."""
+        marker = "Address         Publics by Value"
+        if marker not in content:
+            marker = "Publics by Value"
+        if marker not in content:
+            print("❌ ERROR: Cannot find symbol table in map file!")
+            return
+
+        start = content.find(marker)
+        end = content.find("entry point at", start)
+        if end == -1:
+            end = len(content)
+
+        symbol_text = content[start:end]
+        lines = symbol_text.split('\n')[1:]
+
+        for line in lines:
+            line = line.strip()
+            if not line or line.startswith('---'):
+                continue
+
+            m = self.SYMBOL_LINE_RE.match(line)
+            if m:
+                section = m.group(1)
+                offset = m.group(2)
+                name = m.group(3)
+                rva = m.group(4) or ''
+                obj = m.group(6) or 'unknown'
+                obj_name = Path(obj).name if obj != 'unknown' else 'unknown'
+
+                self.symbols.append({
+                    'name': name,
+                    'section': section,
+                    'offset': offset,
+                    'offset_int': int(offset, 16),
+                    'rva': rva,
+                    'obj': obj_name,
+                    'obj_full': obj,
+                    'line': line.strip()
+                })
+
+    def _calculate_sizes(self):
+        """Calculate symbol sizes using section boundaries and symbol order."""
+        # Group symbols by section
+        sec_map = defaultdict(list)
+        for sym in self.symbols:
+            sec_map[sym['section']].append(sym)
+
+        # Process each section
+        for sec, symlist in sec_map.items():
+            symlist.sort(key=lambda x: x['offset_int'])
+
+            # Find section info
+            sec_len = 0
+            sec_start = 0
+            for (s, start), info in self.sections.items():
+                if s == sec:
+                    sec_len = info['length']
+                    sec_start = int(start, 16)
+                    break
+
+            if sec_len == 0:
+                for sym in symlist:
+                    sym['size'] = 0
+                continue
+
+            # Calculate size as distance to next symbol
+            for i in range(len(symlist) - 1):
+                size = symlist[i+1]['offset_int'] - symlist[i]['offset_int']
+                symlist[i]['size'] = size
+                symlist[i]['size_kb'] = size / 1024.0
+
+            # Last symbol: use remaining section space
+            if symlist:
+                last = symlist[-1]
+                last['size'] = max(0, sec_len - (last['offset_int'] - sec_start))
+                last['size_kb'] = last['size'] / 1024.0
+
+        # Flatten and filter
+        for symlist in sec_map.values():
+            self.symbols_with_size.extend(symlist)
+
+        # Filter out zero-size and abnormally large (>1MB) symbols
+        self.symbols_with_size = [s for s in self.symbols_with_size
+                                  if 0 < s.get('size', 0) < 1024 * 1024]
+
+
+# ============================================================================
+# Symbol Classifier
+# ============================================================================
+class Classifier:
+    """Classify symbols into categories based on name patterns."""
+
+    @staticmethod
+    def classify(symbol):
+        """Return category name for the given symbol."""
+        name = symbol['name']
+        obj = symbol['obj']
+
+        # Match against prioritized patterns
+        for cat_name, patterns in zip(CATEGORY_NAMES, CATEGORY_PATTERNS):
+            for p in patterns:
+                if p.lower() in name.lower():
+                    return cat_name
+
+        # Special: module metadata (C++20 modules)
+        if 'cppm.obj' in obj:
+            return 'module_metadata'
+
+        # Business logic vs library code
+        if not any(lib in obj for lib in LIB_OBJ_KEYWORDS):
+            return 'code_my'
+        else:
+            return 'code_lib'
+
+        return 'other'
+
+
+# ============================================================================
+# Statistics Aggregator
+# ============================================================================
+class StatsAggregator:
+    """Aggregate statistics by category and object file."""
+
+    def __init__(self, symbols):
+        self.symbols = symbols
+        self.by_category = defaultdict(lambda: {'size': 0, 'count': 0})
+        self.by_obj = defaultdict(lambda: {'size': 0, 'count': 0})
+        self.by_obj_detailed = defaultdict(list)
+        self._aggregate()
+
+    def _aggregate(self):
+        """Process all symbols and build statistics."""
+        for sym in self.symbols:
+            cat = Classifier.classify(sym)
+            size = sym['size']
+            obj = sym['obj']
+
+            self.by_category[cat]['size'] += size
+            self.by_category[cat]['count'] += 1
+
+            self.by_obj[obj]['size'] += size
+            self.by_obj[obj]['count'] += 1
+            self.by_obj_detailed[obj].append(sym)
+
+    def get_category_stats(self):
+        """Return statistics per category in KB."""
+        return {k: {'size_kb': v['size'] / 1024, 'count': v['count']}
+                for k, v in self.by_category.items()}
+
+    def get_top_obj(self, n=15):
+        """Return top N object files by size."""
+        sorted_obj = sorted(self.by_obj.items(),
+                            key=lambda x: x[1]['size'],
+                            reverse=True)
+        return sorted_obj[:n]
+
+
+# ============================================================================
+# Extension Analyzers
+# ============================================================================
+class ExtensionAnalyzer:
+    """Deep analysis extensions."""
+
+    @staticmethod
+    def template_hotspots(symbols, threshold=2):
+        """
+        Find frequently instantiated templates across object files.
+
+        Templates with same simplified signature are considered duplicates
+        that could be unified with explicit instantiation.
+        """
+        template_stats = defaultdict(lambda: {
+            'count': 0,
+            'objs': set(),
+            'sizes': [],
+            'example': ''
+        })
+
+        for sym in symbols:
+            name = sym['name']
+            if '?$' in name or '<' in name:
+                # Normalize type parameters to detect duplicates
+                simplified = re.sub(r'\?[A-Z0-9]+@', '?T@', name)
+                simplified = re.sub(r'\$[0-9A-F]+', '', simplified)
+                key = simplified[:120]
+
+                template_stats[key]['count'] += 1
+                template_stats[key]['objs'].add(sym['obj'])
+                template_stats[key]['sizes'].append(sym['size'])
+                if not template_stats[key]['example']:
+                    template_stats[key]['example'] = name
+
+        # Sort by repetition count
+        hot = sorted(template_stats.items(),
+                     key=lambda x: x[1]['count'],
+                     reverse=True)
+
+        print("\n🔥 TEMPLATE INSTANTIATION HOTSPOTS (repeat >= {})".format(threshold))
+        print("-" * 80)
+        total_saved = 0
+
+        for i, (key, stat) in enumerate(hot[:20]):
+            if stat['count'] >= threshold:
+                avg_size = sum(stat['sizes']) / len(stat['sizes']) / 1024
+                total_size = sum(stat['sizes']) / 1024
+                potential_save = (stat['count'] - 1) * (sum(stat['sizes']) / len(stat['sizes']))
+                total_saved += potential_save
+
+                print(f"{i+1:2}. Repeated {stat['count']:3} times | "
+                      f"Total {total_size:7.2f}KB | Avg {avg_size:5.2f}KB")
+
+                obj_list = list(stat['objs'])[:5]
+                print(f"      Objects: {', '.join(obj_list)}{'...' if len(stat['objs']) > 5 else ''}")
+
+        print(f"\n    💡 Potential saving with explicit instantiation: {total_saved/1024:.2f}KB")
+
+    @staticmethod
+    def estimate_icf_savings(symbols):
+        """
+        Estimate potential size reduction with /OPT:ICF (COMDAT folding).
+
+        Symbols with same section, size, and normalized name are considered
+        identical and could be folded by the linker.
+        """
+        groups = defaultdict(list)
+
+        for sym in symbols:
+            if sym['size'] == 0:
+                continue
+
+            # Remove address offsets to detect identical functions
+            simple_name = re.sub(r'[0-9A-F]{8,16}', '', sym['name'])
+            simple_name = re.sub(r'\?\?_[0-9]', '', simple_name)
+            key = (sym['section'], sym['size'], simple_name[:50])
+            groups[key].append(sym)
+
+        saved = 0
+        collapsed = 0
+
+        print("\n🗜️  COMDAT FOLDING ESTIMATE (/OPT:ICF)")
+        print("-" * 80)
+
+        for key, symlist in groups.items():
+            if len(symlist) > 1:
+                repeat = len(symlist) - 1
+                size = symlist[0]['size']
+                saved += repeat * size
+                collapsed += repeat
+                print(f"  Fold {repeat:2} instances, save {repeat * size / 1024:7.2f}KB  {symlist[0]['name'][:60]}")
+
+        print(f"\n    💡 Estimated saving: {saved / 1024:.2f}KB ({collapsed} symbols)")
+
+    @staticmethod
+    def stl_per_obj(stats):
+        """
+        Attribute STL instantiation costs to specific object files.
+
+        Shows which business logic modules are pulling in STL code,
+        helping prioritize optimization efforts.
+        """
+        stl_cats = {'stl_string', 'stl_vector', 'stl_other', 'unordered_map', 'std_function'}
+        per_obj = defaultdict(float)
+
+        for obj, symlist in stats.by_obj_detailed.items():
+            for sym in symlist:
+                cat = Classifier.classify(sym)
+                if cat in stl_cats:
+                    per_obj[obj] += sym['size']
+
+        sorted_obj = sorted(per_obj.items(), key=lambda x: x[1], reverse=True)
+
+        print("\n📎 STL INSTANTIATION BY OBJECT FILE")
+        print("-" * 80)
+
+        for obj, sz in sorted_obj[:15]:
+            print(f"  {sz/1024:7.2f}KB  {obj}")
+
+        total_stl = sum(per_obj.values()) / 1024
+        print(f"\n    💡 Total STL overhead from business logic: {total_stl:.2f}KB")
+        return per_obj
+
+    @staticmethod
+    def export_html_report(parser, stats, args, output_path):
+        """
+        Generate standalone HTML report with interactive charts.
+
+        Uses ECharts CDN, no additional dependencies required.
+        Includes category pie chart, object file bar chart, and template hotspots.
+        """
+        cat_stats = stats.get_category_stats()
+        total_kb = sum(s['size_kb'] for s in cat_stats.values())
+
+        cat_data = [{'name': k, 'value': round(v['size_kb'], 2)}
+                    for k, v in cat_stats.items()]
+        obj_data = [{'name': o[:30], 'value': round(st['size']/1024, 2)}
+                    for o, st in stats.get_top_obj(20)]
+
+        # Get template hotspots for HTML report
+        template_hotspots = []
+        hotspots_raw = ExtensionAnalyzer._get_template_hotspots_raw(stats.symbols, top=10)
+        template_hotspots = [{
+            'name': h['name'][:60],
+            'count': h['count'],
+            'total_kb': round(h['total_kb'], 2)
+        } for h in hotspots_raw]
+
+        html_content = f"""<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8">
+    <title>MSVC Map Analysis - {parser.map_path.name}</title>
+    <script src="https://cdn.jsdelivr.net/npm/echarts@5/dist/echarts.min.js"></script>
+    <style>
+        body {{ font-family: 'Segoe UI', Arial, sans-serif; margin: 20px; background: #f5f5f5; }}
+        .container {{ max-width: 1200px; margin: auto; background: white; padding: 20px; box-shadow: 0 0 10px rgba(0,0,0,0.1); }}
+        h1 {{ color: #333; border-bottom: 2px solid #4CAF50; padding-bottom: 10px; }}
+        h2 {{ color: #555; margin-top: 30px; }}
+        .summary {{ background: #e8f5e9; padding: 15px; border-radius: 5px; margin: 20px 0; }}
+        .chart-container {{ display: flex; flex-wrap: wrap; justify-content: space-around; }}
+        .chart-box {{ width: 45%; min-width: 400px; height: 400px; margin-bottom: 30px; }}
+        table {{ border-collapse: collapse; width: 100%; margin-top: 20px; }}
+        th, td {{ border: 1px solid #ddd; padding: 8px; text-align: left; }}
+        th {{ background-color: #4CAF50; color: white; }}
+        tr:nth-child(even) {{ background-color: #f2f2f2; }}
+        .footer {{ text-align: right; color: #666; margin-top: 30px; font-style: italic; }}
+    </style>
+</head>
+<body>
+<div class="container">
+    <h1>📊 MSVC Map Analysis Report - {parser.map_path.name}</h1>
+    
+    <div class="summary">
+        <strong>Total Code Size:</strong> {total_kb:.2f}KB &nbsp;|&nbsp;
+        <strong>Symbol Count:</strong> {len(parser.symbols_with_size)} &nbsp;|&nbsp;
+        <strong>Analysis Time:</strong> {__import__('datetime').datetime.now().strftime('%Y-%m-%d %H:%M:%S')}
+    </div>
+    
+    <div class="chart-container">
+        <div id="pieChart" class="chart-box"></div>
+        <div id="barChart" class="chart-box"></div>
+    </div>
+    
+    <h2>📌 Template Hotspots (Top 10)</h2>
+    <table>
+        <thead>
+            <tr>
+                <th>Template Signature</th>
+                <th>Repeat Count</th>
+                <th>Total Size (KB)</th>
+            </tr>
+        </thead>
+        <tbody>
+            {''.join(f"<tr><td>{h['name']}</td><td>{h['count']}</td><td>{h['total_kb']}</td></tr>"
+                     for h in template_hotspots)}
+        </tbody>
+    </table>
+    
+    <h2>📦 Top 20 Object Files</h2>
+    <table>
+        <thead>
+            <tr>
+                <th>Object File</th>
+                <th>Size (KB)</th>
+            </tr>
+        </thead>
+        <tbody>
+            {''.join(f"<tr><td>{d['name']}</td><td>{d['value']}</td></tr>" for d in obj_data)}
+        </tbody>
+    </table>
+    
+    <div class="footer">
+        Generated by MSVC Map Profiler - Ultimate Edition
+    </div>
+</div>
+
+<script>
+    // Pie chart
+    var pieChart = echarts.init(document.getElementById('pieChart'));
+    var pieOption = {{
+        title: {{ text: 'Size by Category', left: 'center' }},
+        tooltip: {{ trigger: 'item' }},
+        series: [
+            {{
+                name: 'Size (KB)',
+                type: 'pie',
+                radius: '50%',
+                data: {json.dumps(cat_data)},
+                emphasis: {{
+                    itemStyle: {{
+                        shadowBlur: 10,
+                        shadowOffsetX: 0,
+                        shadowColor: 'rgba(0,0,0,0.5)'
+                    }}
+                }}
+            }}
+        ]
+    }};
+    pieChart.setOption(pieOption);
+    
+    // Bar chart
+    var barChart = echarts.init(document.getElementById('barChart'));
+    var barOption = {{
+        title: {{ text: 'Top 20 Object Files', left: 'center' }},
+        tooltip: {{ trigger: 'axis' }},
+        xAxis: {{
+            type: 'category',
+            data: {json.dumps([d['name'] for d in obj_data])},
+            axisLabel: {{ rotate: 45 }}
+        }},
+        yAxis: {{
+            type: 'value',
+            name: 'Size (KB)'
+        }},
+        series: [{{
+            data: {json.dumps([d['value'] for d in obj_data])},
+            type: 'bar',
+            itemStyle: {{ color: '#4CAF50' }}
+        }}]
+    }};
+    barChart.setOption(barOption);
+</script>
+</body>
+</html>"""
+
+        with open(output_path, 'w', encoding='utf-8') as f:
+            f.write(html_content)
+        print(f"✅ HTML report generated: {output_path}")
+
+    @staticmethod
+    def _get_template_hotspots_raw(symbols, top=10):
+        """Internal helper to get raw template hotspot data."""
+        template_stats = defaultdict(lambda: {'count': 0, 'sizes': [], 'name': ''})
+
+        for sym in symbols:
+            name = sym['name']
+            if '?$' in name or '<' in name:
+                simplified = re.sub(r'\?[A-Z0-9]+@', '?T@', name)
+                simplified = re.sub(r'\$[0-9A-F]+', '', simplified)
+                key = simplified[:120]
+                template_stats[key]['count'] += 1
+                template_stats[key]['sizes'].append(sym['size'])
+                if not template_stats[key]['name']:
+                    template_stats[key]['name'] = name
+
+        hot = sorted(template_stats.items(),
+                     key=lambda x: x[1]['count'],
+                     reverse=True)[:top]
+
+        result = []
+        for key, stat in hot:
+            result.append({
+                'name': stat['name'][:80],
+                'count': stat['count'],
+                'total_kb': sum(stat['sizes']) / 1024
+            })
+        return result
+
+
+# ============================================================================
+# Reporter
+# ============================================================================
+class Reporter:
+    """Generate console, CSV, JSON, and chart reports."""
+
+    def __init__(self, parser, stats, args):
+        self.parser = parser
+        self.stats = stats
+        self.args = args
+
+    def print_console(self):
+        """Print colored console report with ASCII progress bars."""
+        if HAS_COLORAMA and not self.args.no_color:
+            red = Fore.RED
+            green = Fore.GREEN
+            yellow = Fore.YELLOW
+            cyan = Fore.CYAN
+            reset = Style.RESET_ALL
+        else:
+            red = green = yellow = cyan = reset = ''
+
+        print(f"\n{cyan}🔍 ANALYSIS REPORT: {self.parser.map_path}{reset}")
+        print("=" * 80)
+
+        # Category statistics
+        cat_stats = self.stats.get_category_stats()
+        total_kb = sum(s['size_kb'] for s in cat_stats.values())
+        sorted_cat = sorted(cat_stats.items(),
+                            key=lambda x: x[1]['size_kb'],
+                            reverse=True)
+
+        print(f"\n{cyan}📊 CATEGORY SIZE RANKING{reset}")
+        print("-" * 80)
+
+        for cat, stat in sorted_cat:
+            pct = (stat['size_kb'] / total_kb * 100) if total_kb else 0
+            bar_len = int(stat['size_kb'] / total_kb * 50) if total_kb else 0
+            bar = '█' * bar_len + '░' * (50 - bar_len)
+            size_str = f"{stat['size_kb']:>8.2f}KB"
+            print(f"{bar} {size_str} {pct:5.1f}%  {cat:20} ({stat['count']} symbols)")
+
+        # High-risk categories
+        print(f"\n{red}🔥 HIGH-RISK OPTIMIZATION TARGETS{reset}")
+        print("-" * 80)
+        targets = ['std_function', 'unordered_map', 'stl_string', 'stl_vector', 'stl_other']
+        for t in targets:
+            if t in cat_stats:
+                kb = cat_stats[t]['size_kb']
+                if kb > 5:
+                    print(f"  {t:20}: {kb:>8.2f}KB  ✅ Immediate action recommended")
+
+        # Business logic
+        my_code = cat_stats.get('code_my', {}).get('size_kb', 0)
+        print(f"\n{green}💻 BUSINESS LOGIC{reset}")
+        print("-" * 80)
+        print(f"  Total business code: {my_code:.2f}KB  ({my_code/total_kb*100:.1f}%)")
+
+        # Top object files
+        print(f"\n{yellow}📦 TOP 15 OBJECT FILES{reset}")
+        print("-" * 80)
+        top_obj = self.stats.get_top_obj(15)
+        for i, (obj, st) in enumerate(top_obj, 1):
+            size_kb = st['size'] / 1024
+            print(f"{i:2}. {size_kb:>8.2f}KB  {obj}")
+
+        # Overall statistics
+        print(f"\n{cyan}📈 OVERALL STATISTICS{reset}")
+        print("-" * 80)
+        print(f"  Symbols parsed    : {len(self.parser.symbols_with_size)}")
+        print(f"  Total code size   : {total_kb:.2f}KB")
+        print(f"  Average symbol size: {total_kb/len(self.parser.symbols_with_size):.2f}KB")
+
+        # Extension analyses
+        if not self.args.skip_template:
+            ExtensionAnalyzer.template_hotspots(self.parser.symbols_with_size)
+        if not self.args.skip_icf:
+            ExtensionAnalyzer.estimate_icf_savings(self.parser.symbols_with_size)
+        if not self.args.skip_stl_per_obj:
+            ExtensionAnalyzer.stl_per_obj(self.stats)
+
+        # Action items summary
+        print(f"\n{green}💡 ACTION ITEMS{reset}")
+        print("-" * 80)
+        if 'std_function' in cat_stats and cat_stats['std_function']['size_kb'] > 10:
+            print(f"  • Remove std::function: save {cat_stats['std_function']['size_kb']:.1f}KB → "
+                  f"Use function pointers or static dispatch")
+        if 'unordered_map' in cat_stats and cat_stats['unordered_map']['size_kb'] > 10:
+            print(f"  • Remove unordered_map: save {cat_stats['unordered_map']['size_kb']:.1f}KB → "
+                  f"Replace with std::map or linear search")
+        if 'stl_string' in cat_stats and cat_stats['stl_string']['size_kb'] > 50:
+            print(f"  • STL string overhead: {cat_stats['stl_string']['size_kb']:.1f}KB → "
+                  f"Add explicit instantiation, use string_view")
+        if not self.args.skip_icf:
+            print(f"  • Enable /OPT:ICF linker option: zero-cost saving")
+        print()
+
+    def export_csv(self, output_path):
+        """Export all symbols to CSV file."""
+        with open(output_path, 'w', newline='', encoding='utf-8') as f:
+            writer = csv.writer(f)
+            writer.writerow(['Name', 'Size(KB)', 'Category', 'Object', 'Section', 'Offset', 'RVA'])
+
+            for sym in self.parser.symbols_with_size:
+                cat = Classifier.classify(sym)
+                writer.writerow([
+                    sym['name'],
+                    round(sym['size_kb'], 3),
+                    cat,
+                    sym['obj'],
+                    sym['section'],
+                    sym['offset'],
+                    sym['rva']
+                ])
+
+        print(f"✅ CSV report saved: {output_path}")
+
+    def export_json(self, output_path):
+        """Export JSON summary with optional full symbol list."""
+        cat_stats = self.stats.get_category_stats()
+        total_kb = sum(s['size_kb'] for s in cat_stats.values())
+
+        summary = {
+            'map_file': str(self.parser.map_path),
+            'total_symbols': len(self.parser.symbols_with_size),
+            'total_size_kb': round(total_kb, 2),
+            'category': {},
+            'top_obj': []
+        }
+
+        for cat, stat in cat_stats.items():
+            summary['category'][cat] = {
+                'size_kb': round(stat['size_kb'], 2),
+                'count': stat['count'],
+                'percentage': round(stat['size_kb'] / total_kb * 100, 1) if total_kb else 0
+            }
+
+        for obj, st in self.stats.get_top_obj(20):
+            summary['top_obj'].append({
+                'object': obj,
+                'size_kb': round(st['size'] / 1024, 2),
+                'count': st['count']
+            })
+
+        if self.args.full_json:
+            summary['symbols'] = []
+            for sym in self.parser.symbols_with_size:
+                summary['symbols'].append({
+                    'name': sym['name'],
+                    'size_kb': round(sym['size_kb'], 3),
+                    'category': Classifier.classify(sym),
+                    'object': sym['obj'],
+                    'section': sym['section'],
+                    'offset': sym['offset'],
+                    'rva': sym['rva']
+                })
+
+        with open(output_path, 'w', encoding='utf-8') as f:
+            json.dump(summary, f, indent=2, ensure_ascii=False)
+
+        print(f"✅ JSON report saved: {output_path}")
+
+    def generate_charts(self, output_prefix):
+        """Generate matplotlib charts (pie chart and bar chart)."""
+        if not HAS_MATPLOTLIB:
+            print("⚠️ matplotlib not installed, skipping charts")
+            return
+
+        cat_stats = self.stats.get_category_stats()
+        total_kb = sum(s['size_kb'] for s in cat_stats.values())
+
+        # Prepare data for pie chart
+        labels, sizes = [], {}
+        for cat, stat in cat_stats.items():
+            pct = stat['size_kb'] / total_kb * 100
+            if pct >= 1.0:
+                labels.append(f"{cat}\n({stat['size_kb']:.1f}KB)")
+                sizes.append(stat['size_kb'])
+            else:
+                if 'Others' not in labels:
+                    labels.append('Others')
+                    sizes.append(stat['size_kb'])
+                else:
+                    idx = labels.index('Others')
+                    sizes[idx] += stat['size_kb']
+
+        # Pie chart
+        plt.figure(figsize=(10, 6))
+        plt.pie(sizes, labels=labels, autopct='%1.1f%%', startangle=90)
+        plt.title(f"Code Size by Category - {self.parser.map_path.name}")
+        plt.axis('equal')
+        pie_path = f"{output_prefix}_pie.png"
+        plt.savefig(pie_path, dpi=120)
+        plt.close()
+        print(f"✅ Pie chart saved: {pie_path}")
+
+        # Bar chart - Top 15 object files
+        top_obj = self.stats.get_top_obj(15)
+        obj_names = [os.path.basename(o[0])[:30] for o in top_obj]
+        obj_sizes = [o[1]['size'] / 1024 for o in top_obj]
+
+        plt.figure(figsize=(12, 6))
+        plt.barh(range(len(obj_names)), obj_sizes, color='steelblue')
+        plt.yticks(range(len(obj_names)), obj_names)
+        plt.xlabel('Size (KB)')
+        plt.title(f"Top 15 Object Files - {self.parser.map_path.name}")
+        plt.gca().invert_yaxis()
+
+        bar_path = f"{output_prefix}_top_obj.png"
+        plt.tight_layout()
+        plt.savefig(bar_path, dpi=120)
+        plt.close()
+        print(f"✅ Bar chart saved: {bar_path}")
+
+
+# ============================================================================
+# Multi-file comparison
+# ============================================================================
+def compare_maps(map_files, args):
+    """Compare multiple map files side by side."""
+    if len(map_files) < 2:
+        return
+
+    print("\n📊 MULTI-FILE COMPARISON")
+    print("=" * 80)
+
+    results = []
+    for mf in map_files:
+        parser = MapParser(mf).parse()
+        stats = StatsAggregator(parser.symbols_with_size)
+        cat_stats = stats.get_category_stats()
+        total_kb = sum(s['size_kb'] for s in cat_stats.values())
+        results.append({
+            'file': Path(mf).name,
+            'total_kb': total_kb,
+            'cat': cat_stats
+        })
+
+    # Print header
+    header = f"{'Category':30} " + " ".join([f"{r['file']:>12}" for r in results])
+    print(header)
+    print("-" * 80)
+
+    # Print category rows
+    all_cats = set()
+    for r in results:
+        all_cats.update(r['cat'].keys())
+
+    for cat in sorted(all_cats):
+        row = f"{cat:30} "
+        for r in results:
+            kb = r['cat'].get(cat, {}).get('size_kb', 0)
+            row += f"{kb:>12.2f} "
+        print(row)
+
+    # Delta analysis
+    print("\nDELTA ANALYSIS:")
+    base = results[0]
+    for other in results[1:]:
+        diff = other['total_kb'] - base['total_kb']
+        print(f"{other['file']} vs {base['file']}: {'+' if diff > 0 else ''}{diff:.2f}KB")
+
+        for cat in all_cats:
+            diff_cat = other['cat'].get(cat, {}).get('size_kb', 0) - \
+                       base['cat'].get(cat, {}).get('size_kb', 0)
+            if abs(diff_cat) > 10:
+                print(f"    {cat}: {'+' if diff_cat > 0 else ''}{diff_cat:.2f}KB")
+
+
+# ============================================================================
+# Main entry point
+# ============================================================================
+def main():
+    parser = argparse.ArgumentParser(
+        description="MSVC Map File Profiler - Ultimate Edition",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  # Basic analysis with all extensions
+  python map_profiler.py release/app.map
+  
+  # Generate HTML report
+  python map_profiler.py app.map --html report.html
+  
+  # Export CSV and JSON
+  python map_profiler.py app.map --csv symbols.csv --json summary.json
+  
+  # Compare two versions
+  python map_profiler.py old.map new.map
+  
+  # Skip expensive extensions for quick analysis
+  python map_profiler.py app.map --skip-template --skip-icf
+        """
+    )
+
+    parser.add_argument('map_files', nargs='+', help='One or more .map files to analyze')
+    parser.add_argument('--csv', help='Export all symbols to CSV file')
+    parser.add_argument('--json', help='Export JSON summary')
+    parser.add_argument('--full-json', action='store_true',
+                        help='Include full symbol list in JSON export')
+    parser.add_argument('--chart', help='Prefix for chart files (e.g., "output/chart")')
+    parser.add_argument('--html', help='Generate interactive HTML report')
+    parser.add_argument('--threshold', type=float, default=1.0,
+                        help='Symbol size threshold in KB (default: 1.0)')
+    parser.add_argument('--no-color', action='store_true',
+                        help='Disable colored output')
+    parser.add_argument('--skip-template', action='store_true',
+                        help='Skip template hotspot analysis')
+    parser.add_argument('--skip-icf', action='store_true',
+                        help='Skip COMDAT folding estimation')
+    parser.add_argument('--skip-stl-per-obj', action='store_true',
+                        help='Skip STL attribution analysis')
+
+    args = parser.parse_args()
+
+    # Single file analysis
+    if len(args.map_files) == 1:
+        map_file = args.map_files[0]
+        print(f"\n🔍 Analyzing: {map_file}")
+
+        map_parser = MapParser(map_file).parse()
+        stats = StatsAggregator(map_parser.symbols_with_size)
+        reporter = Reporter(map_parser, stats, args)
+
+        reporter.print_console()
+
+        if args.csv:
+            reporter.export_csv(args.csv)
+        if args.json:
+            reporter.export_json(args.json)
+        if args.chart:
+            reporter.generate_charts(args.chart)
+        if args.html:
+            ExtensionAnalyzer.export_html_report(map_parser, stats, args, args.html)
+
+    # Multi-file comparison
+    else:
+        compare_maps(args.map_files, args)
+
+
+if __name__ == '__main__':
+    main()

--- a/src/commands/cat.cpp
+++ b/src/commands/cat.cpp
@@ -19,7 +19,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- *  - File: cat.cppm
+ *  - File: cat.cpp
  *  - Username: Administrator
  *  - CopyrightYear: 2026
  */
@@ -94,7 +94,7 @@ namespace cp = core::pipeline;
 // 1. Validate arguments - OPTIMIZED: pass by reference
 // ----------------------------------------------
 auto validate_arguments(const CommandContext<CAT_OPTIONS.size()> &ctx,
-                        std::vector<std::string>& out_files)
+                        std::vector<std::string> &out_files)
     -> cp::Result<void> {
   for (auto arg : ctx.positionals) {
     out_files.push_back(std::string(arg));
@@ -110,21 +110,18 @@ auto validate_arguments(const CommandContext<CAT_OPTIONS.size()> &ctx,
 }  // namespace cat_pipeline
 
 REGISTER_COMMAND(cat, "cat",
-    "concatenate files and print on the standard output",
-    "Concatenate FILE(s) to standard output.\n"
-    "With no FILE, or when FILE is -, read standard input.\n"
-    "\nExamples:\n"
-    "  cat f g  Output f's contents, then g's contents.\n"
-    "  cat      Copy standard input to standard output.",
-    "  cat file.txt              Display contents of file.txt\n"
-    "  cat -n file.txt           Number all output lines\n"
-    "  cat file1.txt file2.txt   Concatenate multiple files\n"
-    "  cat                       Read from standard input",
-    "tac(1), head(1), tail(1), more(1), less(1)",
-    "caomengxuan666",
-    "Copyright © 2026 WinuxCmd",
-    CAT_OPTIONS) {
-
+                 "concatenate files and print on the standard output",
+                 "Concatenate FILE(s) to standard output.\n"
+                 "With no FILE, or when FILE is -, read standard input.\n"
+                 "\nExamples:\n"
+                 "  cat f g  Output f's contents, then g's contents.\n"
+                 "  cat      Copy standard input to standard output.",
+                 "  cat file.txt              Display contents of file.txt\n"
+                 "  cat -n file.txt           Number all output lines\n"
+                 "  cat file1.txt file2.txt   Concatenate multiple files\n"
+                 "  cat                       Read from standard input",
+                 "tac(1), head(1), tail(1), more(1), less(1)", "caomengxuan666",
+                 "Copyright © 2026 WinuxCmd", CAT_OPTIONS) {
   using namespace cat_pipeline;
   using namespace core::pipeline;
 
@@ -158,8 +155,10 @@ REGISTER_COMMAND(cat, "cat",
         if (c == '\n') {
           safePrint("\n");
         } else if (c == '\t') {
-          if (show_tabs) safePrint("^I");
-          else safePrint("\t");
+          if (show_tabs)
+            safePrint("^I");
+          else
+            safePrint("\t");
         } else if (c == '\f') {
           safePrint("^L");
         } else {

--- a/src/commands/cp.cpp
+++ b/src/commands/cp.cpp
@@ -19,7 +19,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- *  - File: cp.cppm
+ *  - File: cp.cpp
  *  - Username: Administrator
  *  - CopyrightYear: 2026
  */
@@ -352,8 +352,8 @@ auto copy_directory_helper(const std::string& srcPath,
     }
 
     // Get the full path of the source file/directory
-    int fileNameLength = WideCharToMultiByte(CP_UTF8, 0, findData.cFileName,
-                                             -1, NULL, 0, NULL, NULL);
+    int fileNameLength = WideCharToMultiByte(CP_UTF8, 0, findData.cFileName, -1,
+                                             NULL, 0, NULL, NULL);
     if (fileNameLength <= 0) {
       continue;
     }
@@ -445,12 +445,13 @@ auto process_source_paths(
       // If destination is a directory, append source filename
       std::wstring wsrcPath = utf8_to_wstring(srcPath);
       LPWSTR fileName = PathFindFileNameW(wsrcPath.c_str());
-      
+
       // OPTIMIZED: Use stack buffer
       char fileNameBuf[MAX_PATH * 3];
       int fileNameLength =
-          WideCharToMultiByte(CP_UTF8, 0, fileName, -1, fileNameBuf, sizeof(fileNameBuf), NULL, NULL);
-      
+          WideCharToMultiByte(CP_UTF8, 0, fileName, -1, fileNameBuf,
+                              sizeof(fileNameBuf), NULL, NULL);
+
       if (fileNameLength > 0 && fileNameLength < sizeof(fileNameBuf)) {
         finalDestPath += "\\" + std::string(fileNameBuf);
       } else {

--- a/src/commands/cut.cpp
+++ b/src/commands/cut.cpp
@@ -1,0 +1,266 @@
+/// @Author: WinuxCmd
+/// @contributors:
+///   - caomengxuan666 <2507560089@qq.com>
+/// @Description: Implemention for cut.
+/// @Version: 0.1.0
+/// @License: MIT
+/// @Copyright: Copyright © 2026 WinuxCmd
+#include "core/command_macros.h"
+#include "pch/pch.h"
+#include <optional>
+
+import std;
+import core;
+import utils;
+
+using cmd::meta::OptionMeta;
+using cmd::meta::OptionType;
+
+auto constexpr CUT_OPTIONS = std::array{
+    OPTION("-b", "", "select only these bytes [NOT SUPPORT]", STRING_TYPE),
+    OPTION("-c", "", "select only these characters [NOT SUPPORT]", STRING_TYPE),
+    OPTION("-d", "--delimiter", "use DELIM instead of TAB for field delimiter",
+           STRING_TYPE),
+    OPTION("-f", "--fields", "select only these fields", STRING_TYPE),
+    OPTION("-s", "--only-delimited",
+           "do not print lines not containing delimiter"),
+    OPTION("", "--output-delimiter",
+           "use STRING as the output delimiter [NOT SUPPORT]", STRING_TYPE),
+    OPTION("-z", "--zero-terminated", "line delimiter is NUL, not newline")};
+
+namespace cut_pipeline {
+namespace cp = core::pipeline;
+
+struct Range {
+  int start;
+  int end;  // inclusive, INT_MAX means open-ended
+};
+
+struct Config {
+  char delimiter = '\t';
+  bool only_delimited = false;
+  bool zero_terminated = false;
+  std::vector<Range> ranges;
+  std::vector<std::string> files;
+};
+
+auto parse_range_token(std::string_view tok) -> cp::Result<Range> {
+  auto pos = tok.find('-');
+  if (pos == std::string_view::npos) {
+    int v = 0;
+    auto [ptr, ec] = std::from_chars(tok.data(), tok.data() + tok.size(), v);
+    if (ec != std::errc() || ptr != tok.data() + tok.size() || v <= 0) {
+      return std::unexpected("invalid range");
+    }
+    return Range{v, v};
+  }
+
+  std::string_view left = tok.substr(0, pos);
+  std::string_view right = tok.substr(pos + 1);
+
+  int start = 1;
+  int end = std::numeric_limits<int>::max();
+
+  if (!left.empty()) {
+    auto [ptr, ec] = std::from_chars(left.data(), left.data() + left.size(),
+                                     start);
+    if (ec != std::errc() || ptr != left.data() + left.size() || start <= 0) {
+      return std::unexpected("invalid range");
+    }
+  }
+
+  if (!right.empty()) {
+    auto [ptr, ec] = std::from_chars(right.data(), right.data() + right.size(),
+                                     end);
+    if (ec != std::errc() || ptr != right.data() + right.size() || end <= 0) {
+      return std::unexpected("invalid range");
+    }
+  }
+
+  if (start > end) return std::unexpected("invalid range");
+  return Range{start, end};
+}
+
+auto parse_fields(std::string_view list) -> cp::Result<std::vector<Range>> {
+  if (list.empty()) return std::unexpected("missing fields list");
+
+  std::vector<Range> ranges;
+  size_t start = 0;
+  while (start <= list.size()) {
+    size_t pos = list.find(',', start);
+    std::string_view tok = (pos == std::string_view::npos)
+                               ? list.substr(start)
+                               : list.substr(start, pos - start);
+    auto r = parse_range_token(tok);
+    if (!r) return std::unexpected(r.error());
+    ranges.push_back(*r);
+    if (pos == std::string_view::npos) break;
+    start = pos + 1;
+  }
+  return ranges;
+}
+
+auto is_selected(int index, const std::vector<Range>& ranges) -> bool {
+  for (const auto& r : ranges) {
+    if (index >= r.start && index <= r.end) return true;
+  }
+  return false;
+}
+
+auto split_records(std::string_view content, char record_delim)
+    -> std::vector<std::string> {
+  std::vector<std::string> out;
+  size_t start = 0;
+  for (size_t i = 0; i < content.size(); ++i) {
+    if (content[i] == record_delim) {
+      out.emplace_back(content.substr(start, i - start));
+      start = i + 1;
+    }
+  }
+  if (start < content.size()) out.emplace_back(content.substr(start));
+  return out;
+}
+
+auto read_source(std::string_view path) -> cp::Result<std::string> {
+  if (path == "-") {
+    return std::string(std::istreambuf_iterator<char>(std::cin),
+                       std::istreambuf_iterator<char>());
+  }
+  std::ifstream in(std::string(path), std::ios::binary);
+  if (!in.is_open()) {
+    return std::unexpected("cannot open '" + std::string(path) + "'");
+  }
+  return std::string(std::istreambuf_iterator<char>(in),
+                     std::istreambuf_iterator<char>());
+}
+
+auto is_unsupported_used(const CommandContext<CUT_OPTIONS.size()>& ctx)
+    -> std::optional<std::string_view> {
+  if (!ctx.get<std::string>("-b", "").empty()) return "-b is [NOT SUPPORT]";
+  if (!ctx.get<std::string>("-c", "").empty()) return "-c is [NOT SUPPORT]";
+  if (!ctx.get<std::string>("--output-delimiter", "").empty())
+    return "--output-delimiter is [NOT SUPPORT]";
+  return std::nullopt;
+}
+
+auto build_config(const CommandContext<CUT_OPTIONS.size()>& ctx)
+    -> cp::Result<Config> {
+  Config cfg;
+  std::string delim = ctx.get<std::string>("--delimiter", "");
+  if (delim.empty()) delim = ctx.get<std::string>("-d", "");
+  if (!delim.empty()) {
+    if (delim.size() != 1) return std::unexpected("delimiter must be one char");
+    cfg.delimiter = delim[0];
+  }
+
+  cfg.only_delimited =
+      ctx.get<bool>("--only-delimited", false) || ctx.get<bool>("-s", false);
+  cfg.zero_terminated =
+      ctx.get<bool>("--zero-terminated", false) || ctx.get<bool>("-z", false);
+
+  std::string fields = ctx.get<std::string>("--fields", "");
+  if (fields.empty()) fields = ctx.get<std::string>("-f", "");
+  auto ranges = parse_fields(fields);
+  if (!ranges) return std::unexpected(ranges.error());
+  cfg.ranges = *ranges;
+
+  for (auto p : ctx.positionals) cfg.files.emplace_back(p);
+  if (cfg.files.empty()) cfg.files.emplace_back("-");
+
+  return cfg;
+}
+
+auto cut_line(std::string_view line, const Config& cfg) -> std::string {
+  std::vector<std::string_view> fields;
+  size_t start = 0;
+  bool has_delim = false;
+  for (size_t i = 0; i < line.size(); ++i) {
+    if (line[i] == cfg.delimiter) {
+      has_delim = true;
+      fields.emplace_back(line.substr(start, i - start));
+      start = i + 1;
+    }
+  }
+  fields.emplace_back(line.substr(start));
+
+  if (!has_delim && cfg.only_delimited) return {};
+
+  std::string out;
+  bool first = true;
+  for (int idx = 1; idx <= static_cast<int>(fields.size()); ++idx) {
+    if (is_selected(idx, cfg.ranges)) {
+      if (!first) out.push_back(cfg.delimiter);
+      out.append(fields[idx - 1]);
+      first = false;
+    }
+  }
+  return out;
+}
+
+  auto run_file(const std::string& path, const Config& cfg) -> int {
+  auto content = read_source(path);
+  if (!content) {
+    cp::report_error(content, L"cut");
+    return 1;
+  }
+
+  char record_delim = cfg.zero_terminated ? '\0' : '\n';
+
+  std::vector<std::string> records;
+  size_t start = 0;
+  for (size_t i = 0; i < content->size(); ++i) {
+    if ((*content)[i] == record_delim) {
+      records.push_back(content->substr(start, i - start));
+      start = i + 1;
+    }
+  }
+  records.push_back(content->substr(start));
+
+  for (const auto& rec : records) {
+    auto out = cut_line(rec, cfg);
+    if (out.empty() && cfg.only_delimited && rec.find(cfg.delimiter) == std::string::npos) {
+      continue;
+    }
+    safePrint(out);
+    if (cfg.zero_terminated) {
+      safePrint(char{'\0'});
+    } else {
+      safePrint("\n");
+    }
+  }
+  return 0;
+}
+
+auto run(const Config& cfg) -> int {
+  for (const auto& f : cfg.files) {
+    int rc = run_file(f, cfg);
+    if (rc != 0) return rc;
+  }
+  return 0;
+}
+
+}  // namespace cut_pipeline
+
+REGISTER_COMMAND(cut, "cut", "cut OPTION... [FILE]...",
+                 "Print selected parts of lines from each FILE to standard "
+                 "output.",
+                 "  cut -f1,3 file.txt\n"
+                 "  cut -d, -f2 data.csv\n"
+                 "  cut -z -f1 -d: list.txt",
+                 "paste(1)", "WinuxCmd", "Copyright © 2026 WinuxCmd",
+                 CUT_OPTIONS) {
+  using namespace cut_pipeline;
+
+  if (auto unsupported = is_unsupported_used(ctx); unsupported.has_value()) {
+    cp::report_custom_error(L"cut", utf8_to_wstring(*unsupported));
+    return 2;
+  }
+
+  auto cfg = build_config(ctx);
+  if (!cfg) {
+    cp::report_error(cfg, L"cut");
+    return 1;
+  }
+
+  return run(*cfg);
+}

--- a/src/commands/env.cpp
+++ b/src/commands/env.cpp
@@ -1,0 +1,171 @@
+/// @Author: WinuxCmd
+/// @contributors:
+///   - caomengxuan666 <2507560089@qq.com>
+/// @Description: Implemention for env.
+/// @Version: 0.1.0
+/// @License: MIT
+/// @Copyright: Copyright © 2026 WinuxCmd
+#include "core/command_macros.h"
+#include "pch/pch.h"
+
+import std;
+import core;
+import utils;
+
+using cmd::meta::OptionMeta;
+using cmd::meta::OptionType;
+
+auto constexpr ENV_OPTIONS = std::array{
+    OPTION("-i", "--ignore-environment", "start with an empty environment"),
+    OPTION("-u", "--unset", "remove variable from the environment", STRING_TYPE),
+    OPTION("-0", "--null", "end each output line with NUL, not newline"),
+    OPTION("-S", "--split-string", "process and split S into separate arguments [NOT SUPPORT]", STRING_TYPE),
+    OPTION("-C", "--chdir", "change working directory [NOT SUPPORT]", STRING_TYPE)};
+
+namespace env_pipeline {
+namespace cp = core::pipeline;
+
+struct Config {
+  bool ignore_environment = false;
+  bool null_terminated = false;
+  std::string unset_name;
+  std::map<std::string, std::string> assignments;
+  std::vector<std::string> command;
+};
+
+auto parse_env_block() -> std::map<std::string, std::string> {
+  std::map<std::string, std::string> out;
+  LPWCH block = GetEnvironmentStringsW();
+  if (block == nullptr) return out;
+
+  const wchar_t* p = block;
+  while (*p != L'\0') {
+    std::wstring entry = p;
+    p += entry.size() + 1;
+
+    if (entry.empty()) continue;
+    if (entry[0] == L'=') continue;
+
+    auto pos = entry.find(L'=');
+    if (pos == std::wstring::npos) continue;
+
+    auto key = wstring_to_utf8(entry.substr(0, pos));
+    auto value = wstring_to_utf8(entry.substr(pos + 1));
+    out[std::move(key)] = std::move(value);
+  }
+
+  FreeEnvironmentStringsW(block);
+  return out;
+}
+
+auto parse_assignment(std::string_view s)
+    -> std::optional<std::pair<std::string, std::string>> {
+  auto eq = s.find('=');
+  if (eq == std::string_view::npos || eq == 0) return std::nullopt;
+  return std::pair{std::string(s.substr(0, eq)), std::string(s.substr(eq + 1))};
+}
+
+auto is_unsupported_used(const CommandContext<ENV_OPTIONS.size()>& ctx)
+    -> std::optional<std::string_view> {
+  if (!ctx.get<std::string>("--split-string", "").empty() ||
+      !ctx.get<std::string>("-S", "").empty()) {
+    return "--split-string is [NOT SUPPORT]";
+  }
+  if (!ctx.get<std::string>("--chdir", "").empty() ||
+      !ctx.get<std::string>("-C", "").empty()) {
+    return "--chdir is [NOT SUPPORT]";
+  }
+  return std::nullopt;
+}
+
+auto build_config(const CommandContext<ENV_OPTIONS.size()>& ctx)
+    -> cp::Result<Config> {
+  Config cfg;
+  cfg.ignore_environment = ctx.get<bool>("--ignore-environment", false) ||
+                           ctx.get<bool>("-i", false);
+  cfg.null_terminated =
+      ctx.get<bool>("--null", false) || ctx.get<bool>("-0", false);
+  cfg.unset_name = ctx.get<std::string>("--unset", "");
+  if (cfg.unset_name.empty()) cfg.unset_name = ctx.get<std::string>("-u", "");
+
+  bool in_command = false;
+  for (auto p : ctx.positionals) {
+    if (in_command) {
+      cfg.command.emplace_back(p);
+      continue;
+    }
+
+    auto assign = parse_assignment(p);
+    if (assign.has_value()) {
+      cfg.assignments[assign->first] = assign->second;
+      continue;
+    }
+
+    in_command = true;
+    cfg.command.emplace_back(p);
+  }
+
+  return cfg;
+}
+
+auto print_env(const std::map<std::string, std::string>& vars,
+               bool null_terminated) -> void {
+  for (const auto& [k, v] : vars) {
+    safePrint(k);
+    safePrint("=");
+    safePrint(v);
+    if (null_terminated) {
+      safePrint(char{'\0'});
+    } else {
+      safePrint("\n");
+    }
+  }
+}
+
+auto run(const Config& cfg) -> int {
+  if (!cfg.command.empty()) {
+    cp::report_custom_error(L"env", L"running command is [NOT SUPPORT]");
+    return 2;
+  }
+
+  std::map<std::string, std::string> vars;
+  if (!cfg.ignore_environment) {
+    vars = parse_env_block();
+  }
+
+  if (!cfg.unset_name.empty()) {
+    vars.erase(cfg.unset_name);
+  }
+
+  for (const auto& [k, v] : cfg.assignments) {
+    vars[k] = v;
+  }
+
+  print_env(vars, cfg.null_terminated);
+  return 0;
+}
+
+}  // namespace env_pipeline
+
+REGISTER_COMMAND(env, "env", "env [OPTION]... [NAME=VALUE]... [COMMAND [ARG]...]",
+                 "Set each NAME to VALUE in the environment and print the\n"
+                 "resulting environment. Running COMMAND is currently [NOT SUPPORT].",
+                 "  env\n"
+                 "  env -i FOO=bar\n"
+                 "  env -u PATH",
+                 "printenv(1), which(1)", "WinuxCmd",
+                 "Copyright © 2026 WinuxCmd", ENV_OPTIONS) {
+  using namespace env_pipeline;
+
+  if (auto unsupported = is_unsupported_used(ctx); unsupported.has_value()) {
+    cp::report_custom_error(L"env", utf8_to_wstring(*unsupported));
+    return 2;
+  }
+
+  auto cfg = build_config(ctx);
+  if (!cfg) {
+    cp::report_error(cfg, L"env");
+    return 1;
+  }
+  return run(*cfg);
+}

--- a/src/commands/find.cpp
+++ b/src/commands/find.cpp
@@ -1,0 +1,358 @@
+/*
+*  Copyright © 2026 WinuxCmd
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ *  - File: find.cpp
+ *  - CopyrightYear: 2026
+ */
+/// @contributors:
+///   - @contributor1 WinuxCmd
+/// @Description: Implementation for find command.
+/// @Version: 0.1.0
+/// @License: MIT
+/// @Copyright: Copyright © 2026 WinuxCmd
+
+#include "core/command_macros.h"
+#include "pch/pch.h"
+
+import std;
+import core;
+import utils;
+
+using cmd::meta::OptionMeta;
+using cmd::meta::OptionType;
+
+/**
+ * @brief FIND command options definition
+ *
+ * This array defines all the options supported by the find command.
+ * Each option is described with its short form, long form, and description.
+ * The implementation status is also indicated for each option.
+ *
+ * @par Options:
+ *
+ * - @a -name: Base of file name (the path with the leading directories removed) matches shell pattern PATTERN [IMPLEMENTED]
+ * - @a -iname: Like -name, but the match is case insensitive [IMPLEMENTED]
+ * - @a -type: File is of type c: b,d,p,f,l,s,D [only d,f,l are supported] [IMPLEMENTED]
+ * - @a -mindepth: Descend at least LEVELS levels of directories before tests [IMPLEMENTED]
+ * - @a -maxdepth: Descend at most LEVELS levels of directories below starting-points [IMPLEMENTED]
+ * - @a -print: Print the full file name on the standard output [IMPLEMENTED]
+ * - @a -print0: Print the full file name on the standard output, followed by a null character [IMPLEMENTED]
+ * - @a -L: Follow symbolic links [NOT SUPPORT]
+ * - @a -H: Do not follow symbolic links, except while processing command line arguments [NOT SUPPORT]
+ * - @a -P: Never follow symbolic links (default) [IMPLEMENTED]
+ * - @a -delete: Delete files [NOT SUPPORT]
+ * - @a -exec: Execute command [NOT SUPPORT]
+ * - @a -ok: Execute command after confirmation [NOT SUPPORT]
+ * - @a -printf: Print format [NOT SUPPORT]
+ * - @a -prune: Prune tree [NOT SUPPORT]
+ * - @a -quit: Exit immediately [IMPLEMENTED]
+ */
+auto constexpr FIND_OPTIONS = std::array{
+    OPTION("-name", "", "base of file name (the path with the leading directories removed) matches shell pattern PATTERN", STRING_TYPE),
+    OPTION("-iname", "", "like -name, but the match is case insensitive", STRING_TYPE),
+    OPTION("-type", "", "file is of type c: b,d,p,f,l,s,D [only d,f,l are supported]", STRING_TYPE),
+    OPTION("-mindepth", "", "descend at least LEVELS levels of directories before tests", INT_TYPE),
+    OPTION("-maxdepth", "", "descend at most LEVELS levels of directories below starting-points", INT_TYPE),
+    OPTION("-print", "", "print the full file name on the standard output"),
+    OPTION("-print0", "", "print the full file name on the standard output, followed by a null character"),
+    OPTION("-L", "", "follow symbolic links [NOT SUPPORT]"),
+    OPTION("-H", "", "do not follow symbolic links, except while processing command line arguments [NOT SUPPORT]"),
+    OPTION("-P", "", "never follow symbolic links (default)"),
+    OPTION("-delete", "", "delete files [NOT SUPPORT]"),
+    OPTION("-exec", "", "execute command [NOT SUPPORT]", STRING_TYPE),
+    OPTION("-ok", "", "execute command after confirmation [NOT SUPPORT]", STRING_TYPE),
+    OPTION("-printf", "", "print format [NOT SUPPORT]", STRING_TYPE),
+    OPTION("-prune", "", "prune tree [NOT SUPPORT]"),
+    OPTION("-quit", "", "exit immediately")};
+
+namespace find_pipeline {
+namespace cp = core::pipeline;
+
+struct Config {
+  std::vector<std::string> roots;
+  std::string name_pattern;
+  std::string iname_pattern;
+  std::string type_filter;
+  int mindepth = 0;
+  int maxdepth = std::numeric_limits<int>::max();
+  bool has_print = false;
+  bool print0 = false;
+  bool quit = false;
+
+  bool unsupported_used = false;
+  bool had_error = false;
+};
+
+auto to_lower_ascii(std::string_view s) -> std::string {
+  std::string out;
+  out.reserve(s.size());
+  for (unsigned char c : s) out.push_back(static_cast<char>(std::tolower(c)));
+  return out;
+}
+
+auto wildcard_match_impl(std::string_view p, size_t pi, std::string_view s,
+                         size_t si) -> bool {
+  while (pi < p.size()) {
+    char pc = p[pi];
+    if (pc == '*') {
+      while (pi < p.size() && p[pi] == '*') ++pi;
+      if (pi == p.size()) return true;
+      while (si <= s.size()) {
+        if (wildcard_match_impl(p, pi, s, si)) return true;
+        if (si == s.size()) break;
+        ++si;
+      }
+      return false;
+    }
+
+    if (si >= s.size()) return false;
+
+    if (pc == '?') {
+      ++pi;
+      ++si;
+      continue;
+    }
+
+    if (pc != s[si]) return false;
+    ++pi;
+    ++si;
+  }
+
+  return si == s.size();
+}
+
+auto wildcard_match(std::string_view pattern, std::string_view text,
+                    bool ignore_case) -> bool {
+  if (!ignore_case) return wildcard_match_impl(pattern, 0, text, 0);
+  auto p = to_lower_ascii(pattern);
+  auto t = to_lower_ascii(text);
+  return wildcard_match_impl(p, 0, t, 0);
+}
+
+auto type_matches(const std::filesystem::directory_entry& e,
+                  std::string_view type) -> bool {
+  if (type.empty()) return true;
+
+  if (type == "f") return e.is_regular_file();
+  if (type == "d") return e.is_directory();
+  if (type == "l") return e.is_symlink();
+
+  return false;
+}
+
+auto is_unsupported_used(const CommandContext<FIND_OPTIONS.size()>& ctx)
+    -> std::optional<std::string> {
+  if (ctx.get<bool>("-L", false)) return "-L is [NOT SUPPORT]";
+  if (ctx.get<bool>("-H", false)) return "-H is [NOT SUPPORT]";
+  if (ctx.get<bool>("-delete", false)) return "-delete is [NOT SUPPORT]";
+  if (!ctx.get<std::string>("-exec", "").empty())
+    return "-exec is [NOT SUPPORT]";
+  if (!ctx.get<std::string>("-ok", "").empty())
+    return "-ok is [NOT SUPPORT]";
+  if (!ctx.get<std::string>("-printf", "").empty())
+    return "-printf is [NOT SUPPORT]";
+  if (ctx.get<bool>("-prune", false)) return "-prune is [NOT SUPPORT]";
+  return std::nullopt;
+}
+
+auto build_config(const CommandContext<FIND_OPTIONS.size()>& ctx)
+    -> cp::Result<Config> {
+  Config cfg;
+
+  if (auto u = is_unsupported_used(ctx); u.has_value()) {
+    return std::unexpected(*u);
+  }
+
+  cfg.name_pattern = ctx.get<std::string>("-name", "");
+  cfg.iname_pattern = ctx.get<std::string>("-iname", "");
+  cfg.type_filter = ctx.get<std::string>("-type", "");
+  cfg.mindepth = ctx.get<int>("-mindepth", 0);
+  cfg.maxdepth = ctx.get<int>("-maxdepth", std::numeric_limits<int>::max());
+
+  cfg.has_print = ctx.get<bool>("-print", false);
+  cfg.print0 = ctx.get<bool>("-print0", false);
+  cfg.quit = ctx.get<bool>("-quit", false);
+
+  if (!cfg.name_pattern.empty() && !cfg.iname_pattern.empty()) {
+    return std::unexpected("cannot use both -name and -iname");
+  }
+
+  if (!cfg.type_filter.empty() && cfg.type_filter != "f" && cfg.type_filter != "d" &&
+      cfg.type_filter != "l") {
+    return std::unexpected("-type currently supports only f,d,l");
+  }
+
+  if (cfg.mindepth < 0 || cfg.maxdepth < 0 || cfg.mindepth > cfg.maxdepth) {
+    return std::unexpected("invalid depth range");
+  }
+
+  for (auto p : ctx.positionals) cfg.roots.emplace_back(p);
+  if (cfg.roots.empty()) cfg.roots.emplace_back(".");
+
+  if (!cfg.has_print && !cfg.print0) {
+    cfg.has_print = true;  // default action
+  }
+
+  return cfg;
+}
+
+auto relative_or_self(const std::filesystem::path& root,
+                      const std::filesystem::path& p) -> std::filesystem::path {
+  std::error_code ec;
+  auto rel = std::filesystem::relative(p, root, ec);
+  if (ec || rel.empty()) return std::filesystem::path(".");
+  return rel;
+}
+
+auto depth_from_root(const std::filesystem::path& root,
+                     const std::filesystem::path& p) -> int {
+  auto rel = relative_or_self(root, p);
+  if (rel == ".") return 0;
+  int d = 0;
+  for (const auto& part : rel) {
+    (void)part;
+    ++d;
+  }
+  return d;
+}
+
+auto path_display(const std::filesystem::path& p) -> std::string {
+  auto s = p.generic_string();
+  if (s.empty()) return ".";
+  return s;
+}
+
+auto entry_matches(const Config& cfg, const std::filesystem::path& p,
+                   const std::filesystem::directory_entry& e,
+                   int depth) -> bool {
+  if (depth < cfg.mindepth || depth > cfg.maxdepth) return false;
+
+  auto filename = p.filename().string();
+  if (filename.empty()) filename = p.generic_string();
+
+  if (!cfg.name_pattern.empty() &&
+      !wildcard_match(cfg.name_pattern, filename, false)) {
+    return false;
+  }
+
+  if (!cfg.iname_pattern.empty() &&
+      !wildcard_match(cfg.iname_pattern, filename, true)) {
+    return false;
+  }
+
+  if (!type_matches(e, cfg.type_filter)) return false;
+
+  return true;
+}
+
+auto print_path(const Config& cfg, std::string_view path) -> void {
+  safePrint(path);
+  if (cfg.print0) {
+    safePrint("\0");
+  } else {
+    safePrint("\n");
+  }
+}
+
+auto scan_one_root(const std::filesystem::path& root, Config& cfg,
+                   bool& matched_any) -> void {
+  std::error_code ec;
+  bool exists = std::filesystem::exists(root, ec);
+  if (ec || !exists) {
+    safeErrorPrint("find: '");
+    safeErrorPrint(root.string());
+    safeErrorPrint("': No such file or directory\n");
+    cfg.had_error = true;
+    return;
+  }
+
+  std::filesystem::directory_entry root_entry(root, ec);
+  if (!ec) {
+    int d = 0;
+    if (entry_matches(cfg, root, root_entry, d)) {
+      print_path(cfg, path_display(root));
+      matched_any = true;
+      if (cfg.quit) return;
+    }
+  }
+
+  if (!std::filesystem::is_directory(root, ec) || ec) return;
+
+  std::filesystem::recursive_directory_iterator it(
+      root, std::filesystem::directory_options::skip_permission_denied, ec);
+  std::filesystem::recursive_directory_iterator end;
+
+  if (ec) {
+    cfg.had_error = true;
+    return;
+  }
+
+  for (; it != end; ++it) {
+    std::error_code iec;
+    const auto& de = *it;
+    auto p = de.path();
+    int d = depth_from_root(root, p);
+
+    if (d > cfg.maxdepth) {
+      it.disable_recursion_pending();
+      continue;
+    }
+
+    if (entry_matches(cfg, p, de, d)) {
+      print_path(cfg, path_display(p));
+      matched_any = true;
+      if (cfg.quit) return;
+    }
+  }
+}
+
+auto process(Config& cfg) -> int {
+  bool matched_any = false;
+  for (const auto& r : cfg.roots) {
+    scan_one_root(std::filesystem::path(r), cfg, matched_any);
+    if (cfg.quit && matched_any) break;
+  }
+
+  if (cfg.had_error) return 1;
+  return 0;
+}
+
+}  // namespace find_pipeline
+
+REGISTER_COMMAND(
+    find, "find", "find [path...] [expression]",
+    "Search for files in a directory hierarchy.\n"
+    "If no path is given, '.' is used.",
+    "  find . -name '*.cpp'\n"
+    "  find src -type f -maxdepth 2\n"
+    "  find . -iname 'readme*'",
+    "grep(1), ls(1)", "WinuxCmd", "Copyright © 2026 WinuxCmd",
+    FIND_OPTIONS) {
+  using namespace find_pipeline;
+
+  auto cfg = build_config(ctx);
+  if (!cfg) {
+    cp::report_error(cfg, L"find");
+    return 1;
+  }
+
+  return process(*cfg);
+}

--- a/src/commands/grep.cpp
+++ b/src/commands/grep.cpp
@@ -1,0 +1,756 @@
+/*
+*  Copyright © 2026 [caomengxuan666]
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the “Software”), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ *  - File: grep.cpp
+ *  - Username: Administrator
+ *  - CopyrightYear: 2026
+ */
+
+/// @Author: WinuxCmd
+/// @contributors:
+///   - caomengxuan666 <2507560089@qq.com>
+/// @Description: Implemention for grep.
+/// @Version: 0.1.0
+/// @License: MIT
+/// @Copyright: Copyright © 2026 WinuxCmd
+/// @TODO:1.Stream reading. 2.Replace filesystem 3.String optimization(too large).
+#include "core/command_macros.h"
+#include "pch/pch.h"
+
+import std;
+import core;
+import utils;
+
+using cmd::meta::OptionMeta;
+using cmd::meta::OptionType;
+
+/**
+ * @brief GREP command options definition
+ *
+ * This array defines all the options supported by the grep command.
+ * Each option is described with its short form, long form, and description.
+ * The implementation status is also indicated for each option.
+ *
+ * @par Options:
+ *
+ * - @a -E, @a --extended-regexp: PATTERNS are extended regular expressions [IMPLEMENTED]
+ * - @a -F, @a --fixed-strings: PATTERNS are strings [IMPLEMENTED]
+ * - @a -G, @a --basic-regexp: PATTERNS are basic regular expressions [IMPLEMENTED]
+ * - @a -P, @a --perl-regexp: PATTERNS are Perl regular expressions [NOT SUPPORT]
+ * - @a -e, @a --regexp: Use PATTERNS for matching [IMPLEMENTED]
+ * - @a -f, @a --file: Take PATTERNS from FILE [IMPLEMENTED]
+ * - @a -i, @a --ignore-case: Ignore case distinctions in patterns and data [IMPLEMENTED]
+ * - @a --no-ignore-case: Do not ignore case distinctions (default) [IMPLEMENTED]
+ * - @a -w, @a --word-regexp: Match only whole words [IMPLEMENTED]
+ * - @a -x, @a --line-regexp: Match only whole lines [IMPLEMENTED]
+ * - @a -z, @a --null-data: A data line ends in 0 byte, not newline [IMPLEMENTED]
+ * - @a -s, @a --no-messages: Suppress error messages [IMPLEMENTED]
+ * - @a -v, @a --invert-match: Select non-matching lines [IMPLEMENTED]
+ * - @a -m, @a --max-count: Stop after NUM selected lines [IMPLEMENTED]
+ * - @a -b, @a --byte-offset: Print the byte offset with output lines [IMPLEMENTED]
+ * - @a -n, @a --line-number: Print line number with output lines [IMPLEMENTED]
+ * - @a --line-buffered: Flush output on every line [IMPLEMENTED]
+ * - @a -H, @a --with-filename: Print file name with output lines [IMPLEMENTED]
+ * - @a -h, @a --no-filename: Suppress the file name prefix on output [IMPLEMENTED]
+ * - @a --label: Use LABEL as the standard input file name prefix [IMPLEMENTED]
+ * - @a -o, @a --only-matching: Show only nonempty parts of lines that match [IMPLEMENTED]
+ * - @a -q, @a --quiet: Suppress all normal output [IMPLEMENTED]
+ * - @a --silent: Suppress all normal output [IMPLEMENTED]
+ * - @a --binary-files: Assume that binary files are TYPE [NOT SUPPORT]
+ * - @a -a, @a --text: Equivalent to --binary-files=text [NOT SUPPORT]
+ * - @a -I: Equivalent to --binary-files=without-match [NOT SUPPORT]
+ * - @a -d, @a --directories: How to handle directories: read, recurse, skip [IMPLEMENTED]
+ * - @a -D, @a --devices: How to handle devices/FIFOs/sockets [NOT SUPPORT]
+ * - @a -r, @a --recursive: Like --directories=recurse [IMPLEMENTED]
+ * - @a -R, @a --dereference-recursive: Like -r but follow symlinks [NOT SUPPORT]
+ * - @a --include: Search only files that match GLOB [NOT SUPPORT]
+ * - @a --exclude: Skip files that match GLOB [NOT SUPPORT]
+ * - @a --exclude-from: Skip files from patterns in FILE [NOT SUPPORT]
+ * - @a --exclude-dir: Skip directories that match GLOB [NOT SUPPORT]
+ * - @a -L, @a --files-without-match: Print only names of FILEs with no selected lines [IMPLEMENTED]
+ * - @a -l, @a --files-with-matches: Print only names of FILEs with selected lines [IMPLEMENTED]
+ * - @a -c, @a --count: Print only a count of selected lines per FILE [IMPLEMENTED]
+ * - @a -T, @a --initial-tab: Make tabs line up (if needed) [NOT SUPPORT]
+ * - @a -Z, @a --null: Print 0 byte after FILE name [IMPLEMENTED]
+ * - @a -B, @a --before-context: Print NUM lines of leading context [NOT SUPPORT]
+ * - @a -A, @a --after-context: Print NUM lines of trailing context [NOT SUPPORT]
+ * - @a -C, @a --context: Print NUM lines of output context [NOT SUPPORT]
+ * - @a --group-separator: Print separator between groups [NOT SUPPORT]
+ * - @a --no-group-separator: Do not print group separator [NOT SUPPORT]
+ * - @a --color: Highlight matching strings [NOT SUPPORT]
+ * - @a --colour: Highlight matching strings [NOT SUPPORT]
+ * - @a -U, @a --binary: Do not strip CR at EOL [NOT SUPPORT]
+ */
+auto constexpr GREP_OPTIONS = std::array{
+    OPTION("-E", "--extended-regexp",
+           "PATTERNS are extended regular expressions"),
+    OPTION("-F", "--fixed-strings", "PATTERNS are strings"),
+    OPTION("-G", "--basic-regexp", "PATTERNS are basic regular expressions"),
+    OPTION("-P", "--perl-regexp",
+           "PATTERNS are Perl regular expressions [NOT SUPPORT]"),
+    OPTION("-e", "--regexp", "use PATTERNS for matching", STRING_TYPE),
+    OPTION("-f", "--file", "take PATTERNS from FILE", STRING_TYPE),
+    OPTION("-i", "--ignore-case",
+           "ignore case distinctions in patterns and data"),
+    OPTION("", "--no-ignore-case", "do not ignore case distinctions (default)"),
+    OPTION("-w", "--word-regexp", "match only whole words"),
+    OPTION("-x", "--line-regexp", "match only whole lines"),
+    OPTION("-z", "--null-data", "a data line ends in 0 byte, not newline"),
+    OPTION("-s", "--no-messages", "suppress error messages"),
+    OPTION("-v", "--invert-match", "select non-matching lines"),
+    OPTION("-m", "--max-count", "stop after NUM selected lines", INT_TYPE),
+    OPTION("-b", "--byte-offset", "print the byte offset with output lines"),
+    OPTION("-n", "--line-number", "print line number with output lines"),
+    OPTION("", "--line-buffered", "flush output on every line"),
+    OPTION("-H", "--with-filename", "print file name with output lines"),
+    OPTION("-h", "--no-filename", "suppress the file name prefix on output"),
+    OPTION("", "--label", "use LABEL as the standard input file name prefix",
+           STRING_TYPE),
+    OPTION("-o", "--only-matching",
+           "show only nonempty parts of lines that match"),
+    OPTION("-q", "--quiet", "suppress all normal output"),
+    OPTION("", "--silent", "suppress all normal output"),
+    OPTION("", "--binary-files",
+           "assume that binary files are TYPE [NOT SUPPORT]", STRING_TYPE),
+    OPTION("-a", "--text", "equivalent to --binary-files=text [NOT SUPPORT]"),
+    OPTION("-I", "",
+           "equivalent to --binary-files=without-match [NOT SUPPORT]"),
+    OPTION("-d", "--directories",
+           "how to handle directories: read, recurse, skip", STRING_TYPE),
+    OPTION("-D", "--devices",
+           "how to handle devices/FIFOs/sockets [NOT SUPPORT]", STRING_TYPE),
+    OPTION("-r", "--recursive", "like --directories=recurse"),
+    OPTION("-R", "--dereference-recursive",
+           "like -r but follow symlinks [NOT SUPPORT]"),
+    OPTION("", "--include", "search only files that match GLOB [NOT SUPPORT]",
+           STRING_TYPE),
+    OPTION("", "--exclude", "skip files that match GLOB [NOT SUPPORT]",
+           STRING_TYPE),
+    OPTION("", "--exclude-from",
+           "skip files from patterns in FILE [NOT SUPPORT]", STRING_TYPE),
+    OPTION("", "--exclude-dir",
+           "skip directories that match GLOB [NOT SUPPORT]", STRING_TYPE),
+    OPTION("-L", "--files-without-match",
+           "print only names of FILEs with no selected lines"),
+    OPTION("-l", "--files-with-matches",
+           "print only names of FILEs with selected lines"),
+    OPTION("-c", "--count", "print only a count of selected lines per FILE"),
+    OPTION("-T", "--initial-tab",
+           "make tabs line up (if needed) [NOT SUPPORT]"),
+    OPTION("-Z", "--null", "print 0 byte after FILE name"),
+    OPTION("-B", "--before-context",
+           "print NUM lines of leading context [NOT SUPPORT]", INT_TYPE),
+    OPTION("-A", "--after-context",
+           "print NUM lines of trailing context [NOT SUPPORT]", INT_TYPE),
+    OPTION("-C", "--context", "print NUM lines of output context [NOT SUPPORT]",
+           INT_TYPE),
+    OPTION("", "--group-separator",
+           "print separator between groups [NOT SUPPORT]", STRING_TYPE),
+    OPTION("", "--no-group-separator",
+           "do not print group separator [NOT SUPPORT]"),
+    OPTION("", "--color", "highlight matching strings [NOT SUPPORT]",
+           STRING_TYPE),
+    OPTION("", "--colour", "highlight matching strings [NOT SUPPORT]",
+           STRING_TYPE),
+    OPTION("-U", "--binary", "do not strip CR at EOL [NOT SUPPORT]")};
+
+namespace grep_pipeline {
+namespace cp = core::pipeline;
+
+enum class PatternMode { BasicRegex, ExtendedRegex, Fixed };
+
+struct MatchPiece {
+  size_t begin = 0;
+  size_t end = 0;
+};
+
+struct Pattern {
+  std::string raw;
+  std::string lowered;
+  std::optional<std::regex> regex;
+};
+
+struct Config {
+  PatternMode mode = PatternMode::BasicRegex;
+  bool ignore_case = false;
+  bool word_regexp = false;
+  bool line_regexp = false;
+  bool null_data = false;
+  bool no_messages = false;
+  bool invert_match = false;
+  int max_count = -1;
+  bool byte_offset = false;
+  bool line_number = false;
+  bool with_filename = false;
+  bool no_filename = false;
+  std::string label;
+  bool only_matching = false;
+  bool quiet = false;
+  std::string directories = "read";
+  bool files_without_match = false;
+  bool files_with_matches = false;
+  bool count_only = false;
+  bool null_after_filename = false;
+  bool recursive = false;
+  std::vector<Pattern> patterns;
+  std::vector<std::string> files;
+  bool has_error = false;
+};
+
+auto to_lower_ascii(std::string_view s) -> std::string {
+  std::string out;
+  out.reserve(s.size());
+  for (unsigned char c : s) {
+    out.push_back(static_cast<char>(std::tolower(c)));
+  }
+  return out;
+}
+
+auto split_lines(std::string_view s) -> std::vector<std::string> {
+  std::vector<std::string> parts;
+  size_t start = 0;
+  while (start <= s.size()) {
+    size_t pos = s.find('\n', start);
+    if (pos == std::string_view::npos) {
+      parts.emplace_back(s.substr(start));
+      break;
+    }
+    parts.emplace_back(s.substr(start, pos - start));
+    start = pos + 1;
+  }
+  return parts;
+}
+
+auto split_records(const std::string& s, char delim)
+    -> std::vector<std::pair<size_t, size_t>> {
+  std::vector<std::pair<size_t, size_t>> out;
+  size_t start = 0;
+  for (size_t i = 0; i < s.size(); ++i) {
+    if (s[i] == delim) {
+      out.emplace_back(start, i + 1);
+      start = i + 1;
+    }
+  }
+  if (start < s.size()) {
+    out.emplace_back(start, s.size());
+  }
+  return out;
+}
+
+auto is_word_char(unsigned char c) -> bool {
+  return std::isalnum(c) || c == '_';
+}
+
+auto word_boundary_ok(std::string_view line, size_t begin, size_t end) -> bool {
+  bool left_ok = (begin == 0) ||
+                 !is_word_char(static_cast<unsigned char>(line[begin - 1]));
+  bool right_ok = (end >= line.size()) ||
+                  !is_word_char(static_cast<unsigned char>(line[end]));
+  return left_ok && right_ok;
+}
+
+auto compile_pattern(PatternMode mode, bool ignore_case, std::string_view raw)
+    -> cp::Result<Pattern> {
+  Pattern p;
+  p.raw = std::string(raw);
+  p.lowered = to_lower_ascii(raw);
+
+  if (mode == PatternMode::Fixed) return p;
+
+  try {
+    auto flags = std::regex::ECMAScript;
+    if (ignore_case) flags |= std::regex::icase;
+    p.regex.emplace(p.raw, flags);
+  } catch (const std::regex_error&) {
+    return std::unexpected("invalid regular expression: " + std::string(raw));
+  }
+
+  return p;
+}
+
+auto load_patterns_from_file(const std::string& path)
+    -> cp::Result<std::vector<std::string>> {
+  std::ifstream in(path, std::ios::binary);
+  if (!in.is_open()) {
+    return std::unexpected("cannot open pattern file '" + path + "'");
+  }
+
+  std::string buf((std::istreambuf_iterator<char>(in)),
+                  std::istreambuf_iterator<char>());
+  return split_lines(buf);
+}
+
+auto is_unsupported_used(const CommandContext<GREP_OPTIONS.size()>& ctx)
+    -> std::optional<std::string> {
+  if (ctx.get<bool>("--perl-regexp", false) || ctx.get<bool>("-P", false))
+    return "--perl-regexp is [NOT SUPPORT]";
+  if (!ctx.get<std::string>("--binary-files", "").empty() ||
+      ctx.get<bool>("--text", false) || ctx.get<bool>("-a", false) ||
+      ctx.get<bool>("-I", false))
+    return "binary file mode options are [NOT SUPPORT]";
+  if (!ctx.get<std::string>("--devices", "").empty() ||
+      !ctx.get<std::string>("-D", "").empty())
+    return "--devices is [NOT SUPPORT]";
+  if (ctx.get<bool>("--dereference-recursive", false) ||
+      ctx.get<bool>("-R", false))
+    return "--dereference-recursive is [NOT SUPPORT]";
+  if (!ctx.get<std::string>("--include", "").empty() ||
+      !ctx.get<std::string>("--exclude", "").empty() ||
+      !ctx.get<std::string>("--exclude-from", "").empty() ||
+      !ctx.get<std::string>("--exclude-dir", "").empty())
+    return "include/exclude options are [NOT SUPPORT]";
+  if (ctx.get<bool>("--initial-tab", false) || ctx.get<bool>("-T", false))
+    return "--initial-tab is [NOT SUPPORT]";
+  if (ctx.get<int>("--before-context", -1) >= 0 ||
+      ctx.get<int>("-B", -1) >= 0 || ctx.get<int>("--after-context", -1) >= 0 ||
+      ctx.get<int>("-A", -1) >= 0 || ctx.get<int>("--context", -1) >= 0 ||
+      ctx.get<int>("-C", -1) >= 0)
+    return "context options are [NOT SUPPORT]";
+  if (!ctx.get<std::string>("--group-separator", "").empty() ||
+      ctx.get<bool>("--no-group-separator", false))
+    return "group separator options are [NOT SUPPORT]";
+  if (!ctx.get<std::string>("--color", "").empty() ||
+      !ctx.get<std::string>("--colour", "").empty())
+    return "--color is [NOT SUPPORT]";
+  if (ctx.get<bool>("--binary", false) || ctx.get<bool>("-U", false))
+    return "--binary is [NOT SUPPORT]";
+  return std::nullopt;
+}
+
+auto build_config(const CommandContext<GREP_OPTIONS.size()>& ctx)
+    -> cp::Result<Config> {
+  Config cfg;
+
+  if (auto unsupported = is_unsupported_used(ctx); unsupported.has_value()) {
+    return std::unexpected(*unsupported);
+  }
+
+  cfg.mode = PatternMode::BasicRegex;
+  if (ctx.get<bool>("--fixed-strings", false) || ctx.get<bool>("-F", false))
+    cfg.mode = PatternMode::Fixed;
+  if (ctx.get<bool>("--extended-regexp", false) || ctx.get<bool>("-E", false))
+    cfg.mode = PatternMode::ExtendedRegex;
+  if (ctx.get<bool>("--basic-regexp", false) || ctx.get<bool>("-G", false))
+    cfg.mode = PatternMode::BasicRegex;
+
+  cfg.ignore_case =
+      ctx.get<bool>("--ignore-case", false) || ctx.get<bool>("-i", false);
+  if (ctx.get<bool>("--no-ignore-case", false)) cfg.ignore_case = false;
+
+  cfg.word_regexp =
+      ctx.get<bool>("--word-regexp", false) || ctx.get<bool>("-w", false);
+  cfg.line_regexp =
+      ctx.get<bool>("--line-regexp", false) || ctx.get<bool>("-x", false);
+  cfg.null_data =
+      ctx.get<bool>("--null-data", false) || ctx.get<bool>("-z", false);
+  cfg.no_messages =
+      ctx.get<bool>("--no-messages", false) || ctx.get<bool>("-s", false);
+  cfg.invert_match =
+      ctx.get<bool>("--invert-match", false) || ctx.get<bool>("-v", false);
+  cfg.max_count = ctx.get<int>("--max-count", -1);
+  if (cfg.max_count < 0) cfg.max_count = ctx.get<int>("-m", -1);
+  cfg.byte_offset =
+      ctx.get<bool>("--byte-offset", false) || ctx.get<bool>("-b", false);
+  cfg.line_number =
+      ctx.get<bool>("--line-number", false) || ctx.get<bool>("-n", false);
+  cfg.with_filename =
+      ctx.get<bool>("--with-filename", false) || ctx.get<bool>("-H", false);
+  cfg.no_filename =
+      ctx.get<bool>("--no-filename", false) || ctx.get<bool>("-h", false);
+  cfg.label = ctx.get<std::string>("--label", "");
+  cfg.only_matching =
+      ctx.get<bool>("--only-matching", false) || ctx.get<bool>("-o", false);
+  cfg.quiet = ctx.get<bool>("--quiet", false) ||
+              ctx.get<bool>("--silent", false) || ctx.get<bool>("-q", false);
+  cfg.files_without_match = ctx.get<bool>("--files-without-match", false) ||
+                            ctx.get<bool>("-L", false);
+  cfg.files_with_matches = ctx.get<bool>("--files-with-matches", false) ||
+                           ctx.get<bool>("-l", false);
+  cfg.count_only =
+      ctx.get<bool>("--count", false) || ctx.get<bool>("-c", false);
+  cfg.null_after_filename =
+      ctx.get<bool>("--null", false) || ctx.get<bool>("-Z", false);
+
+  cfg.recursive =
+      ctx.get<bool>("--recursive", false) || ctx.get<bool>("-r", false);
+  cfg.directories = ctx.get<std::string>("--directories", "");
+  if (cfg.directories.empty()) cfg.directories = ctx.get<std::string>("-d", "");
+  if (cfg.directories.empty())
+    cfg.directories = cfg.recursive ? "recurse" : "read";
+
+  std::vector<std::string> raw_patterns;
+  std::string p_e = ctx.get<std::string>("--regexp", "");
+  if (p_e.empty()) p_e = ctx.get<std::string>("-e", "");
+  if (!p_e.empty()) {
+    auto from_e = split_lines(p_e);
+    raw_patterns.insert(raw_patterns.end(), from_e.begin(), from_e.end());
+  }
+
+  std::string p_file = ctx.get<std::string>("--file", "");
+  if (p_file.empty()) p_file = ctx.get<std::string>("-f", "");
+  if (!p_file.empty()) {
+    auto file_patterns = load_patterns_from_file(p_file);
+    if (!file_patterns) return std::unexpected(file_patterns.error());
+    raw_patterns.insert(raw_patterns.end(), file_patterns->begin(),
+                        file_patterns->end());
+  }
+
+  std::vector<std::string> positionals;
+  for (auto p : ctx.positionals) positionals.emplace_back(p);
+
+  if (raw_patterns.empty()) {
+    if (positionals.empty()) {
+      return std::unexpected("missing PATTERNS");
+    }
+    auto split = split_lines(positionals.front());
+    raw_patterns.insert(raw_patterns.end(), split.begin(), split.end());
+    positionals.erase(positionals.begin());
+  }
+
+  if (raw_patterns.empty()) {
+    return std::unexpected("missing PATTERNS");
+  }
+
+  for (const auto& rp : raw_patterns) {
+    auto c = compile_pattern(cfg.mode, cfg.ignore_case, rp);
+    if (!c) return std::unexpected(c.error());
+    cfg.patterns.push_back(*c);
+  }
+
+  cfg.files = positionals;
+  if (cfg.files.empty()) {
+    if (cfg.directories == "recurse") {
+      cfg.files.push_back(".");
+    } else {
+      cfg.files.push_back("-");
+    }
+  }
+
+  return cfg;
+}
+
+auto record_name_for_output(std::string_view input_name, const Config& cfg)
+    -> std::string {
+  if (input_name == "-") {
+    if (!cfg.label.empty()) return cfg.label;
+    return "(standard input)";
+  }
+  return std::string(input_name);
+}
+
+auto match_fixed_once(std::string_view haystack, std::string_view needle,
+                      bool ignore_case, size_t start_pos)
+    -> std::optional<MatchPiece> {
+  if (needle.empty()) return std::nullopt;
+
+  if (!ignore_case) {
+    size_t pos = haystack.find(needle, start_pos);
+    if (pos == std::string_view::npos) return std::nullopt;
+    return MatchPiece{pos, pos + needle.size()};
+  }
+
+  std::string h = to_lower_ascii(haystack);
+  std::string n = to_lower_ascii(needle);
+  size_t pos = h.find(n, start_pos);
+  if (pos == std::string::npos) return std::nullopt;
+  return MatchPiece{pos, pos + needle.size()};
+}
+
+auto collect_matches_in_line(std::string_view line, const Config& cfg)
+    -> std::vector<MatchPiece> {
+  std::vector<MatchPiece> out;
+
+  for (const auto& p : cfg.patterns) {
+    if (cfg.mode == PatternMode::Fixed) {
+      if (cfg.line_regexp) {
+        bool eq = cfg.ignore_case ? (to_lower_ascii(line) == p.lowered)
+                                  : (line == p.raw);
+        if (eq) out.push_back(MatchPiece{0, line.size()});
+        continue;
+      }
+
+      size_t cursor = 0;
+      while (true) {
+        auto m = match_fixed_once(line, p.raw, cfg.ignore_case, cursor);
+        if (!m.has_value()) break;
+        if (!cfg.word_regexp || word_boundary_ok(line, m->begin, m->end)) {
+          out.push_back(*m);
+        }
+        cursor = m->begin + 1;
+      }
+      continue;
+    }
+
+    if (!p.regex.has_value()) continue;
+
+    if (cfg.line_regexp) {
+      if (std::regex_match(line.begin(), line.end(), *p.regex)) {
+        out.push_back(MatchPiece{0, line.size()});
+      }
+      continue;
+    }
+
+    std::string line_copy(line);
+    for (auto it =
+             std::sregex_iterator(line_copy.begin(), line_copy.end(), *p.regex);
+         it != std::sregex_iterator(); ++it) {
+      auto pos = static_cast<size_t>(it->position());
+      auto len = static_cast<size_t>(it->length());
+      if (len == 0) continue;
+      MatchPiece m{pos, pos + len};
+      if (!cfg.word_regexp || word_boundary_ok(line, m.begin, m.end)) {
+        out.push_back(m);
+      }
+    }
+  }
+
+  std::sort(out.begin(), out.end(),
+            [](const MatchPiece& a, const MatchPiece& b) {
+              if (a.begin != b.begin) return a.begin < b.begin;
+              return a.end < b.end;
+            });
+  out.erase(std::unique(out.begin(), out.end(),
+                        [](const MatchPiece& a, const MatchPiece& b) {
+                          return a.begin == b.begin && a.end == b.end;
+                        }),
+            out.end());
+  return out;
+}
+
+auto print_prefix(const Config& cfg, bool show_filename,
+                  std::string_view display_name, size_t line_no, size_t offset)
+    -> void {
+  if (show_filename) {
+    safePrint(display_name);
+    safePrint(":");
+  }
+  if (cfg.line_number) {
+    safePrint(std::to_string(line_no));
+    safePrint(":");
+  }
+  if (cfg.byte_offset) {
+    safePrint(std::to_string(offset));
+    safePrint(":");
+  }
+}
+
+auto scan_text(std::string_view text, std::string_view display_name,
+               bool show_filename, Config& cfg) -> std::pair<bool, size_t> {
+  const char delim = cfg.null_data ? '\0' : '\n';
+  std::string buf(text);
+  auto records = split_records(buf, delim);
+
+  bool any_selected = false;
+  size_t selected_count = 0;
+
+  for (size_t i = 0; i < records.size(); ++i) {
+    const auto [b, e] = records[i];
+    std::string_view whole(buf.data() + b, e - b);
+    std::string_view line = whole;
+    if (!line.empty() && line.back() == delim)
+      line = line.substr(0, line.size() - 1);
+
+    auto matches = collect_matches_in_line(line, cfg);
+    bool is_match = !matches.empty();
+    bool selected = cfg.invert_match ? !is_match : is_match;
+
+    if (!selected) continue;
+
+    any_selected = true;
+    ++selected_count;
+
+    if (cfg.quiet) {
+      if (cfg.max_count >= 0 &&
+          static_cast<int>(selected_count) >= cfg.max_count)
+        break;
+      return {true, selected_count};
+    }
+
+    if (cfg.files_with_matches || cfg.files_without_match || cfg.count_only) {
+      if (cfg.max_count >= 0 &&
+          static_cast<int>(selected_count) >= cfg.max_count)
+        break;
+      continue;
+    }
+
+    if (cfg.only_matching && !cfg.invert_match) {
+      for (const auto& m : matches) {
+        if (m.end <= m.begin) continue;
+        print_prefix(cfg, show_filename, display_name, i + 1, b + m.begin);
+        safePrint(line.substr(m.begin, m.end - m.begin));
+        safePrint(cfg.null_data ? "\0" : "\n");
+      }
+    } else {
+      print_prefix(cfg, show_filename, display_name, i + 1, b);
+      safePrint(whole);
+      if (whole.empty() || whole.back() != delim) {
+        safePrint(cfg.null_data ? "\0" : "\n");
+      }
+    }
+
+    if (cfg.max_count >= 0 && static_cast<int>(selected_count) >= cfg.max_count)
+      break;
+  }
+
+  return {any_selected, selected_count};
+}
+
+auto read_file_binary(const std::string& path) -> cp::Result<std::string> {
+  std::ifstream in(path, std::ios::binary);
+  if (!in.is_open()) {
+    return std::unexpected("cannot open '" + path + "'");
+  }
+  return std::string((std::istreambuf_iterator<char>(in)),
+                     std::istreambuf_iterator<char>());
+}
+
+auto gather_files_for_input(const Config& cfg, std::vector<std::string>& out)
+    -> cp::Result<void> {
+  for (const auto& f : cfg.files) {
+    if (f == "-") {
+      out.push_back(f);
+      continue;
+    }
+
+    std::error_code ec;
+    bool is_dir = std::filesystem::is_directory(f, ec);
+    if (ec) {
+      out.push_back(f);
+      continue;
+    }
+
+    if (!is_dir) {
+      out.push_back(f);
+      continue;
+    }
+
+    if (cfg.directories == "skip") continue;
+
+    if (cfg.directories == "recurse") {
+      for (const auto& e : std::filesystem::recursive_directory_iterator(f)) {
+        if (e.is_regular_file()) {
+          out.push_back(e.path().string());
+        }
+      }
+      continue;
+    }
+
+    return std::unexpected("'" + f + "' is a directory");
+  }
+  return {};
+}
+
+auto process(Config& cfg) -> int {
+  std::vector<std::string> inputs;
+  auto gather = gather_files_for_input(cfg, inputs);
+  if (!gather) {
+    if (!cfg.no_messages && !cfg.quiet) {
+      safeErrorPrint("grep: ");
+      safeErrorPrint(gather.error());
+      safeErrorPrint("\n");
+    }
+    return 2;
+  }
+
+  bool show_filename = false;
+  if (cfg.with_filename) {
+    show_filename = true;
+  } else if (!cfg.no_filename && inputs.size() > 1) {
+    show_filename = true;
+  }
+
+  bool any_selected_global = false;
+
+  for (const auto& input : inputs) {
+    std::string data;
+    if (input == "-") {
+      data = std::string((std::istreambuf_iterator<char>(std::cin)),
+                         std::istreambuf_iterator<char>());
+    } else {
+      auto read = read_file_binary(input);
+      if (!read) {
+        cfg.has_error = true;
+        if (!cfg.no_messages && !cfg.quiet) {
+          safeErrorPrint("grep: ");
+          safeErrorPrint(read.error());
+          safeErrorPrint("\n");
+        }
+        continue;
+      }
+      data = *read;
+    }
+
+    auto display_name = record_name_for_output(input, cfg);
+    auto [any_selected, selected_count] =
+        scan_text(data, display_name, show_filename, cfg);
+    any_selected_global = any_selected_global || any_selected;
+
+    if (!cfg.quiet) {
+      if (cfg.files_with_matches && any_selected) {
+        safePrint(display_name);
+        safePrint(cfg.null_after_filename ? "\0" : "\n");
+      }
+
+      if (cfg.files_without_match && !any_selected) {
+        safePrint(display_name);
+        safePrint(cfg.null_after_filename ? "\0" : "\n");
+      }
+
+      if (cfg.count_only) {
+        if (show_filename) {
+          safePrint(display_name);
+          safePrint(":");
+        }
+        safePrint(std::to_string(selected_count));
+        safePrint("\n");
+      }
+    }
+
+    if (cfg.quiet && any_selected_global) break;
+  }
+
+  if (cfg.has_error && !cfg.quiet) return 2;
+  return any_selected_global ? 0 : 1;
+}
+
+}  // namespace grep_pipeline
+
+REGISTER_COMMAND(
+    grep, "grep", "grep [OPTION]... PATTERNS [FILE]...",
+    "Search for PATTERNS in each FILE.\n"
+    "PATTERNS can contain multiple patterns separated by newlines.\n"
+    "With no FILE, read '-' unless recursive mode is selected.",
+    "  grep -i 'hello world' menu.h main.c\n"
+    "  grep -n -E 'foo|bar' file.txt\n"
+    "  grep -r pattern .\n"
+    "  grep -F -x exact_line file.txt",
+    "sed(1), awk(1), find(1)", "WinuxCmd", "Copyright © 2026 WinuxCmd",
+    GREP_OPTIONS) {
+  using namespace grep_pipeline;
+
+  auto config = build_config(ctx);
+  if (!config) {
+    cp::report_error(config, L"grep");
+    return 2;
+  }
+
+  return process(*config);
+}

--- a/src/commands/head.cpp
+++ b/src/commands/head.cpp
@@ -1,0 +1,284 @@
+/*
+ *  Copyright © 2026 [caomengxuan666]
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the “Software”), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ *  - File: head.cpp
+ *  - Username: Administrator
+ *  - CopyrightYear: 2026
+ */
+
+#include "core/command_macros.h"
+#include "pch/pch.h"
+
+import std;
+import core;
+import utils;
+
+using cmd::meta::OptionMeta;
+using cmd::meta::OptionType;
+
+/**
+ * @brief HEAD command options definition
+ *
+ * This array defines all the options supported by the head command.
+ * Each option is described with its short form, long form, and description.
+ * The implementation status is also indicated for each option.
+ *
+ * @par Options:
+ *
+ * - @a -c, @a --bytes: Print the first NUM bytes of each file; with the leading '-',
+ *   print all but the last NUM bytes [IMPLEMENTED]
+ * - @a -n, @a --lines: Print the first NUM lines instead of the first 10; with the
+ *   leading '-', print all but the last NUM lines [IMPLEMENTED]
+ * - @a -q, @a --quiet: Never print headers giving file names for multiple files [IMPLEMENTED]
+ * - @a --silent: Never print headers giving file names for multiple files [IMPLEMENTED]
+ * - @a -v, @a --verbose: Always print headers giving file names for multiple files [IMPLEMENTED]
+ * - @a -z, @a --zero-terminated: Line delimiter is NUL, not newline [IMPLEMENTED]
+ */
+auto constexpr HEAD_OPTIONS = std::array{
+    OPTION("-c", "--bytes",
+           "print the first NUM bytes of each file; with the leading '-',\n"
+           "print all but the last NUM bytes",
+           STRING_TYPE),
+    OPTION("-n", "--lines",
+           "print the first NUM lines instead of the first 10; with the\n"
+           "leading '-', print all but the last NUM lines",
+           STRING_TYPE),
+    OPTION("-q", "--quiet",
+           "never print headers giving file names for multiple files"),
+    OPTION("", "--silent",
+           "never print headers giving file names for multiple files"),
+    OPTION("-v", "--verbose",
+           "always print headers giving file names for multiple files"),
+    OPTION("-z", "--zero-terminated", "line delimiter is NUL, not newline")};
+
+namespace head_pipeline {
+namespace cp = core::pipeline;
+
+struct CountSpec {
+  std::uintmax_t value = 10;
+  bool all_but_last = false;
+};
+
+struct HeadConfig {
+  bool by_bytes = false;
+  CountSpec spec;
+  bool quiet = false;
+  bool verbose = false;
+  char delimiter = '\n';
+};
+
+auto read_all(std::istream& in) -> std::string {
+  return std::string(std::istreambuf_iterator<char>(in),
+                     std::istreambuf_iterator<char>());
+}
+
+auto parse_uint(std::string_view text) -> std::optional<std::uintmax_t> {
+  if (text.empty()) return std::nullopt;
+  std::uintmax_t value = 0;
+  auto [ptr, ec] =
+      std::from_chars(text.data(), text.data() + text.size(), value);
+  if (ec != std::errc() || ptr != text.data() + text.size()) {
+    return std::nullopt;
+  }
+  return value;
+}
+
+auto parse_count_spec(std::string spec_text, std::string_view opt_name)
+    -> cp::Result<CountSpec> {
+  if (spec_text.empty()) {
+    return std::unexpected("invalid number of " + std::string(opt_name));
+  }
+
+  CountSpec spec;
+  if (spec_text[0] == '-') {
+    spec.all_but_last = true;
+    spec_text.erase(0, 1);
+    if (spec_text.empty()) {
+      return std::unexpected("invalid number of " + std::string(opt_name));
+    }
+  }
+
+  auto parsed = parse_uint(spec_text);
+  if (!parsed.has_value()) {
+    return std::unexpected("invalid number of " + std::string(opt_name));
+  }
+  spec.value = *parsed;
+  return spec;
+}
+
+auto split_records(const std::string& data, char delimiter)
+    -> std::vector<std::pair<size_t, size_t>> {
+  std::vector<std::pair<size_t, size_t>> records;
+  size_t start = 0;
+  for (size_t i = 0; i < data.size(); ++i) {
+    if (data[i] == delimiter) {
+      records.emplace_back(start, i + 1);
+      start = i + 1;
+    }
+  }
+  if (start < data.size()) {
+    records.emplace_back(start, data.size());
+  }
+  return records;
+}
+
+auto print_ranges(const std::string& data,
+                  const std::vector<std::pair<size_t, size_t>>& ranges,
+                  size_t first, size_t last) -> void {
+  for (size_t i = first; i < last; ++i) {
+    const auto [begin, end] = ranges[i];
+    safePrint(std::string_view(data.data() + begin, end - begin));
+  }
+}
+
+auto output_head(const std::string& data, const HeadConfig& config) -> void {
+  if (config.by_bytes) {
+    size_t keep = static_cast<size_t>(config.spec.value);
+    if (config.spec.all_but_last) {
+      if (keep >= data.size()) return;
+      safePrint(std::string_view(data.data(), data.size() - keep));
+      return;
+    }
+
+    size_t count = std::min(keep, data.size());
+    if (count > 0) {
+      safePrint(std::string_view(data.data(), count));
+    }
+    return;
+  }
+
+  auto ranges = split_records(data, config.delimiter);
+  if (ranges.empty()) return;
+
+  size_t total = ranges.size();
+  size_t count = static_cast<size_t>(config.spec.value);
+
+  if (config.spec.all_but_last) {
+    if (count >= total) return;
+    print_ranges(data, ranges, 0, total - count);
+    return;
+  }
+
+  size_t take = std::min(count, total);
+  print_ranges(data, ranges, 0, take);
+}
+
+auto read_input(std::string_view path) -> cp::Result<std::string> {
+  if (path == "-") return read_all(std::cin);
+
+  std::ifstream file(std::string(path), std::ios::binary);
+  if (!file.is_open()) {
+    return std::unexpected("cannot open '" + std::string(path) + "'");
+  }
+
+  return read_all(file);
+}
+
+template <size_t N>
+auto build_config(const CommandContext<N>& ctx) -> cp::Result<HeadConfig> {
+  HeadConfig config;
+  config.quiet =
+      ctx.get<bool>("--quiet", false) || ctx.get<bool>("--silent", false);
+  config.verbose = ctx.get<bool>("--verbose", false);
+  config.delimiter = ctx.get<bool>("--zero-terminated", false) ? '\0' : '\n';
+
+  const std::string bytes_arg = ctx.get<std::string>("--bytes", "");
+  const std::string bytes_short = ctx.get<std::string>("-c", "");
+  const std::string lines_arg = ctx.get<std::string>("--lines", "");
+  const std::string lines_short = ctx.get<std::string>("-n", "");
+
+  std::string bytes_spec = bytes_arg.empty() ? bytes_short : bytes_arg;
+  std::string lines_spec = lines_arg.empty() ? lines_short : lines_arg;
+
+  if (!bytes_spec.empty()) {
+    auto spec = parse_count_spec(bytes_spec, "bytes");
+    if (!spec) return std::unexpected(spec.error());
+    config.by_bytes = true;
+    config.spec = *spec;
+    return config;
+  }
+
+  if (!lines_spec.empty()) {
+    auto spec = parse_count_spec(lines_spec, "lines");
+    if (!spec) return std::unexpected(spec.error());
+    config.spec = *spec;
+  }
+
+  return config;
+}
+
+}  // namespace head_pipeline
+
+REGISTER_COMMAND(
+    head, "head", "head [OPTION]... [FILE]...",
+    "Print the first 10 lines of each FILE to standard output.\n"
+    "With more than one FILE, precede each with a header giving the file "
+    "name.\n"
+    "\n"
+    "With no FILE, or when FILE is -, read standard input.",
+    "  head file.txt\n"
+    "  head -n 20 file.txt\n"
+    "  head -c 64 file.txt\n"
+    "  head -n -5 file.txt\n"
+    "  head -v a.txt b.txt",
+    "tail(1), cat(1)", "WinuxCmd", "Copyright © 2026 WinuxCmd", HEAD_OPTIONS) {
+  using namespace head_pipeline;
+
+  auto config_result = build_config(ctx);
+  if (!config_result) {
+    cp::report_error(config_result, L"head");
+    return 1;
+  }
+  auto config = *config_result;
+
+  std::vector<std::string> files;
+  for (auto p : ctx.positionals) files.emplace_back(p);
+  if (files.empty()) files.emplace_back("-");
+
+  bool any_error = false;
+  bool first_print = true;
+  bool multi = files.size() > 1;
+
+  for (const auto& file : files) {
+    auto data_result = read_input(file);
+    if (!data_result) {
+      safeErrorPrint("head: ");
+      safeErrorPrint(data_result.error());
+      safeErrorPrint("\n");
+      any_error = true;
+      continue;
+    }
+
+    bool show_header =
+        (config.verbose || (multi && !config.quiet)) && file != "-";
+    if (show_header) {
+      if (!first_print) safePrint("\n");
+      safePrint("==> ");
+      safePrint(file);
+      safePrint(" <==\n");
+    }
+
+    output_head(*data_result, config);
+    first_print = false;
+  }
+
+  return any_error ? 1 : 0;
+}

--- a/src/commands/ls.cpp
+++ b/src/commands/ls.cpp
@@ -19,7 +19,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- *  - File: ls.cppm
+ *  - File: ls.cpp
  *  - Username: Administrator
  *  - CopyrightYear: 2026
  */
@@ -73,7 +73,8 @@ using cmd::meta::OptionType;
  * show information for the file the link references [TODO]
  * - @a -l, @a --long-list: Use a long listing format [IMPLEMENTED]
  * - @a -m: Fill width with a comma separated list of entries [TODO]
- * - @a -n, @a --numeric-uid-gid: Like -l, but list numeric user and group IDs [IMPLEMENTED]
+ * - @a -n, @a --numeric-uid-gid: Like -l, but list numeric user and group IDs
+ * [IMPLEMENTED]
  * - @a -N, @a --literal: Print entry names without quoting [TODO]
  * - @a -o: Like -l, but do not list group information [IMPLEMENTED]
  * - @a -p, @a --indicator-style=slash: Append / indicator to directories [TODO]
@@ -300,7 +301,7 @@ auto get_file_size_string(const WIN32_FIND_DATAW &find_data,
                       (static_cast<uint64_t>(find_data.nFileSizeHigh) << 32);
 
   char buf[32];
-  
+
   if (ctx.get<bool>("-h", false) || ctx.get<bool>("--human-readable", false)) {
     const char *units[] = {"B", "K", "M", "G", "T"};
     int unitIndex = 0;
@@ -319,7 +320,7 @@ auto get_file_size_string(const WIN32_FIND_DATAW &find_data,
   } else {
     snprintf(buf, sizeof(buf), "%llu", fileSize);
   }
-  
+
   return std::string(buf);
 }
 
@@ -341,14 +342,13 @@ auto get_modification_time_string(const WIN32_FIND_DATAW &find_data,
     FileTimeToSystemTime(&local_ft, &st);
   }
 
-  const char *month_abbrs[] = {"",    "Jan", "Feb", "Mar", "Apr",
-                               "May", "Jun", "Jul", "Aug", "Sep",
-                               "Oct", "Nov", "Dec"};
+  const char *month_abbrs[] = {"",    "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+                               "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
 
   char buf[64];
-  snprintf(buf, sizeof(buf), "%s %2d %02d:%02d",
-           month_abbrs[st.wMonth], st.wDay, st.wHour, st.wMinute);
-  
+  snprintf(buf, sizeof(buf), "%s %2d %02d:%02d", month_abbrs[st.wMonth],
+           st.wDay, st.wHour, st.wMinute);
+
   return std::string(buf);
 }
 
@@ -357,7 +357,8 @@ auto get_modification_time_string(const WIN32_FIND_DATAW &find_data,
  * @param use_numeric Whether to return numeric UID/GID (-n option)
  * @return Pair of (owner, group) strings
  */
-auto get_file_owner_and_group(bool use_numeric = false) -> std::pair<std::string, std::string> {
+auto get_file_owner_and_group(bool use_numeric = false)
+    -> std::pair<std::string, std::string> {
   if (use_numeric) {
     // Get Windows SID (simulate UID/GID)
     HANDLE hToken;
@@ -366,14 +367,17 @@ auto get_file_owner_and_group(bool use_numeric = false) -> std::pair<std::string
       GetTokenInformation(hToken, TokenUser, nullptr, 0, &bufferSize);
       std::vector<BYTE> buffer(bufferSize);
       PTOKEN_USER pTokenUser = reinterpret_cast<PTOKEN_USER>(buffer.data());
-      if (GetTokenInformation(hToken, TokenUser, pTokenUser, bufferSize, &bufferSize)) {
+      if (GetTokenInformation(hToken, TokenUser, pTokenUser, bufferSize,
+                              &bufferSize)) {
         LPWSTR sidStr = nullptr;
         if (ConvertSidToStringSidW(pTokenUser->User.Sid, &sidStr)) {
           // Extract numeric part from SID (simulate UID 197121)
           std::wstring sid = sidStr;
           size_t lastDash = sid.find_last_of(L'-');
-          std::wstring uid_wstr = (lastDash != std::wstring::npos) ? sid.substr(lastDash+1) : L"197121";
-          
+          std::wstring uid_wstr = (lastDash != std::wstring::npos)
+                                      ? sid.substr(lastDash + 1)
+                                      : L"197121";
+
           // Convert wide string to UTF-8
           std::string uid = wstring_to_utf8(uid_wstr);
           LocalFree(sidStr);
@@ -714,7 +718,8 @@ auto list_directory(const std::string &path,
       ctx.get<bool>("-l", false) || ctx.get<bool>("--long-list", false);
   bool one_per_line = ctx.get<bool>("-1", false);
   bool columns = ctx.get<bool>("-C", false);
-  bool use_numeric = ctx.get<bool>("-n", false) || ctx.get<bool>("--numeric-uid-gid", false);
+  bool use_numeric =
+      ctx.get<bool>("-n", false) || ctx.get<bool>("--numeric-uid-gid", false);
   if (long_format) {
     // FileInfo struct for storing file information
     struct FileInfo {
@@ -911,8 +916,7 @@ auto list_directory(const std::string &path,
             // Check file extensions for different types
             std::wstring ext;
             size_t dot_pos = entry.find_last_of(L".");
-            if (dot_pos != std::wstring::npos &&
-                dot_pos < entry.length() - 1) {
+            if (dot_pos != std::wstring::npos && dot_pos < entry.length() - 1) {
               ext = entry.substr(dot_pos + 1);
               std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
             }

--- a/src/commands/mkdir.cpp
+++ b/src/commands/mkdir.cpp
@@ -19,7 +19,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- *  - File: mkdir.cppm
+ *  - File: mkdir.cpp
  *  - Username: Administrator
  *  - CopyrightYear: 2026
  */

--- a/src/commands/rm.cpp
+++ b/src/commands/rm.cpp
@@ -19,7 +19,7 @@
  * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
  * IN THE SOFTWARE.
  *
- *  - File: rm.cppm
+ *  - File: rm.cpp
  *  - Username: Administrator
  *  - CopyrightYear: 2026
  */

--- a/src/commands/rmdir.cpp
+++ b/src/commands/rmdir.cpp
@@ -1,0 +1,144 @@
+/*
+ *  Copyright © 2026 [caomengxuan666]
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the “Software”), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ *  - File: rmdir.cpp
+ *  - Username: Administrator
+ *  - CopyrightYear: 2026
+ */
+
+#include "core/command_macros.h"
+#include "pch/pch.h"
+
+import std;
+import core;
+import utils;
+
+using cmd::meta::OptionMeta;
+using cmd::meta::OptionType;
+
+auto constexpr RMDIR_OPTIONS =
+    std::array{OPTION("", "--ignore-fail-on-non-empty",
+                      "ignore each failure to remove a non-empty directory"),
+               OPTION("-p", "--parents", "remove DIRECTORY and its ancestors"),
+               OPTION("-v", "--verbose",
+                      "output a diagnostic for every directory processed")};
+
+namespace rmdir_pipeline {
+namespace cp = core::pipeline;
+
+auto is_root_path(const std::wstring& p) -> bool {
+  if (p.empty()) return true;
+  if (p == L"\\" || p == L"/") return true;
+  return (p.size() == 3 && p[1] == L':' && (p[2] == L'\\' || p[2] == L'/'));
+}
+
+auto parent_path(std::wstring p) -> std::wstring {
+  while (!p.empty() && (p.back() == L'\\' || p.back() == L'/')) p.pop_back();
+  auto pos = p.find_last_of(L"\\/");
+  if (pos == std::wstring::npos) return L"";
+  return p.substr(0, pos);
+}
+
+auto remove_one(const std::string& utf8_path, bool ignore_non_empty,
+                bool verbose) -> bool {
+  std::wstring wpath = utf8_to_wstring(utf8_path);
+  if (RemoveDirectoryW(wpath.c_str())) {
+    if (verbose) {
+      safePrint("rmdir: removing directory '");
+      safePrint(utf8_path);
+      safePrint("'\n");
+    }
+    return true;
+  }
+
+  DWORD e = GetLastError();
+  if (e == ERROR_DIR_NOT_EMPTY && ignore_non_empty) return true;
+
+  if (e == ERROR_PATH_NOT_FOUND || e == ERROR_FILE_NOT_FOUND) {
+    safeErrorPrint("rmdir: failed to remove '");
+    safeErrorPrint(utf8_path);
+    safeErrorPrint("': No such file or directory\n");
+    return false;
+  }
+  if (e == ERROR_DIR_NOT_EMPTY) {
+    safeErrorPrint("rmdir: failed to remove '");
+    safeErrorPrint(utf8_path);
+    safeErrorPrint("': Directory not empty\n");
+    return false;
+  }
+
+  safeErrorPrint("rmdir: failed to remove '");
+  safeErrorPrint(utf8_path);
+  safeErrorPrint("'\n");
+  return false;
+}
+
+auto process_command(const CommandContext<RMDIR_OPTIONS.size()>& ctx)
+    -> cp::Result<bool> {
+  if (ctx.positionals.empty()) return std::unexpected("missing operand");
+
+  bool parents =
+      ctx.get<bool>("--parents", false) || ctx.get<bool>("-p", false);
+  bool verbose =
+      ctx.get<bool>("--verbose", false) || ctx.get<bool>("-v", false);
+  bool ignore_non_empty = ctx.get<bool>("--ignore-fail-on-non-empty", false);
+
+  bool ok_all = true;
+
+  for (auto arg : ctx.positionals) {
+    std::string cur(arg);
+    if (!remove_one(cur, ignore_non_empty, verbose)) {
+      ok_all = false;
+      continue;
+    }
+
+    if (!parents) continue;
+
+    std::wstring wcur = utf8_to_wstring(cur);
+    while (true) {
+      std::wstring p = parent_path(wcur);
+      if (p.empty() || is_root_path(p)) break;
+
+      std::string p8 = wstring_to_utf8(p);
+      if (!remove_one(p8, ignore_non_empty, verbose)) break;
+      wcur = p;
+    }
+  }
+
+  return ok_all;
+}
+}  // namespace rmdir_pipeline
+
+REGISTER_COMMAND(rmdir, "rmdir", "rmdir [OPTION]... DIRECTORY...",
+                 "Remove the DIRECTORY(ies), if they are empty.",
+                 "  rmdir dir\n"
+                 "  rmdir -p a/b/c\n"
+                 "  rmdir --ignore-fail-on-non-empty dir",
+                 "mkdir(1), rm(1)", "WinuxCmd", "Copyright © 2026 WinuxCmd",
+                 RMDIR_OPTIONS) {
+  using namespace rmdir_pipeline;
+  auto result = process_command(ctx);
+  if (!result) {
+    cp::report_error(result, L"rmdir");
+    return 1;
+  }
+  return *result ? 0 : 1;
+}

--- a/src/commands/sort.cpp
+++ b/src/commands/sort.cpp
@@ -1,0 +1,406 @@
+/*
+*  Copyright © 2026 [caomengxuan666]
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the “Software”), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ *  - File: sort.cpp
+ *  - Username: Administrator
+ *  - CopyrightYear: 2026
+ */
+
+/// @Author: WinuxCmd
+/// @contributors:
+///   - caomengxuan666 <2507560089@qq.com>
+/// @Description: Implemention for sort.
+/// @Version: 0.1.0
+/// @License: MIT
+/// @Copyright: Copyright © 2026 WinuxCmd
+#include "core/command_macros.h"
+#include "pch/pch.h"
+
+import std;
+import core;
+import utils;
+
+using cmd::meta::OptionMeta;
+using cmd::meta::OptionType;
+
+auto constexpr SORT_OPTIONS = std::array{
+    OPTION("-b", "--ignore-leading-blanks",
+           "ignore leading blanks"),
+    OPTION("-d", "--dictionary-order",
+           "consider only blanks and alphanumeric characters [NOT SUPPORT]"),
+    OPTION("-f", "--ignore-case", "fold lower case to upper case"),
+    OPTION("-g", "--general-numeric-sort",
+           "compare according to general numerical value [NOT SUPPORT]"),
+    OPTION("-i", "--ignore-nonprinting",
+           "consider only printable characters [NOT SUPPORT]"),
+    OPTION("-h", "--human-numeric-sort",
+           "compare human readable numbers [NOT SUPPORT]"),
+    OPTION("-M", "--month-sort",
+           "compare as month names [NOT SUPPORT]"),
+    OPTION("-m", "--merge", "merge already sorted files [NOT SUPPORT]"),
+    OPTION("-n", "--numeric-sort", "compare according to string numerical value"),
+    OPTION("-R", "--random-sort", "shuffle [NOT SUPPORT]"),
+    OPTION("-r", "--reverse", "reverse the result of comparisons"),
+    OPTION("-s", "--stable",
+           "stabilize sort by disabling last-resort comparison [NOT SUPPORT]"),
+    OPTION("-u", "--unique", "output only the first of equal runs"),
+    OPTION("-z", "--zero-terminated", "line delimiter is NUL, not newline"),
+    OPTION("-o", "--output", "write result to FILE instead of standard output",
+           STRING_TYPE),
+    OPTION("-t", "--field-separator",
+           "use SEP instead of non-blank to blank transition", STRING_TYPE),
+    OPTION("-k", "--key",
+           "sort via a key; KEYDEF has form F[.C][,F[.C]]", STRING_TYPE)};
+
+namespace sort_pipeline {
+namespace cp = core::pipeline;
+
+struct KeySpec {
+  size_t start_field = 1;
+  bool enabled = false;
+};
+
+struct Config {
+  bool ignore_leading_blanks = false;
+  bool ignore_case = false;
+  bool numeric_sort = false;
+  bool reverse = false;
+  bool unique = false;
+  char delimiter = '\n';
+  std::optional<char> field_separator;
+  std::string output_file;
+  KeySpec key;
+  std::vector<std::string> files;
+};
+
+auto read_all(std::istream& in) -> std::string {
+  return std::string(std::istreambuf_iterator<char>(in),
+                     std::istreambuf_iterator<char>());
+}
+
+auto read_source(std::string_view path) -> cp::Result<std::string> {
+  if (path == "-") return read_all(std::cin);
+
+  std::ifstream in(std::string(path), std::ios::binary);
+  if (!in.is_open()) {
+    return std::unexpected("cannot open '" + std::string(path) + "'");
+  }
+  return read_all(in);
+}
+
+auto split_records(std::string_view content, char delimiter)
+    -> std::vector<std::string> {
+  std::vector<std::string> out;
+  size_t start = 0;
+  for (size_t i = 0; i < content.size(); ++i) {
+    if (content[i] == delimiter) {
+      out.emplace_back(content.substr(start, i - start));
+      start = i + 1;
+    }
+  }
+  if (start < content.size()) {
+    out.emplace_back(content.substr(start));
+  }
+  return out;
+}
+
+auto to_lower_ascii(std::string_view s) -> std::string {
+  std::string out;
+  out.reserve(s.size());
+  for (unsigned char c : s) {
+    out.push_back(static_cast<char>(std::tolower(c)));
+  }
+  return out;
+}
+
+auto ltrim_ascii(std::string_view s) -> std::string_view {
+  size_t i = 0;
+  while (i < s.size() &&
+         std::isspace(static_cast<unsigned char>(s[i])) != 0) {
+    ++i;
+  }
+  return s.substr(i);
+}
+
+auto parse_key_spec(std::string_view text) -> cp::Result<KeySpec> {
+  KeySpec key;
+  if (text.empty()) return key;
+
+  auto comma = text.find(',');
+  auto first = text.substr(0, comma);
+  auto dot = first.find('.');
+  if (dot != std::string_view::npos) {
+    first = first.substr(0, dot);
+  }
+
+  if (first.empty()) {
+    return std::unexpected("invalid key spec");
+  }
+
+  size_t value = 0;
+  auto [ptr, ec] =
+      std::from_chars(first.data(), first.data() + first.size(), value);
+  if (ec != std::errc() || ptr != first.data() + first.size() || value == 0) {
+    return std::unexpected("invalid key spec");
+  }
+
+  key.enabled = true;
+  key.start_field = value;
+  return key;
+}
+
+auto get_field_by_whitespace(std::string_view line, size_t index)
+    -> std::string_view {
+  size_t field = 0;
+  size_t i = 0;
+  while (i < line.size()) {
+    while (i < line.size() &&
+           std::isspace(static_cast<unsigned char>(line[i])) != 0) {
+      ++i;
+    }
+    if (i >= line.size()) break;
+
+    size_t start = i;
+    while (i < line.size() &&
+           std::isspace(static_cast<unsigned char>(line[i])) == 0) {
+      ++i;
+    }
+    ++field;
+    if (field == index) return line.substr(start, i - start);
+  }
+  return {};
+}
+
+auto get_field_by_separator(std::string_view line, size_t index, char sep)
+    -> std::string_view {
+  size_t field = 1;
+  size_t start = 0;
+  while (true) {
+    size_t pos = line.find(sep, start);
+    if (field == index) {
+      if (pos == std::string_view::npos) return line.substr(start);
+      return line.substr(start, pos - start);
+    }
+    if (pos == std::string_view::npos) break;
+    start = pos + 1;
+    ++field;
+  }
+  return {};
+}
+
+auto extract_key(std::string_view line, const Config& cfg) -> std::string_view {
+  if (!cfg.key.enabled) return line;
+
+  std::string_view key;
+  if (cfg.field_separator.has_value()) {
+    key = get_field_by_separator(line, cfg.key.start_field, *cfg.field_separator);
+  } else {
+    key = get_field_by_whitespace(line, cfg.key.start_field);
+  }
+
+  if (cfg.ignore_leading_blanks) key = ltrim_ascii(key);
+  return key;
+}
+
+auto parse_double_strict(std::string_view s) -> std::optional<double> {
+  auto trimmed = ltrim_ascii(s);
+  if (trimmed.empty()) return std::nullopt;
+
+  std::string local(trimmed);
+  char* end = nullptr;
+  errno = 0;
+  const double value = std::strtod(local.c_str(), &end);
+  if (end == local.c_str() || *end != '\0' || errno == ERANGE) {
+    return std::nullopt;
+  }
+  return value;
+}
+
+auto compare_records(std::string_view a, std::string_view b, const Config& cfg)
+    -> int {
+  auto key_a = extract_key(a, cfg);
+  auto key_b = extract_key(b, cfg);
+
+  if (cfg.numeric_sort) {
+    auto n_a = parse_double_strict(key_a);
+    auto n_b = parse_double_strict(key_b);
+    if (n_a.has_value() && n_b.has_value()) {
+      if (*n_a < *n_b) return -1;
+      if (*n_a > *n_b) return 1;
+    }
+  }
+
+  std::string left = std::string(key_a);
+  std::string right = std::string(key_b);
+  if (cfg.ignore_case) {
+    left = to_lower_ascii(left);
+    right = to_lower_ascii(right);
+  }
+
+  if (left < right) return -1;
+  if (left > right) return 1;
+
+  if (a < b) return -1;
+  if (a > b) return 1;
+  return 0;
+}
+
+auto is_unsupported_used(const CommandContext<SORT_OPTIONS.size()>& ctx)
+    -> std::optional<std::string_view> {
+  if (ctx.get<bool>("--dictionary-order", false) || ctx.get<bool>("-d", false))
+    return "--dictionary-order is [NOT SUPPORT]";
+  if (ctx.get<bool>("--general-numeric-sort", false) ||
+      ctx.get<bool>("-g", false))
+    return "--general-numeric-sort is [NOT SUPPORT]";
+  if (ctx.get<bool>("--ignore-nonprinting", false) || ctx.get<bool>("-i", false))
+    return "--ignore-nonprinting is [NOT SUPPORT]";
+  if (ctx.get<bool>("--human-numeric-sort", false) || ctx.get<bool>("-h", false))
+    return "--human-numeric-sort is [NOT SUPPORT]";
+  if (ctx.get<bool>("--month-sort", false) || ctx.get<bool>("-M", false))
+    return "--month-sort is [NOT SUPPORT]";
+  if (ctx.get<bool>("--merge", false) || ctx.get<bool>("-m", false))
+    return "--merge is [NOT SUPPORT]";
+  if (ctx.get<bool>("--random-sort", false) || ctx.get<bool>("-R", false))
+    return "--random-sort is [NOT SUPPORT]";
+  if (ctx.get<bool>("--stable", false) || ctx.get<bool>("-s", false))
+    return "--stable is [NOT SUPPORT]";
+  return std::nullopt;
+}
+
+auto build_config(const CommandContext<SORT_OPTIONS.size()>& ctx)
+    -> cp::Result<Config> {
+  Config cfg;
+
+  cfg.ignore_leading_blanks = ctx.get<bool>("--ignore-leading-blanks", false) ||
+                              ctx.get<bool>("-b", false);
+  cfg.ignore_case =
+      ctx.get<bool>("--ignore-case", false) || ctx.get<bool>("-f", false);
+  cfg.numeric_sort =
+      ctx.get<bool>("--numeric-sort", false) || ctx.get<bool>("-n", false);
+  cfg.reverse = ctx.get<bool>("--reverse", false) || ctx.get<bool>("-r", false);
+  cfg.unique = ctx.get<bool>("--unique", false) || ctx.get<bool>("-u", false);
+  cfg.delimiter =
+      (ctx.get<bool>("--zero-terminated", false) || ctx.get<bool>("-z", false))
+          ? '\0'
+          : '\n';
+
+  cfg.output_file = ctx.get<std::string>("--output", "");
+  if (cfg.output_file.empty()) cfg.output_file = ctx.get<std::string>("-o", "");
+
+  std::string sep = ctx.get<std::string>("--field-separator", "");
+  if (sep.empty()) sep = ctx.get<std::string>("-t", "");
+  if (!sep.empty()) {
+    if (sep.size() != 1) {
+      return std::unexpected("field separator must be a single character");
+    }
+    cfg.field_separator = sep[0];
+  }
+
+  std::string key_text = ctx.get<std::string>("--key", "");
+  if (key_text.empty()) key_text = ctx.get<std::string>("-k", "");
+  auto key = parse_key_spec(key_text);
+  if (!key) return std::unexpected(key.error());
+  cfg.key = *key;
+
+  for (auto p : ctx.positionals) cfg.files.emplace_back(p);
+  if (cfg.files.empty()) cfg.files.emplace_back("-");
+
+  return cfg;
+}
+
+auto run(const Config& cfg) -> int {
+  std::vector<std::string> records;
+  for (const auto& file : cfg.files) {
+    auto content = read_source(file);
+    if (!content) {
+      cp::report_error(content, L"sort");
+      return 1;
+    }
+    auto chunk = split_records(*content, cfg.delimiter);
+    records.insert(records.end(), std::make_move_iterator(chunk.begin()),
+                   std::make_move_iterator(chunk.end()));
+  }
+
+  std::stable_sort(records.begin(), records.end(), [&](const auto& a, const auto& b) {
+    int cmp = compare_records(a, b, cfg);
+    if (cfg.reverse) return cmp > 0;
+    return cmp < 0;
+  });
+
+  if (cfg.unique) {
+    std::vector<std::string> unique_records;
+    unique_records.reserve(records.size());
+    for (const auto& rec : records) {
+      if (unique_records.empty()) {
+        unique_records.push_back(rec);
+        continue;
+      }
+      if (compare_records(unique_records.back(), rec, cfg) != 0) {
+        unique_records.push_back(rec);
+      }
+    }
+    records = std::move(unique_records);
+  }
+
+  std::ostream* out = &std::cout;
+  std::ofstream file_out;
+  if (!cfg.output_file.empty()) {
+    file_out.open(cfg.output_file, std::ios::binary | std::ios::trunc);
+    if (!file_out.is_open()) {
+      cp::report_custom_error(L"sort", L"cannot open output file");
+      return 1;
+    }
+    out = &file_out;
+  }
+
+  for (const auto& rec : records) {
+    (*out) << rec;
+    (*out) << cfg.delimiter;
+  }
+  out->flush();
+  return 0;
+}
+
+}  // namespace sort_pipeline
+
+REGISTER_COMMAND(sort, "sort", "sort [OPTION]... [FILE]...",
+                 "Sort lines of text files.\n"
+                 "With no FILE, or when FILE is -, read standard input.",
+                 "  sort a.txt\n"
+                 "  sort -n -r data.txt\n"
+                 "  sort -u -k 1 names.txt",
+                 "uniq(1), grep(1), head(1)", "WinuxCmd",
+                 "Copyright © 2026 WinuxCmd", SORT_OPTIONS) {
+  using namespace sort_pipeline;
+
+  if (auto unsupported = is_unsupported_used(ctx); unsupported.has_value()) {
+    cp::report_custom_error(L"sort", utf8_to_wstring(*unsupported));
+    return 2;
+  }
+
+  auto cfg = build_config(ctx);
+  if (!cfg) {
+    cp::report_error(cfg, L"sort");
+    return 1;
+  }
+
+  return run(*cfg);
+}

--- a/src/commands/tail.cpp
+++ b/src/commands/tail.cpp
@@ -1,0 +1,403 @@
+/*
+ *  Copyright © 2026 [caomengxuan666]
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the “Software”), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ *  - File: tail.cpp
+ *  - Username: Administrator
+ *  - CopyrightYear: 2026
+ */
+
+#include "core/command_macros.h"
+#include "pch/pch.h"
+
+import std;
+import core;
+import utils;
+
+using cmd::meta::OptionMeta;
+using cmd::meta::OptionType;
+
+/**
+ * @brief TAIL command options definition
+ *
+ * This array defines all the options supported by the tail command.
+ * Each option is described with its short form, long form, and description.
+ * The implementation status is also indicated for each option.
+ *
+ * @par Options:
+ *
+ * - @a -c, @a --bytes: Output the last NUM bytes; or use -c +NUM to output
+ *   starting with byte NUM of each file [IMPLEMENTED]
+ * - @a -f, @a --follow: Output appended data as the file grows [NOT SUPPORT]
+ * - @a -F: Same as --follow=name --retry [NOT SUPPORT]
+ * - @a -n, @a --lines: Output the last NUM lines, instead of the last 10; or
+ *   use -n +NUM to skip NUM-1 lines at the start [IMPLEMENTED]
+ * - @a --max-unchanged-stats: With --follow=name, reopen a FILE which has not changed
+ *   size after N iterations to see if it has been renamed [NOT SUPPORT]
+ * - @a --pid: With -f, terminate after process ID, PID dies [NOT SUPPORT]
+ * - @a -q, @a --quiet: Never output headers giving file names [IMPLEMENTED]
+ * - @a --silent: Never output headers giving file names [IMPLEMENTED]
+ * - @a --retry: Keep trying to open a file if it is inaccessible [NOT SUPPORT]
+ * - @a -s, @a --sleep-interval: With -f, sleep for approximately N seconds between iterations
+ *   [NOT SUPPORT]
+ * - @a -v, @a --verbose: Always output headers giving file names [IMPLEMENTED]
+ * - @a -z, @a --zero-terminated: Line delimiter is NUL, not newline [IMPLEMENTED]
+ */
+auto constexpr TAIL_OPTIONS = std::array{
+    OPTION("-c", "--bytes",
+           "output the last NUM bytes; or use -c +NUM to output\n"
+           "starting with byte NUM of each file",
+           STRING_TYPE),
+    OPTION("-f", "--follow",
+           "output appended data as the file grows [NOT SUPPORT]"),
+    OPTION("-F", "", "same as --follow=name --retry [NOT SUPPORT]"),
+    OPTION("-n", "--lines",
+           "output the last NUM lines, instead of the last 10; or\n"
+           "use -n +NUM to skip NUM-1 lines at the start",
+           STRING_TYPE),
+    OPTION("", "--max-unchanged-stats",
+           "with --follow=name, reopen a FILE which has not changed\n"
+           "size after N iterations to see if it has been renamed\n"
+           "[NOT SUPPORT]",
+           INT_TYPE),
+    OPTION("", "--pid",
+           "with -f, terminate after process ID, PID dies [NOT SUPPORT]",
+           INT_TYPE),
+    OPTION("-q", "--quiet", "never output headers giving file names"),
+    OPTION("", "--silent", "never output headers giving file names"),
+    OPTION("", "--retry",
+           "keep trying to open a file if it is inaccessible [NOT SUPPORT]"),
+    OPTION("-s", "--sleep-interval",
+           "with -f, sleep for approximately N seconds between iterations\n"
+           "[NOT SUPPORT]",
+           STRING_TYPE),
+    OPTION("-v", "--verbose", "always output headers giving file names"),
+    OPTION("-z", "--zero-terminated", "line delimiter is NUL, not newline")};
+
+namespace tail_pipeline {
+namespace cp = core::pipeline;
+
+struct CountSpec {
+  std::uintmax_t value = 10;
+  bool from_start = false;
+};
+
+struct TailConfig {
+  bool by_bytes = false;
+  CountSpec spec;
+  bool quiet = false;
+  bool verbose = false;
+  char delimiter = '\n';
+};
+
+auto read_all(std::istream& in) -> std::string {
+  return std::string(std::istreambuf_iterator<char>(in),
+                     std::istreambuf_iterator<char>());
+}
+
+auto read_input(std::string_view path) -> cp::Result<std::string> {
+  if (path == "-") return read_all(std::cin);
+
+  std::ifstream file(std::string(path), std::ios::binary);
+  if (!file.is_open()) {
+    return std::unexpected("cannot open '" + std::string(path) + "'");
+  }
+  return read_all(file);
+}
+
+auto suffix_multiplier(std::string_view suffix)
+    -> std::optional<std::uintmax_t> {
+  static constexpr std::array<std::pair<std::string_view, std::uintmax_t>, 25>
+      kMultipliers = {
+          std::pair{"b", 512ULL},
+          std::pair{"kB", 1000ULL},
+          std::pair{"K", 1024ULL},
+          std::pair{"KiB", 1024ULL},
+          std::pair{"MB", 1000ULL * 1000ULL},
+          std::pair{"M", 1024ULL * 1024ULL},
+          std::pair{"MiB", 1024ULL * 1024ULL},
+          std::pair{"GB", 1000ULL * 1000ULL * 1000ULL},
+          std::pair{"G", 1024ULL * 1024ULL * 1024ULL},
+          std::pair{"GiB", 1024ULL * 1024ULL * 1024ULL},
+          std::pair{"TB", 1000ULL * 1000ULL * 1000ULL * 1000ULL},
+          std::pair{"T", 1024ULL * 1024ULL * 1024ULL * 1024ULL},
+          std::pair{"TiB", 1024ULL * 1024ULL * 1024ULL * 1024ULL},
+          std::pair{"PB", 1000ULL * 1000ULL * 1000ULL * 1000ULL * 1000ULL},
+          std::pair{"P", 1024ULL * 1024ULL * 1024ULL * 1024ULL * 1024ULL},
+          std::pair{"PiB", 1024ULL * 1024ULL * 1024ULL * 1024ULL * 1024ULL},
+          std::pair{"EB",
+                    1000ULL * 1000ULL * 1000ULL * 1000ULL * 1000ULL * 1000ULL},
+          std::pair{"E",
+                    1024ULL * 1024ULL * 1024ULL * 1024ULL * 1024ULL * 1024ULL},
+          std::pair{"EiB",
+                    1024ULL * 1024ULL * 1024ULL * 1024ULL * 1024ULL * 1024ULL},
+          std::pair{"Z", 1024ULL * 1024ULL * 1024ULL * 1024ULL * 1024ULL *
+                             1024ULL * 1024ULL},
+          std::pair{"Y", 1024ULL * 1024ULL * 1024ULL * 1024ULL * 1024ULL *
+                             1024ULL * 1024ULL * 1024ULL},
+          std::pair{"R", 0ULL},
+          std::pair{"Q", 0ULL},
+          std::pair{"ZB", 0ULL},
+          std::pair{"YB", 0ULL}};
+
+  if (suffix.empty()) return 1;
+
+  for (const auto& [key, mult] : kMultipliers) {
+    if (key == suffix) {
+      if (mult == 0ULL) return std::nullopt;
+      return mult;
+    }
+  }
+
+  if (suffix == "RB" || suffix == "QB") {
+    return std::nullopt;
+  }
+
+  return std::nullopt;
+}
+
+auto parse_numeric_with_suffix(std::string_view text)
+    -> std::optional<std::uintmax_t> {
+  if (text.empty()) return std::nullopt;
+
+  size_t i = 0;
+  while (i < text.size() && std::isdigit(static_cast<unsigned char>(text[i]))) {
+    ++i;
+  }
+  if (i == 0) return std::nullopt;
+
+  std::uintmax_t base = 0;
+  auto [ptr, ec] = std::from_chars(text.data(), text.data() + i, base);
+  if (ec != std::errc() || ptr != text.data() + i) return std::nullopt;
+
+  auto mult = suffix_multiplier(text.substr(i));
+  if (!mult.has_value()) return std::nullopt;
+
+  if (*mult != 0 &&
+      base > (std::numeric_limits<std::uintmax_t>::max() / *mult)) {
+    return std::nullopt;
+  }
+
+  return base * *mult;
+}
+
+auto parse_count_spec(std::string spec_text, std::string_view opt_name)
+    -> cp::Result<CountSpec> {
+  if (spec_text.empty()) {
+    return std::unexpected("invalid number of " + std::string(opt_name));
+  }
+
+  CountSpec spec;
+  if (spec_text[0] == '+') {
+    spec.from_start = true;
+    spec_text.erase(0, 1);
+  }
+
+  auto parsed = parse_numeric_with_suffix(spec_text);
+  if (!parsed.has_value()) {
+    return std::unexpected("invalid number of " + std::string(opt_name));
+  }
+
+  spec.value = *parsed;
+  return spec;
+}
+
+auto split_records(const std::string& data, char delimiter)
+    -> std::vector<std::pair<size_t, size_t>> {
+  std::vector<std::pair<size_t, size_t>> records;
+  size_t start = 0;
+  for (size_t i = 0; i < data.size(); ++i) {
+    if (data[i] == delimiter) {
+      records.emplace_back(start, i + 1);
+      start = i + 1;
+    }
+  }
+  if (start < data.size()) {
+    records.emplace_back(start, data.size());
+  }
+  return records;
+}
+
+auto print_ranges(const std::string& data,
+                  const std::vector<std::pair<size_t, size_t>>& ranges,
+                  size_t first, size_t last) -> void {
+  for (size_t i = first; i < last; ++i) {
+    const auto [begin, end] = ranges[i];
+    safePrint(std::string_view(data.data() + begin, end - begin));
+  }
+}
+
+auto output_tail(const std::string& data, const TailConfig& config) -> void {
+  if (config.by_bytes) {
+    size_t n = static_cast<size_t>(config.spec.value);
+    if (config.spec.from_start) {
+      size_t offset = n > 0 ? n - 1 : 0;
+      if (offset >= data.size()) return;
+      safePrint(std::string_view(data.data() + offset, data.size() - offset));
+      return;
+    }
+
+    if (n >= data.size()) {
+      if (!data.empty()) safePrint(std::string_view(data.data(), data.size()));
+      return;
+    }
+
+    safePrint(std::string_view(data.data() + (data.size() - n), n));
+    return;
+  }
+
+  auto ranges = split_records(data, config.delimiter);
+  if (ranges.empty()) return;
+
+  size_t total = ranges.size();
+  size_t n = static_cast<size_t>(config.spec.value);
+
+  if (config.spec.from_start) {
+    size_t start = n > 0 ? n - 1 : 0;
+    if (start >= total) return;
+    print_ranges(data, ranges, start, total);
+    return;
+  }
+
+  if (n >= total) {
+    print_ranges(data, ranges, 0, total);
+    return;
+  }
+
+  print_ranges(data, ranges, total - n, total);
+}
+
+template <size_t N>
+auto check_unsupported(const CommandContext<N>& ctx) -> cp::Result<void> {
+  if (ctx.get<bool>("--follow", false) || ctx.get<bool>("-f", false)) {
+    return std::unexpected("--follow is [NOT SUPPORT] on this platform");
+  }
+  if (ctx.get<bool>("-F", false)) {
+    return std::unexpected("-F is [NOT SUPPORT] on this platform");
+  }
+  if (ctx.get<int>("--max-unchanged-stats", -1) >= 0) {
+    return std::unexpected("--max-unchanged-stats is [NOT SUPPORT]");
+  }
+  if (ctx.get<int>("--pid", -1) >= 0) {
+    return std::unexpected("--pid is [NOT SUPPORT]");
+  }
+  if (ctx.get<bool>("--retry", false)) {
+    return std::unexpected("--retry is [NOT SUPPORT]");
+  }
+  if (!ctx.get<std::string>("--sleep-interval", "").empty() ||
+      !ctx.get<std::string>("-s", "").empty()) {
+    return std::unexpected("--sleep-interval is [NOT SUPPORT]");
+  }
+  return {};
+}
+
+template <size_t N>
+auto build_config(const CommandContext<N>& ctx) -> cp::Result<TailConfig> {
+  TailConfig config;
+  config.quiet =
+      ctx.get<bool>("--quiet", false) || ctx.get<bool>("--silent", false);
+  config.verbose = ctx.get<bool>("--verbose", false);
+  config.delimiter = ctx.get<bool>("--zero-terminated", false) ? '\0' : '\n';
+
+  auto unsupported = check_unsupported(ctx);
+  if (!unsupported) return std::unexpected(unsupported.error());
+
+  const std::string bytes_arg = ctx.get<std::string>("--bytes", "");
+  const std::string bytes_short = ctx.get<std::string>("-c", "");
+  const std::string lines_arg = ctx.get<std::string>("--lines", "");
+  const std::string lines_short = ctx.get<std::string>("-n", "");
+
+  std::string bytes_spec = bytes_arg.empty() ? bytes_short : bytes_arg;
+  std::string lines_spec = lines_arg.empty() ? lines_short : lines_arg;
+
+  if (!bytes_spec.empty()) {
+    auto spec = parse_count_spec(bytes_spec, "bytes");
+    if (!spec) return std::unexpected(spec.error());
+    config.by_bytes = true;
+    config.spec = *spec;
+    return config;
+  }
+
+  if (!lines_spec.empty()) {
+    auto spec = parse_count_spec(lines_spec, "lines");
+    if (!spec) return std::unexpected(spec.error());
+    config.spec = *spec;
+  }
+
+  return config;
+}
+
+}  // namespace tail_pipeline
+
+REGISTER_COMMAND(
+    tail, "tail", "tail [OPTION]... [FILE]...",
+    "Print the last 10 lines of each FILE to standard output.\n"
+    "With more than one FILE, precede each with a header giving the file "
+    "name.\n"
+    "\n"
+    "With no FILE, or when FILE is -, read standard input.",
+    "  tail file.txt\n"
+    "  tail -n 20 file.txt\n"
+    "  tail -n +5 file.txt\n"
+    "  tail -c 64 file.txt\n"
+    "  tail -v a.txt b.txt",
+    "head(1), cat(1)", "WinuxCmd", "Copyright © 2026 WinuxCmd", TAIL_OPTIONS) {
+  using namespace tail_pipeline;
+
+  auto config_result = build_config(ctx);
+  if (!config_result) {
+    cp::report_error(config_result, L"tail");
+    return 1;
+  }
+  auto config = *config_result;
+
+  std::vector<std::string> files;
+  for (auto p : ctx.positionals) files.emplace_back(p);
+  if (files.empty()) files.emplace_back("-");
+
+  bool any_error = false;
+  bool first_print = true;
+  bool multi = files.size() > 1;
+
+  for (const auto& file : files) {
+    auto data_result = read_input(file);
+    if (!data_result) {
+      safeErrorPrint("tail: ");
+      safeErrorPrint(data_result.error());
+      safeErrorPrint("\n");
+      any_error = true;
+      continue;
+    }
+
+    bool show_header =
+        (config.verbose || (multi && !config.quiet)) && file != "-";
+    if (show_header) {
+      if (!first_print) safePrint("\n");
+      safePrint("==> ");
+      safePrint(file);
+      safePrint(" <==\n");
+    }
+
+    output_tail(*data_result, config);
+    first_print = false;
+  }
+
+  return any_error ? 1 : 0;
+}

--- a/src/commands/touch.cpp
+++ b/src/commands/touch.cpp
@@ -1,0 +1,239 @@
+/*
+ *  Copyright © 2026 [caomengxuan666]
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the “Software”), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ *  - File: touch.cpp
+ *  - Username: Administrator
+ *  - CopyrightYear: 2026
+ */
+
+#include "core/command_macros.h"
+#include "pch/pch.h"
+
+import std;
+import core;
+import utils;
+
+using cmd::meta::OptionMeta;
+using cmd::meta::OptionType;
+
+/**
+ * @brief TOUCH command options definition
+ *
+ * This array defines all the options supported by the touch command.
+ * Each option is described with its short form, long form, and description.
+ * The implementation status is also indicated for each option.
+ *
+ * @par Options:
+ *
+ * - @a -a: Change only the access time [IMPLEMENTED]
+ * - @a -c, @a --no-create: Do not create any files [IMPLEMENTED]
+ * - @a -d, @a --date: Parse STRING and use it instead of current time [NOT SUPPORT]
+ * - @a -f: (ignored) [IMPLEMENTED]
+ * - @a -h, @a --no-dereference: Affect symbolic link instead of referenced file [NOT SUPPORT]
+ * - @a -m: Change only the modification time [IMPLEMENTED]
+ * - @a -r, @a --reference: Use this file's times instead of current time [IMPLEMENTED]
+ * - @a -t: Use [[CC]YY]MMDDhhmm[.ss] instead of current time [NOT SUPPORT]
+ * - @a --time: Change the specified time (access/atime/use/modify/mtime) [IMPLEMENTED]
+ */
+auto constexpr TOUCH_OPTIONS = std::array{
+    OPTION("-a", "", "change only the access time"),
+    OPTION("-c", "--no-create", "do not create any files"),
+    OPTION("-d", "--date",
+           "parse STRING and use it instead of current time [NOT SUPPORT]",
+           STRING_TYPE),
+    OPTION("-f", "", "(ignored)"),
+    OPTION("-h", "--no-dereference",
+           "affect symbolic link instead of referenced file [NOT SUPPORT]"),
+    OPTION("-m", "", "change only the modification time"),
+    OPTION("-r", "--reference", "use this file's times instead of current time",
+           STRING_TYPE),
+    OPTION("-t", "",
+           "use [[CC]YY]MMDDhhmm[.ss] instead of current time [NOT SUPPORT]",
+           STRING_TYPE),
+    OPTION("", "--time",
+           "change the specified time (access/atime/use/modify/mtime)",
+           STRING_TYPE)};
+
+namespace touch_pipeline {
+namespace cp = core::pipeline;
+
+struct TimePair {
+  FILETIME atime{};
+  FILETIME mtime{};
+};
+
+auto read_times_from_file(const std::wstring& wpath)
+    -> std::optional<TimePair> {
+  HANDLE h =
+      CreateFileW(wpath.c_str(), FILE_READ_ATTRIBUTES,
+                  FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                  nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+  if (h == INVALID_HANDLE_VALUE) return std::nullopt;
+
+  FILETIME c{}, a{}, m{};
+  bool ok = GetFileTime(h, &c, &a, &m) != 0;
+  CloseHandle(h);
+  if (!ok) return std::nullopt;
+
+  return TimePair{a, m};
+}
+
+auto apply_touch_one(const std::string& path,
+                     const CommandContext<TOUCH_OPTIONS.size()>& ctx,
+                     bool update_access, bool update_modify, bool no_create,
+                     const std::optional<TimePair>& ref_times) -> bool {
+  std::wstring wpath = utf8_to_wstring(path);
+
+  DWORD create_mode = no_create ? OPEN_EXISTING : OPEN_ALWAYS;
+  HANDLE h =
+      CreateFileW(wpath.c_str(), FILE_READ_ATTRIBUTES | FILE_WRITE_ATTRIBUTES,
+                  FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+                  nullptr, create_mode, FILE_ATTRIBUTE_NORMAL, nullptr);
+
+  if (h == INVALID_HANDLE_VALUE) {
+    DWORD e = GetLastError();
+    if (no_create && (e == ERROR_FILE_NOT_FOUND || e == ERROR_PATH_NOT_FOUND)) {
+      return true;
+    }
+    safeErrorPrint("touch: cannot touch '");
+    safeErrorPrint(path);
+    safeErrorPrint("': No such file or directory\n");
+    return false;
+  }
+
+  FILETIME c{}, cur_a{}, cur_m{};
+  if (!GetFileTime(h, &c, &cur_a, &cur_m)) {
+    CloseHandle(h);
+    safeErrorPrint("touch: cannot touch '");
+    safeErrorPrint(path);
+    safeErrorPrint("'\n");
+    return false;
+  }
+
+  FILETIME set_a = cur_a;
+  FILETIME set_m = cur_m;
+
+  if (ref_times.has_value()) {
+    if (update_access) set_a = ref_times->atime;
+    if (update_modify) set_m = ref_times->mtime;
+  } else {
+    FILETIME now{};
+    GetSystemTimeAsFileTime(&now);
+    if (update_access) set_a = now;
+    if (update_modify) set_m = now;
+  }
+
+  FILETIME* pa = update_access ? &set_a : nullptr;
+  FILETIME* pm = update_modify ? &set_m : nullptr;
+
+  bool ok = SetFileTime(h, nullptr, pa, pm) != 0;
+  CloseHandle(h);
+
+  if (!ok) {
+    safeErrorPrint("touch: cannot touch '");
+    safeErrorPrint(path);
+    safeErrorPrint("'\n");
+    return false;
+  }
+
+  return true;
+}
+
+auto process_command(const CommandContext<TOUCH_OPTIONS.size()>& ctx)
+    -> cp::Result<bool> {
+  if (ctx.positionals.empty()) return std::unexpected("missing file operand");
+
+  bool flag_a = ctx.get<bool>("-a", false);
+  bool flag_m = ctx.get<bool>("-m", false);
+
+  std::string time_word = ctx.get<std::string>("--time", "");
+  if (!time_word.empty()) {
+    if (time_word == "access" || time_word == "atime" || time_word == "use") {
+      flag_a = true;
+      flag_m = false;
+    } else if (time_word == "modify" || time_word == "mtime") {
+      flag_a = false;
+      flag_m = true;
+    }
+  }
+
+  bool update_access = flag_a;
+  bool update_modify = flag_m;
+  if (!flag_a && !flag_m) {
+    update_access = true;
+    update_modify = true;
+  }
+
+  bool no_create =
+      ctx.get<bool>("--no-create", false) || ctx.get<bool>("-c", false);
+
+  // parsed but currently not implemented on Windows in this command
+  (void)ctx.get<std::string>("--date", "");
+  (void)ctx.get<std::string>("-t", "");
+  (void)ctx.get<bool>("--no-dereference", false);
+  (void)ctx.get<bool>("-h", false);
+  (void)ctx.get<bool>("-f", false);
+
+  std::optional<TimePair> ref_times = std::nullopt;
+  std::string ref_path = ctx.get<std::string>("--reference", "");
+  if (ref_path.empty()) ref_path = ctx.get<std::string>("-r", "");
+  if (!ref_path.empty()) {
+    ref_times = read_times_from_file(utf8_to_wstring(ref_path));
+    if (!ref_times.has_value()) {
+      safeErrorPrint("touch: failed to get attributes of '");
+      safeErrorPrint(ref_path);
+      safeErrorPrint("'\n");
+      return std::unexpected("reference file error");
+    }
+  }
+
+  bool all_ok = true;
+  for (auto p : ctx.positionals) {
+    if (!apply_touch_one(std::string(p), ctx, update_access, update_modify,
+                         no_create, ref_times)) {
+      all_ok = false;
+    }
+  }
+
+  return all_ok;
+}
+}  // namespace touch_pipeline
+
+REGISTER_COMMAND(touch, "touch", "touch [OPTION]... FILE...",
+                 "Update the access and modification times of each FILE to the "
+                 "current time.\n"
+                 "A FILE argument that does not exist is created empty, unless "
+                 "-c is supplied.",
+                 "  touch file.txt\n"
+                 "  touch -a file.txt\n"
+                 "  touch -m file.txt\n"
+                 "  touch -c missing.txt\n"
+                 "  touch -r ref.txt target.txt",
+                 "stat(1), date(1)", "WinuxCmd", "Copyright © 2026 WinuxCmd",
+                 TOUCH_OPTIONS) {
+  using namespace touch_pipeline;
+  auto result = process_command(ctx);
+  if (!result) {
+    cp::report_error(result, L"touch");
+    return 1;
+  }
+  return *result ? 0 : 1;
+}

--- a/src/commands/uniq.cpp
+++ b/src/commands/uniq.cpp
@@ -1,0 +1,293 @@
+/*
+*  Copyright © 2026 [caomengxuan666]
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the “Software”), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ *  - File: uniq.cpp
+ *  - Username: Administrator
+ *  - CopyrightYear: 2026
+ */
+
+/// @Author: WinuxCmd
+/// @contributors:
+///   - caomengxuan666 <2507560089@qq.com>
+/// @Description: Implemention for uniq.
+/// @Version: 0.1.0
+/// @License: MIT
+/// @Copyright: Copyright © 2026 WinuxCmd
+#include "core/command_macros.h"
+#include "pch/pch.h"
+
+import std;
+import core;
+import utils;
+
+using cmd::meta::OptionMeta;
+using cmd::meta::OptionType;
+
+/**
+ * @brief UNIQ command options definition
+ *
+ * This array defines all the options supported by the uniq command.
+ * Each option is described with its short form, long form, and description.
+ * The implementation status is also indicated for each option.
+ *
+ * @par Options:
+ *
+ * - @a -c, @a --count: Prefix lines by the number of occurrences [IMPLEMENTED]
+ * - @a -d, @a --repeated: Only print duplicate lines [IMPLEMENTED]
+ * - @a -D, @a --all-repeated: Print all duplicate lines [NOT SUPPORT]
+ * - @a -f, @a --skip-fields: Avoid comparing the first N fields [IMPLEMENTED]
+ * - @a -i, @a --ignore-case: Ignore differences in case [IMPLEMENTED]
+ * - @a -s, @a --skip-chars: Avoid comparing the first N characters [IMPLEMENTED]
+ * - @a -u, @a --unique: Only print unique lines [IMPLEMENTED]
+ * - @a -w, @a --check-chars: Compare no more than N characters [IMPLEMENTED]
+ * - @a -z, @a --zero-terminated: Line delimiter is NUL, not newline [IMPLEMENTED]
+ * - @a --group: Show all items, separating groups [NOT SUPPORT]
+ */
+auto constexpr UNIQ_OPTIONS = std::array{
+    OPTION("-c", "--count", "prefix lines by the number of occurrences"),
+    OPTION("-d", "--repeated", "only print duplicate lines"),
+    OPTION("-D", "--all-repeated", "print all duplicate lines [NOT SUPPORT]"),
+    OPTION("-f", "--skip-fields", "avoid comparing the first N fields", INT_TYPE),
+    OPTION("-i", "--ignore-case", "ignore differences in case"),
+    OPTION("-s", "--skip-chars", "avoid comparing the first N characters",
+           INT_TYPE),
+    OPTION("-u", "--unique", "only print unique lines"),
+    OPTION("-w", "--check-chars", "compare no more than N characters",
+           INT_TYPE),
+    OPTION("-z", "--zero-terminated", "line delimiter is NUL, not newline"),
+    OPTION("", "--group", "show all items, separating groups [NOT SUPPORT]")};
+
+namespace uniq_pipeline {
+namespace cp = core::pipeline;
+
+struct Config {
+  bool show_count = false;
+  bool repeated_only = false;
+  bool unique_only = false;
+  bool ignore_case = false;
+  int skip_fields = 0;
+  int skip_chars = 0;
+  int check_chars = -1;
+  char delimiter = '\n';
+  std::string input = "-";
+  std::string output = "-";
+};
+
+auto read_all(std::istream& in) -> std::string {
+  return std::string(std::istreambuf_iterator<char>(in),
+                     std::istreambuf_iterator<char>());
+}
+
+auto read_source(std::string_view path) -> cp::Result<std::string> {
+  if (path == "-") return read_all(std::cin);
+
+  std::ifstream in(std::string(path), std::ios::binary);
+  if (!in.is_open()) {
+    return std::unexpected("cannot open '" + std::string(path) + "'");
+  }
+  return read_all(in);
+}
+
+auto split_records(std::string_view content, char delimiter)
+    -> std::vector<std::string> {
+  std::vector<std::string> out;
+  size_t start = 0;
+  for (size_t i = 0; i < content.size(); ++i) {
+    if (content[i] == delimiter) {
+      out.emplace_back(content.substr(start, i - start));
+      start = i + 1;
+    }
+  }
+  if (start < content.size()) {
+    out.emplace_back(content.substr(start));
+  }
+  return out;
+}
+
+auto to_lower_ascii(std::string_view s) -> std::string {
+  std::string out;
+  out.reserve(s.size());
+  for (unsigned char c : s) {
+    out.push_back(static_cast<char>(std::tolower(c)));
+  }
+  return out;
+}
+
+auto skip_n_fields(std::string_view line, int n) -> std::string_view {
+  if (n <= 0) return line;
+
+  size_t i = 0;
+  int fields = 0;
+  while (i < line.size() && fields < n) {
+    while (i < line.size() &&
+           std::isspace(static_cast<unsigned char>(line[i])) != 0) {
+      ++i;
+    }
+    if (i >= line.size()) break;
+    while (i < line.size() &&
+           std::isspace(static_cast<unsigned char>(line[i])) == 0) {
+      ++i;
+    }
+    ++fields;
+  }
+  return line.substr(i);
+}
+
+auto comparison_key(std::string_view line, const Config& cfg) -> std::string {
+  auto key = skip_n_fields(line, cfg.skip_fields);
+  size_t start = std::min<size_t>(key.size(), static_cast<size_t>(cfg.skip_chars));
+  key = key.substr(start);
+  if (cfg.check_chars >= 0) {
+    key = key.substr(0, static_cast<size_t>(cfg.check_chars));
+  }
+  if (cfg.ignore_case) return to_lower_ascii(key);
+  return std::string(key);
+}
+
+auto is_unsupported_used(const CommandContext<UNIQ_OPTIONS.size()>& ctx)
+    -> std::optional<std::string_view> {
+  if (ctx.get<bool>("--all-repeated", false) || ctx.get<bool>("-D", false))
+    return "--all-repeated is [NOT SUPPORT]";
+  if (ctx.get<bool>("--group", false))
+    return "--group is [NOT SUPPORT]";
+  return std::nullopt;
+}
+
+auto build_config(const CommandContext<UNIQ_OPTIONS.size()>& ctx)
+    -> cp::Result<Config> {
+  Config cfg;
+
+  cfg.show_count = ctx.get<bool>("--count", false) || ctx.get<bool>("-c", false);
+  cfg.repeated_only =
+      ctx.get<bool>("--repeated", false) || ctx.get<bool>("-d", false);
+  cfg.unique_only = ctx.get<bool>("--unique", false) || ctx.get<bool>("-u", false);
+  cfg.ignore_case =
+      ctx.get<bool>("--ignore-case", false) || ctx.get<bool>("-i", false);
+
+  cfg.skip_fields = ctx.get<int>("--skip-fields", 0);
+  if (cfg.skip_fields == 0) cfg.skip_fields = ctx.get<int>("-f", 0);
+
+  cfg.skip_chars = ctx.get<int>("--skip-chars", 0);
+  if (cfg.skip_chars == 0) cfg.skip_chars = ctx.get<int>("-s", 0);
+
+  cfg.check_chars = ctx.get<int>("--check-chars", -1);
+  if (cfg.check_chars < 0) cfg.check_chars = ctx.get<int>("-w", -1);
+
+  cfg.delimiter =
+      (ctx.get<bool>("--zero-terminated", false) || ctx.get<bool>("-z", false))
+          ? '\0'
+          : '\n';
+
+  if (cfg.skip_fields < 0 || cfg.skip_chars < 0 || cfg.check_chars < -1) {
+    return std::unexpected("negative counts are not allowed");
+  }
+
+  if (ctx.positionals.size() > 2) {
+    return std::unexpected("extra operand '" + std::string(ctx.positionals[2]) +
+                           "'");
+  }
+  if (ctx.positionals.size() >= 1) cfg.input = std::string(ctx.positionals[0]);
+  if (ctx.positionals.size() == 2) cfg.output = std::string(ctx.positionals[1]);
+
+  return cfg;
+}
+
+auto should_emit(size_t count, const Config& cfg) -> bool {
+  if (!cfg.repeated_only && !cfg.unique_only) return true;
+  if (cfg.repeated_only && count > 1) return true;
+  if (cfg.unique_only && count == 1) return true;
+  return false;
+}
+
+auto emit_one(std::ostream& out, std::string_view line, size_t count,
+              const Config& cfg) -> void {
+  if (cfg.show_count) {
+    out << std::setw(7) << count << " ";
+  }
+  out << line;
+  out << cfg.delimiter;
+}
+
+auto run(const Config& cfg) -> int {
+  auto content = read_source(cfg.input);
+  if (!content) {
+    cp::report_error(content, L"uniq");
+    return 1;
+  }
+
+  auto records = split_records(*content, cfg.delimiter);
+  std::ostream* out = &std::cout;
+  std::ofstream file_out;
+  if (cfg.output != "-") {
+    file_out.open(cfg.output, std::ios::binary | std::ios::trunc);
+    if (!file_out.is_open()) {
+      cp::report_custom_error(L"uniq", L"cannot open output file");
+      return 1;
+    }
+    out = &file_out;
+  }
+
+  if (records.empty()) return 0;
+
+  size_t i = 0;
+  while (i < records.size()) {
+    size_t j = i + 1;
+    const auto key = comparison_key(records[i], cfg);
+    while (j < records.size() && comparison_key(records[j], cfg) == key) {
+      ++j;
+    }
+
+    const size_t count = j - i;
+    if (should_emit(count, cfg)) {
+      emit_one(*out, records[i], count, cfg);
+    }
+    i = j;
+  }
+
+  out->flush();
+  return 0;
+}
+
+}  // namespace uniq_pipeline
+
+REGISTER_COMMAND(uniq, "uniq", "uniq [OPTION]... [INPUT [OUTPUT]]",
+                 "Filter adjacent matching lines from INPUT (or standard input),\n"
+                 "writing to OUTPUT (or standard output).",
+                 "  uniq data.txt\n"
+                 "  sort a.txt | uniq -c\n"
+                 "  uniq -i -d words.txt",
+                 "sort(1), grep(1)", "WinuxCmd", "Copyright © 2026 WinuxCmd",
+                 UNIQ_OPTIONS) {
+  using namespace uniq_pipeline;
+
+  if (auto unsupported = is_unsupported_used(ctx); unsupported.has_value()) {
+    cp::report_custom_error(L"uniq", utf8_to_wstring(*unsupported));
+    return 2;
+  }
+
+  auto cfg = build_config(ctx);
+  if (!cfg) {
+    cp::report_error(cfg, L"uniq");
+    return 1;
+  }
+
+  return run(*cfg);
+}

--- a/src/commands/wc.cpp
+++ b/src/commands/wc.cpp
@@ -1,13 +1,29 @@
-/// @Author: TODO: fill in your name
-/// @contributors:
-///   - contributor1 <name> <email2@example.com>
-///   - contributor2 <name> <email2@example.com>
-///   - contributor3 <name> <email3@example.com>
-///   - description:
-/// @Description: TODO: Add command description
-/// @Version: 0.1.0
-/// @License: MIT
-/// @Copyright: Copyright © 2026 WinuxCmd
+/*
+ *  Copyright © 2026 [caomengxuan666]
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the “Software”), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ * IN THE SOFTWARE.
+ *
+ *  - File: wc.cpp
+ *  - Username: Administrator
+ *  - CopyrightYear: 2026
+ */
+
 #include "core/command_macros.h"
 #include "pch/pch.h"
 import std;
@@ -333,8 +349,11 @@ REGISTER_COMMAND(
     // OPTIMIZED: Use string literals instead of wstring
     safePrintLn("wc (WinuxCmd) 0.1.0");
     safePrintLn("Copyright © 2026 WinuxCmd");
-    safePrintLn("This is free software; see the source for copying conditions.");
-    safePrintLn("There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.");
+    safePrintLn(
+        "This is free software; see the source for copying conditions.");
+    safePrintLn(
+        "There is NO warranty; not even for MERCHANTABILITY or FITNESS FOR A "
+        "PARTICULAR PURPOSE.");
     return 0;
   }
 
@@ -396,37 +415,43 @@ REGISTER_COMMAND(
 
   // Print results
   auto print_result = [&](const CountResult& result) {
-    // OPTIMIZED: Use snprintf instead of to_wstring and avoid wstring concatenation
+    // OPTIMIZED: Use snprintf instead of to_wstring and avoid wstring
+    // concatenation
     char buf[256];
     int offset = 0;
-    
+
     if (print_lines) {
-      int len = snprintf(buf + offset, sizeof(buf) - offset, "%ju ", result.lines);
+      int len =
+          snprintf(buf + offset, sizeof(buf) - offset, "%ju ", result.lines);
       offset += len;
     }
     if (print_words) {
-      int len = snprintf(buf + offset, sizeof(buf) - offset, "%ju ", result.words);
+      int len =
+          snprintf(buf + offset, sizeof(buf) - offset, "%ju ", result.words);
       offset += len;
     }
     if (print_chars) {
-      int len = snprintf(buf + offset, sizeof(buf) - offset, "%ju ", result.chars);
+      int len =
+          snprintf(buf + offset, sizeof(buf) - offset, "%ju ", result.chars);
       offset += len;
     }
     if (print_bytes) {
-      int len = snprintf(buf + offset, sizeof(buf) - offset, "%ju ", result.bytes);
+      int len =
+          snprintf(buf + offset, sizeof(buf) - offset, "%ju ", result.bytes);
       offset += len;
     }
     if (print_max_line_length) {
-      int len = snprintf(buf + offset, sizeof(buf) - offset, "%ju ", result.max_line_length);
+      int len = snprintf(buf + offset, sizeof(buf) - offset, "%ju ",
+                         result.max_line_length);
       offset += len;
     }
-    
+
     // Remove trailing space
     if (offset > 0 && buf[offset - 1] == ' ') {
       buf[offset - 1] = '\0';
       offset--;
     }
-    
+
     if (!(result.filename == "-" && count_results.size() == 1)) {
       if (offset > 0) {
         buf[offset++] = ' ';
@@ -439,7 +464,7 @@ REGISTER_COMMAND(
       }
       buf[offset] = '\0';
     }
-    
+
     safePrintLn(std::string_view(buf, offset));
   };
 

--- a/src/commands/which.cpp
+++ b/src/commands/which.cpp
@@ -1,0 +1,186 @@
+/// @Author: WinuxCmd
+/// @contributors:
+///   - caomengxuan666 <2507560089@qq.com>
+/// @Description: Implemention for which.
+/// @Version: 0.1.0
+/// @License: MIT
+/// @Copyright: Copyright © 2026 WinuxCmd
+#include "core/command_macros.h"
+#include "pch/pch.h"
+
+import std;
+import core;
+import utils;
+
+using cmd::meta::OptionMeta;
+using cmd::meta::OptionType;
+
+auto constexpr WHICH_OPTIONS = std::array{
+    OPTION("-a", "--all", "print all matching pathnames of each argument"),
+    OPTION("-s", "--skip-dot", "skip directories in PATH that start with a dot [NOT SUPPORT]"),
+    OPTION("", "--skip-tilde", "skip directories in PATH that start with a tilde [NOT SUPPORT]"),
+    OPTION("", "--show-dot", "if a directory in PATH starts with a dot, print it [NOT SUPPORT]"),
+    OPTION("", "--show-tilde", "output a tilde for HOME directory [NOT SUPPORT]")};
+
+namespace which_pipeline {
+namespace cp = core::pipeline;
+namespace fs = std::filesystem;
+
+struct Config {
+  bool all = false;
+  std::vector<std::string> names;
+};
+
+auto split_semicolon(std::string_view text) -> std::vector<std::string> {
+  std::vector<std::string> out;
+  size_t start = 0;
+  while (start <= text.size()) {
+    size_t pos = text.find(';', start);
+    if (pos == std::string_view::npos) {
+      out.emplace_back(text.substr(start));
+      break;
+    }
+    out.emplace_back(text.substr(start, pos - start));
+    start = pos + 1;
+  }
+  return out;
+}
+
+auto get_path_entries() -> std::vector<std::string> {
+  const char* path_env = std::getenv("PATH");
+  if (path_env == nullptr) return {};
+  return split_semicolon(path_env);
+}
+
+auto get_pathext_entries() -> std::vector<std::string> {
+  const char* ext_env = std::getenv("PATHEXT");
+  if (ext_env == nullptr || *ext_env == '\0') {
+    return {".exe", ".cmd", ".bat", ".com"};
+  }
+  auto exts = split_semicolon(ext_env);
+  if (exts.empty()) exts = {".exe", ".cmd", ".bat", ".com"};
+  return exts;
+}
+
+auto has_path_separator(std::string_view s) -> bool {
+  return s.find('/') != std::string_view::npos ||
+         s.find('\\') != std::string_view::npos;
+}
+
+auto exists_regular(const fs::path& p) -> bool {
+  std::error_code ec;
+  return fs::exists(p, ec) && fs::is_regular_file(p, ec);
+}
+
+auto with_extensions(const fs::path& base,
+                     const std::vector<std::string>& exts)
+    -> std::vector<fs::path> {
+  std::vector<fs::path> out;
+  out.push_back(base);
+  if (base.has_extension()) return out;
+
+  for (const auto& ext : exts) {
+    fs::path p = base;
+    p += ext;
+    out.push_back(std::move(p));
+  }
+  return out;
+}
+
+auto find_one(std::string_view name, bool all) -> std::vector<std::string> {
+  std::vector<std::string> hits;
+  std::unordered_set<std::string> seen;
+  const auto pathext = get_pathext_entries();
+
+  auto append_hit = [&](const fs::path& p) {
+    auto display = p.generic_string();
+    if (seen.insert(display).second) {
+      hits.push_back(std::move(display));
+    }
+  };
+
+  if (has_path_separator(name)) {
+    fs::path base = std::string(name);
+    for (const auto& candidate : with_extensions(base, pathext)) {
+      if (exists_regular(candidate)) {
+        append_hit(candidate);
+        if (!all) return hits;
+      }
+    }
+    return hits;
+  }
+
+  for (const auto& dir : get_path_entries()) {
+    if (dir.empty()) continue;
+    fs::path base = fs::path(dir) / std::string(name);
+    for (const auto& candidate : with_extensions(base, pathext)) {
+      if (exists_regular(candidate)) {
+        append_hit(candidate);
+        if (!all) return hits;
+      }
+    }
+  }
+
+  return hits;
+}
+
+auto is_unsupported_used(const CommandContext<WHICH_OPTIONS.size()>& ctx)
+    -> std::optional<std::string_view> {
+  if (ctx.get<bool>("--skip-dot", false) || ctx.get<bool>("-s", false))
+    return "--skip-dot is [NOT SUPPORT]";
+  if (ctx.get<bool>("--skip-tilde", false))
+    return "--skip-tilde is [NOT SUPPORT]";
+  if (ctx.get<bool>("--show-dot", false))
+    return "--show-dot is [NOT SUPPORT]";
+  if (ctx.get<bool>("--show-tilde", false))
+    return "--show-tilde is [NOT SUPPORT]";
+  return std::nullopt;
+}
+
+auto build_config(const CommandContext<WHICH_OPTIONS.size()>& ctx)
+    -> cp::Result<Config> {
+  Config cfg;
+  cfg.all = ctx.get<bool>("--all", false) || ctx.get<bool>("-a", false);
+  for (auto arg : ctx.positionals) cfg.names.emplace_back(arg);
+  if (cfg.names.empty()) return std::unexpected("missing command operand");
+  return cfg;
+}
+
+auto run(const Config& cfg) -> int {
+  bool all_found = true;
+  for (const auto& name : cfg.names) {
+    auto hits = find_one(name, cfg.all);
+    if (hits.empty()) {
+      all_found = false;
+      continue;
+    }
+    for (const auto& h : hits) {
+      safePrint(h);
+      safePrint("\n");
+    }
+  }
+  return all_found ? 0 : 1;
+}
+
+}  // namespace which_pipeline
+
+REGISTER_COMMAND(which, "which", "which [OPTION]... COMMAND...",
+                 "Locate COMMAND in PATH.",
+                 "  which ls\n"
+                 "  which -a python",
+                 "where(1), command(1)", "WinuxCmd",
+                 "Copyright © 2026 WinuxCmd", WHICH_OPTIONS) {
+  using namespace which_pipeline;
+
+  if (auto unsupported = is_unsupported_used(ctx); unsupported.has_value()) {
+    cp::report_custom_error(L"which", utf8_to_wstring(*unsupported));
+    return 2;
+  }
+
+  auto cfg = build_config(ctx);
+  if (!cfg) {
+    cp::report_error(cfg, L"which");
+    return 1;
+  }
+  return run(*cfg);
+}

--- a/src/pch/pch.h
+++ b/src/pch/pch.h
@@ -43,9 +43,9 @@
 #include <handleapi.h>   // For GetStdHandle, INVALID_HANDLE_VALUE
 #include <io.h>          // For _get_osfhandle
 #include <lmcons.h>      // For UNLEN
+#include <sddl.h>        // For ConvertSidToStringSidW
 #include <shlwapi.h>     // For PathFileExistsW
 #include <sysinfoapi.h>  // For GetUserNameW
-#include <sddl.h>        // For ConvertSidToStringSidW
 
 #include <cctype>   // For isspace
 #include <cstdint>  // For uint64_t

--- a/src/pch/string_instances.cpp
+++ b/src/pch/string_instances.cpp
@@ -1,24 +1,61 @@
+/*
+ *  Copyright © 2026 [caomengxuan666]
+ *  
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the “Software”), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is furnished
+ *  to do so, subject to the following conditions:
+ *  
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *  
+ *  THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *  
+ *  - File: string_instances.cpp
+ *  - Username: Administrator
+ *  - CopyrightYear: 2026
+ */
 #include "pch/string_instances.h"
 
 template class std::basic_string<char>;
 
 template std::basic_string<char>::basic_string(const char*);
-template std::basic_string<char>& std::basic_string<char>::operator=(const char*);
+template std::basic_string<char>& std::basic_string<char>::operator=(
+    const char*);
 template std::basic_string<char>& std::basic_string<char>::assign(const char*);
 template std::basic_string<char>& std::basic_string<char>::append(const char*);
-template std::basic_string<char>& std::basic_string<char>::append(const char*, size_t);
+template std::basic_string<char>& std::basic_string<char>::append(const char*,
+                                                                  size_t);
 template std::basic_string<char>& std::basic_string<char>::append(size_t, char);
 
-template std::istream& std::getline<char>(std::istream&, std::basic_string<char>&);
-template std::istream& std::getline<char>(std::istream&, std::basic_string<char>&, char);
+template std::istream& std::getline<char>(std::istream&,
+                                          std::basic_string<char>&);
+template std::istream& std::getline<char>(std::istream&,
+                                          std::basic_string<char>&, char);
 
 template class std::basic_string<wchar_t>;
 template std::basic_string<wchar_t>::basic_string(const wchar_t*);
-template std::basic_string<wchar_t>& std::basic_string<wchar_t>::operator=(const wchar_t*);
-template std::basic_string<wchar_t>& std::basic_string<wchar_t>::assign(const wchar_t*);
-template std::basic_string<wchar_t>& std::basic_string<wchar_t>::append(const wchar_t*);
-template std::basic_string<wchar_t>& std::basic_string<wchar_t>::append(const wchar_t*, size_t);
-template std::basic_string<wchar_t>& std::basic_string<wchar_t>::append(size_t, wchar_t);
+template std::basic_string<wchar_t>& std::basic_string<wchar_t>::operator=(
+    const wchar_t*);
+template std::basic_string<wchar_t>& std::basic_string<wchar_t>::assign(
+    const wchar_t*);
+template std::basic_string<wchar_t>& std::basic_string<wchar_t>::append(
+    const wchar_t*);
+template std::basic_string<wchar_t>& std::basic_string<wchar_t>::append(
+    const wchar_t*, size_t);
+template std::basic_string<wchar_t>& std::basic_string<wchar_t>::append(
+    size_t, wchar_t);
 
-template std::wistream& std::getline<wchar_t>(std::wistream&, std::basic_string<wchar_t>&);
-template std::wistream& std::getline<wchar_t>(std::wistream&, std::basic_string<wchar_t>&, wchar_t);
+template std::wistream& std::getline<wchar_t>(std::wistream&,
+                                              std::basic_string<wchar_t>&);
+template std::wistream& std::getline<wchar_t>(std::wistream&,
+                                              std::basic_string<wchar_t>&,
+                                              wchar_t);

--- a/src/pch/string_instances.h
+++ b/src/pch/string_instances.h
@@ -1,27 +1,67 @@
+/*
+ *  Copyright © 2026 [caomengxuan666]
+ *  
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the “Software”), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is furnished
+ *  to do so, subject to the following conditions:
+ *  
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *  
+ *  THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *  
+ *  - File: string_instances.h
+ *  - Username: Administrator
+ *  - CopyrightYear: 2026
+ */
 // src/core/string_instances.h
 #pragma once
-#include <string>
 #include <istream>
+#include <string>
 
 extern template class std::basic_string<char>;
 
 extern template std::basic_string<char>::basic_string(const char*);
-extern template std::basic_string<char>& std::basic_string<char>::operator=(const char*);
-extern template std::basic_string<char>& std::basic_string<char>::assign(const char*);
-extern template std::basic_string<char>& std::basic_string<char>::append(const char*);
-extern template std::basic_string<char>& std::basic_string<char>::append(const char*, size_t);
-extern template std::basic_string<char>& std::basic_string<char>::append(size_t, char);
+extern template std::basic_string<char>& std::basic_string<char>::operator=(
+    const char*);
+extern template std::basic_string<char>& std::basic_string<char>::assign(
+    const char*);
+extern template std::basic_string<char>& std::basic_string<char>::append(
+    const char*);
+extern template std::basic_string<char>& std::basic_string<char>::append(
+    const char*, size_t);
+extern template std::basic_string<char>& std::basic_string<char>::append(size_t,
+                                                                         char);
 
-extern template std::istream& std::getline<char>(std::istream&, std::basic_string<char>&);
-extern template std::istream& std::getline<char>(std::istream&, std::basic_string<char>&, char);
+extern template std::istream& std::getline<char>(std::istream&,
+                                                 std::basic_string<char>&);
+extern template std::istream& std::getline<char>(std::istream&,
+                                                 std::basic_string<char>&,
+                                                 char);
 
 extern template class std::basic_string<wchar_t>;
 extern template std::basic_string<wchar_t>::basic_string(const wchar_t*);
-extern template std::basic_string<wchar_t>& std::basic_string<wchar_t>::operator=(const wchar_t*);
-extern template std::basic_string<wchar_t>& std::basic_string<wchar_t>::assign(const wchar_t*);
-extern template std::basic_string<wchar_t>& std::basic_string<wchar_t>::append(const wchar_t*);
-extern template std::basic_string<wchar_t>& std::basic_string<wchar_t>::append(const wchar_t*, size_t);
-extern template std::basic_string<wchar_t>& std::basic_string<wchar_t>::append(size_t, wchar_t);
+extern template std::basic_string<wchar_t>&
+std::basic_string<wchar_t>::operator=(const wchar_t*);
+extern template std::basic_string<wchar_t>& std::basic_string<wchar_t>::assign(
+    const wchar_t*);
+extern template std::basic_string<wchar_t>& std::basic_string<wchar_t>::append(
+    const wchar_t*);
+extern template std::basic_string<wchar_t>& std::basic_string<wchar_t>::append(
+    const wchar_t*, size_t);
+extern template std::basic_string<wchar_t>& std::basic_string<wchar_t>::append(
+    size_t, wchar_t);
 
-extern template std::wistream& std::getline<wchar_t>(std::wistream&, std::basic_string<wchar_t>&);
-extern template std::wistream& std::getline<wchar_t>(std::wistream&, std::basic_string<wchar_t>&, wchar_t);
+extern template std::wistream& std::getline<wchar_t>(
+    std::wistream&, std::basic_string<wchar_t>&);
+extern template std::wistream& std::getline<wchar_t>(
+    std::wistream&, std::basic_string<wchar_t>&, wchar_t);

--- a/src/utils/console.cppm
+++ b/src/utils/console.cppm
@@ -39,29 +39,30 @@ export constexpr auto COLOR_MEDIA =
     L"\033[01;35m";  ///< Media: .jpg, .mp4 (bold magenta)
 
 namespace {
-  HANDLE getStdOut() {
-    static HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
-    return hOut;
-  }
-
-  HANDLE getStdErr() {
-    static HANDLE hErr = GetStdHandle(STD_ERROR_HANDLE);
-    return hErr;
-  }
-
-  bool isConsoleHandle(HANDLE h) {
-    if (h == INVALID_HANDLE_VALUE) return false;
-    DWORD mode;
-    return GetConsoleMode(h, &mode) != 0;
-  }
+HANDLE getStdOut() {
+  static HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
+  return hOut;
 }
+
+HANDLE getStdErr() {
+  static HANDLE hErr = GetStdHandle(STD_ERROR_HANDLE);
+  return hErr;
+}
+
+bool isConsoleHandle(HANDLE h) {
+  if (h == INVALID_HANDLE_VALUE) return false;
+  DWORD mode;
+  return GetConsoleMode(h, &mode) != 0;
+}
+}  // namespace
 
 export bool writeConsole(const std::wstring_view& wstr) {
   HANDLE hOut = GetStdHandle(STD_OUTPUT_HANDLE);
   if (hOut == INVALID_HANDLE_VALUE) return false;
 
   DWORD written;
-  return WriteConsoleW(hOut, wstr.data(), static_cast<DWORD>(wstr.size()), &written, nullptr) != 0;
+  return WriteConsoleW(hOut, wstr.data(), static_cast<DWORD>(wstr.size()),
+                       &written, nullptr) != 0;
 }
 
 export bool writeErrorConsole(const std::wstring_view& wstr) {
@@ -69,17 +70,13 @@ export bool writeErrorConsole(const std::wstring_view& wstr) {
   if (hErr == INVALID_HANDLE_VALUE) return false;
 
   DWORD written;
-  return WriteConsoleW(hErr, wstr.data(), static_cast<DWORD>(wstr.size()), &written, nullptr) != 0;
+  return WriteConsoleW(hErr, wstr.data(), static_cast<DWORD>(wstr.size()),
+                       &written, nullptr) != 0;
 }
 
-export bool isOutputConsole() {
-  return isConsoleHandle(getStdOut());
-}
+export bool isOutputConsole() { return isConsoleHandle(getStdOut()); }
 
-export bool isErrorConsole() {
-  return isConsoleHandle(getStdErr());
-}
-
+export bool isErrorConsole() { return isConsoleHandle(getStdErr()); }
 
 /**
  * @brief Check if terminal supports color
@@ -165,65 +162,66 @@ export bool setupConsoleForUnicode() {
 // Low level write primitives - NO fprintf/wprintf
 // ============================================================================
 namespace detail {
-  bool writeConsoleW(HANDLE h, const wchar_t* data, size_t len) {
-    if (!data || len == 0) return true;
-    DWORD written;
-    return WriteConsoleW(h, data, static_cast<DWORD>(len), &written, nullptr) != 0;
-  }
-
-  bool writeFile(HANDLE h, const char* data, size_t len) {
-    if (!data || len == 0) return true;
-    DWORD written;
-    return WriteFile(h, data, static_cast<DWORD>(len), &written, nullptr) != 0;
-  }
+bool writeConsoleW(HANDLE h, const wchar_t* data, size_t len) {
+  if (!data || len == 0) return true;
+  DWORD written;
+  return WriteConsoleW(h, data, static_cast<DWORD>(len), &written, nullptr) !=
+         0;
 }
+
+bool writeFile(HANDLE h, const char* data, size_t len) {
+  if (!data || len == 0) return true;
+  DWORD written;
+  return WriteFile(h, data, static_cast<DWORD>(len), &written, nullptr) != 0;
+}
+}  // namespace detail
 
 // ============================================================================
 // Stack allocated conversion buffer (zero heap allocation)
 // ============================================================================
 namespace detail {
-    template<size_t StackSize = 256>
-    class wchar_buffer {
-        wchar_t stack_[StackSize];
-        wchar_t* data_;
-        size_t size_;
+template <size_t StackSize = 256>
+class wchar_buffer {
+  wchar_t stack_[StackSize];
+  wchar_t* data_;
+  size_t size_;
 
-    public:
-        explicit wchar_buffer(std::string_view sv) {
-            int len = MultiByteToWideChar(CP_UTF8, 0, sv.data(),
-                                         static_cast<int>(sv.size()), nullptr, 0);
-            if (len <= 0) {
-                data_ = nullptr;
-                size_ = 0;
-                return;
-            }
+ public:
+  explicit wchar_buffer(std::string_view sv) {
+    int len = MultiByteToWideChar(CP_UTF8, 0, sv.data(),
+                                  static_cast<int>(sv.size()), nullptr, 0);
+    if (len <= 0) {
+      data_ = nullptr;
+      size_ = 0;
+      return;
+    }
 
-            if (static_cast<size_t>(len) <= StackSize) {
-                data_ = stack_;
-            } else {
-                data_ = static_cast<wchar_t*>(HeapAlloc(GetProcessHeap(), 0,
-                                            len * sizeof(wchar_t)));
-            }
+    if (static_cast<size_t>(len) <= StackSize) {
+      data_ = stack_;
+    } else {
+      data_ = static_cast<wchar_t*>(
+          HeapAlloc(GetProcessHeap(), 0, len * sizeof(wchar_t)));
+    }
 
-            size_ = static_cast<size_t>(len);
-            MultiByteToWideChar(CP_UTF8, 0, sv.data(),
-                              static_cast<int>(sv.size()), data_, len);
-        }
+    size_ = static_cast<size_t>(len);
+    MultiByteToWideChar(CP_UTF8, 0, sv.data(), static_cast<int>(sv.size()),
+                        data_, len);
+  }
 
-        ~wchar_buffer() {
-            if (data_ && data_ != stack_) {
-                HeapFree(GetProcessHeap(), 0, data_);
-            }
-        }
+  ~wchar_buffer() {
+    if (data_ && data_ != stack_) {
+      HeapFree(GetProcessHeap(), 0, data_);
+    }
+  }
 
-        wchar_buffer(const wchar_buffer&) = delete;
-        wchar_buffer& operator=(const wchar_buffer&) = delete;
+  wchar_buffer(const wchar_buffer&) = delete;
+  wchar_buffer& operator=(const wchar_buffer&) = delete;
 
-        const wchar_t* data() const { return data_; }
-        size_t size() const { return size_; }
-        bool valid() const { return data_ != nullptr; }
-    };
-}
+  const wchar_t* data() const { return data_; }
+  size_t size() const { return size_; }
+  bool valid() const { return data_ != nullptr; }
+};
+}  // namespace detail
 
 // ============================================================================
 // Core output functions - ALL PATHS use WriteFile/WriteConsoleW, NO fprintf
@@ -233,247 +231,247 @@ namespace detail {
 // Wide string overloads (zero conversion)
 // ----------------------------------------------------------------------------
 export void safePrint(std::wstring_view wsv) {
-    HANDLE h = getStdOut();
-    if (isConsoleHandle(h)) {
-        detail::writeConsoleW(h, wsv.data(), wsv.size());
-    } else {
-        std::string utf8 = wstring_to_utf8(wsv);
-        detail::writeFile(h, utf8.data(), utf8.size());
-    }
+  HANDLE h = getStdOut();
+  if (isConsoleHandle(h)) {
+    detail::writeConsoleW(h, wsv.data(), wsv.size());
+  } else {
+    std::string utf8 = wstring_to_utf8(wsv);
+    detail::writeFile(h, utf8.data(), utf8.size());
+  }
 }
 
 export void safeErrorPrint(std::wstring_view wsv) {
-    HANDLE h = getStdErr();
-    if (isConsoleHandle(h)) {
-        detail::writeConsoleW(h, wsv.data(), wsv.size());
-    } else {
-        std::string utf8 = wstring_to_utf8(wsv);
-        detail::writeFile(h, utf8.data(), utf8.size());
-    }
+  HANDLE h = getStdErr();
+  if (isConsoleHandle(h)) {
+    detail::writeConsoleW(h, wsv.data(), wsv.size());
+  } else {
+    std::string utf8 = wstring_to_utf8(wsv);
+    detail::writeFile(h, utf8.data(), utf8.size());
+  }
 }
 
 export void safePrintLn(std::wstring_view wsv) {
-    safePrint(wsv);
-    safePrint(L"\n");
+  safePrint(wsv);
+  safePrint(L"\n");
 }
 
 export void safeErrorPrintLn(std::wstring_view wsv) {
-    safeErrorPrint(wsv);
-    safeErrorPrint(L"\n");
+  safeErrorPrint(wsv);
+  safeErrorPrint(L"\n");
 }
 
 // ----------------------------------------------------------------------------
 // UTF-8 string overloads (stack conversion)
 // ----------------------------------------------------------------------------
 export void safePrint(std::string_view sv) {
-    HANDLE h = getStdOut();
-    if (isConsoleHandle(h)) {
-        detail::wchar_buffer buf(sv);
-        if (buf.valid()) {
-            detail::writeConsoleW(h, buf.data(), buf.size());
-        }
-    } else {
-        detail::writeFile(h, sv.data(), sv.size());
+  HANDLE h = getStdOut();
+  if (isConsoleHandle(h)) {
+    detail::wchar_buffer buf(sv);
+    if (buf.valid()) {
+      detail::writeConsoleW(h, buf.data(), buf.size());
     }
+  } else {
+    detail::writeFile(h, sv.data(), sv.size());
+  }
 }
 
 export void safeErrorPrint(std::string_view sv) {
-    HANDLE h = getStdErr();
-    if (isConsoleHandle(h)) {
-        detail::wchar_buffer buf(sv);
-        if (buf.valid()) {
-            detail::writeConsoleW(h, buf.data(), buf.size());
-        }
-    } else {
-        detail::writeFile(h, sv.data(), sv.size());
+  HANDLE h = getStdErr();
+  if (isConsoleHandle(h)) {
+    detail::wchar_buffer buf(sv);
+    if (buf.valid()) {
+      detail::writeConsoleW(h, buf.data(), buf.size());
     }
+  } else {
+    detail::writeFile(h, sv.data(), sv.size());
+  }
 }
 
 export void safePrintLn(std::string_view sv) {
-    safePrint(sv);
-    safePrint("\n");
+  safePrint(sv);
+  safePrint("\n");
 }
 
 export void safeErrorPrintLn(std::string_view sv) {
-    safeErrorPrint(sv);
-    safeErrorPrint("\n");
+  safeErrorPrint(sv);
+  safeErrorPrint("\n");
 }
 
 // ----------------------------------------------------------------------------
 // C string overloads (zero copy)
 // ----------------------------------------------------------------------------
 export void safePrint(const char* str) {
-    if (str) safePrint(std::string_view(str));
+  if (str) safePrint(std::string_view(str));
 }
 
 export void safeErrorPrint(const char* str) {
-    if (str) safeErrorPrint(std::string_view(str));
+  if (str) safeErrorPrint(std::string_view(str));
 }
 
 export void safePrintLn(const char* str) {
-    if (str) safePrint(std::string_view(str));
-    else safePrint("\n");
+  if (str)
+    safePrint(std::string_view(str));
+  else
     safePrint("\n");
+  safePrint("\n");
 }
 
 export void safeErrorPrintLn(const char* str) {
-    if (str) safeErrorPrint(std::string_view(str));
-    else safeErrorPrint("\n");
+  if (str)
+    safeErrorPrint(std::string_view(str));
+  else
     safeErrorPrint("\n");
+  safeErrorPrint("\n");
 }
 
 export void safePrint(const wchar_t* wstr) {
-    if (!wstr) return;
-    safePrint(std::wstring_view(wstr));
+  if (!wstr) return;
+  safePrint(std::wstring_view(wstr));
 }
 
 export void safeErrorPrint(const wchar_t* wstr) {
-    if (!wstr) return;
-    safeErrorPrint(std::wstring_view(wstr));
+  if (!wstr) return;
+  safeErrorPrint(std::wstring_view(wstr));
 }
 
 export void safePrintLn(const wchar_t* wstr) {
-    safePrint(wstr);
-    safePrint(L"\n");
+  safePrint(wstr);
+  safePrint(L"\n");
 }
 
 export void safeErrorPrintLn(const wchar_t* wstr) {
-    safeErrorPrint(wstr);
-    safeErrorPrint(L"\n");
+  safeErrorPrint(wstr);
+  safeErrorPrint(L"\n");
 }
 // ----------------------------------------------------------------------------
 // Character overloads (single char)
 // ----------------------------------------------------------------------------
 export void safePrint(char c) {
-    HANDLE h = getStdOut();
-    if (isConsoleHandle(h)) {
-        wchar_t wc = static_cast<wchar_t>(c);
-        detail::writeConsoleW(h, &wc, 1);
-    } else {
-        detail::writeFile(h, &c, 1);
-    }
+  HANDLE h = getStdOut();
+  if (isConsoleHandle(h)) {
+    wchar_t wc = static_cast<wchar_t>(c);
+    detail::writeConsoleW(h, &wc, 1);
+  } else {
+    detail::writeFile(h, &c, 1);
+  }
 }
 
 export void safeErrorPrint(char c) {
-    HANDLE h = getStdErr();
-    if (isConsoleHandle(h)) {
-        wchar_t wc = static_cast<wchar_t>(c);
-        detail::writeConsoleW(h, &wc, 1);
-    } else {
-        detail::writeFile(h, &c, 1);
-    }
+  HANDLE h = getStdErr();
+  if (isConsoleHandle(h)) {
+    wchar_t wc = static_cast<wchar_t>(c);
+    detail::writeConsoleW(h, &wc, 1);
+  } else {
+    detail::writeFile(h, &c, 1);
+  }
 }
 
 export void safePrintLn(char c) {
-    safePrint(c);
-    safePrint("\n");
+  safePrint(c);
+  safePrint("\n");
 }
 
 export void safeErrorPrintLn(char c) {
-    safeErrorPrint(c);
-    safeErrorPrint("\n");
+  safeErrorPrint(c);
+  safeErrorPrint("\n");
 }
 
 // ----------------------------------------------------------------------------
 // Integer overloads (stack formatting)
 // ----------------------------------------------------------------------------
 export void safePrint(int n) {
-    char buf[32];
-    int len = snprintf(buf, sizeof(buf), "%d", n);
-    safePrint(std::string_view(buf, static_cast<size_t>(len)));
+  char buf[32];
+  int len = snprintf(buf, sizeof(buf), "%d", n);
+  safePrint(std::string_view(buf, static_cast<size_t>(len)));
 }
 
 export void safeErrorPrint(int n) {
-    char buf[32];
-    int len = snprintf(buf, sizeof(buf), "%d", n);
-    safeErrorPrint(std::string_view(buf, static_cast<size_t>(len)));
+  char buf[32];
+  int len = snprintf(buf, sizeof(buf), "%d", n);
+  safeErrorPrint(std::string_view(buf, static_cast<size_t>(len)));
 }
 
 export void safePrint(unsigned int n) {
-    char buf[32];
-    int len = snprintf(buf, sizeof(buf), "%u", n);
-    safePrint(std::string_view(buf, static_cast<size_t>(len)));
+  char buf[32];
+  int len = snprintf(buf, sizeof(buf), "%u", n);
+  safePrint(std::string_view(buf, static_cast<size_t>(len)));
 }
 
 export void safeErrorPrint(unsigned int n) {
-    char buf[32];
-    int len = snprintf(buf, sizeof(buf), "%u", n);
-    safeErrorPrint(std::string_view(buf, static_cast<size_t>(len)));
+  char buf[32];
+  int len = snprintf(buf, sizeof(buf), "%u", n);
+  safeErrorPrint(std::string_view(buf, static_cast<size_t>(len)));
 }
 
 export void safePrint(long n) {
-    char buf[32];
-    int len = snprintf(buf, sizeof(buf), "%ld", n);
-    safePrint(std::string_view(buf, static_cast<size_t>(len)));
+  char buf[32];
+  int len = snprintf(buf, sizeof(buf), "%ld", n);
+  safePrint(std::string_view(buf, static_cast<size_t>(len)));
 }
 
 export void safeErrorPrint(long n) {
-    char buf[32];
-    int len = snprintf(buf, sizeof(buf), "%ld", n);
-    safeErrorPrint(std::string_view(buf, static_cast<size_t>(len)));
+  char buf[32];
+  int len = snprintf(buf, sizeof(buf), "%ld", n);
+  safeErrorPrint(std::string_view(buf, static_cast<size_t>(len)));
 }
 
 export void safePrint(unsigned long n) {
-    char buf[32];
-    int len = snprintf(buf, sizeof(buf), "%lu", n);
-    safePrint(std::string_view(buf, static_cast<size_t>(len)));
+  char buf[32];
+  int len = snprintf(buf, sizeof(buf), "%lu", n);
+  safePrint(std::string_view(buf, static_cast<size_t>(len)));
 }
 
 export void safeErrorPrint(unsigned long n) {
-    char buf[32];
-    int len = snprintf(buf, sizeof(buf), "%lu", n);
-    safeErrorPrint(std::string_view(buf, static_cast<size_t>(len)));
+  char buf[32];
+  int len = snprintf(buf, sizeof(buf), "%lu", n);
+  safeErrorPrint(std::string_view(buf, static_cast<size_t>(len)));
 }
 
 export void safePrint(long long n) {
-    char buf[32];
-    int len = snprintf(buf, sizeof(buf), "%lld", n);
-    safePrint(std::string_view(buf, static_cast<size_t>(len)));
+  char buf[32];
+  int len = snprintf(buf, sizeof(buf), "%lld", n);
+  safePrint(std::string_view(buf, static_cast<size_t>(len)));
 }
 
 export void safeErrorPrint(long long n) {
-    char buf[32];
-    int len = snprintf(buf, sizeof(buf), "%lld", n);
-    safeErrorPrint(std::string_view(buf, static_cast<size_t>(len)));
+  char buf[32];
+  int len = snprintf(buf, sizeof(buf), "%lld", n);
+  safeErrorPrint(std::string_view(buf, static_cast<size_t>(len)));
 }
 
 export void safePrint(unsigned long long n) {
-    char buf[32];
-    int len = snprintf(buf, sizeof(buf), "%llu", n);
-    safePrint(std::string_view(buf, static_cast<size_t>(len)));
+  char buf[32];
+  int len = snprintf(buf, sizeof(buf), "%llu", n);
+  safePrint(std::string_view(buf, static_cast<size_t>(len)));
 }
 
 export void safeErrorPrint(unsigned long long n) {
-    char buf[32];
-    int len = snprintf(buf, sizeof(buf), "%llu", n);
-    safeErrorPrint(std::string_view(buf, static_cast<size_t>(len)));
+  char buf[32];
+  int len = snprintf(buf, sizeof(buf), "%llu", n);
+  safeErrorPrint(std::string_view(buf, static_cast<size_t>(len)));
 }
 
 // ----------------------------------------------------------------------------
 // Pointer overload
 // ----------------------------------------------------------------------------
 export void safePrint(const void* ptr) {
-    char buf[32];
-    int len = snprintf(buf, sizeof(buf), "%p", ptr);
-    safePrint(std::string_view(buf, static_cast<size_t>(len)));
+  char buf[32];
+  int len = snprintf(buf, sizeof(buf), "%p", ptr);
+  safePrint(std::string_view(buf, static_cast<size_t>(len)));
 }
 
 export void safeErrorPrint(const void* ptr) {
-    char buf[32];
-    int len = snprintf(buf, sizeof(buf), "%p", ptr);
-    safeErrorPrint(std::string_view(buf, static_cast<size_t>(len)));
+  char buf[32];
+  int len = snprintf(buf, sizeof(buf), "%p", ptr);
+  safeErrorPrint(std::string_view(buf, static_cast<size_t>(len)));
 }
 
 // ----------------------------------------------------------------------------
 // Boolean overload
 // ----------------------------------------------------------------------------
-export void safePrint(bool b) {
-    safePrint(b ? "true" : "false");
-}
+export void safePrint(bool b) { safePrint(b ? "true" : "false"); }
 
-export void safeErrorPrint(bool b) {
-    safeErrorPrint(b ? "true" : "false");
-}
+export void safeErrorPrint(bool b) { safeErrorPrint(b ? "true" : "false"); }
 
 /// @brief Calculate display width of a wide string in terminal columns.
 /// Handles Unicode fullwidth/halfwidth characters (e.g., Chinese = 2 cols).
@@ -481,7 +479,7 @@ export void safeErrorPrint(bool b) {
 /// @brief Calculate the terminal display width of a wide string.
 /// Fullwidth characters (e.g., Chinese, Japanese) count as 2 columns.
 /// Halfwidth characters (e.g., ASCII) count as 1 column.
-export size_t string_display_width(const std::wstring &s) {
+export size_t string_display_width(const std::wstring& s) {
   size_t width = 0;
   for (wchar_t c : s) {
     // Check for fullwidth Unicode ranges

--- a/src/utils/path.cppm
+++ b/src/utils/path.cppm
@@ -28,8 +28,8 @@ export module utils:path;
 import std;
 import :utf8;
 
-#include <windows.h>
 #include <shlwapi.h>
+#include <windows.h>
 #pragma comment(lib, "shlwapi.lib")
 
 namespace path {
@@ -73,8 +73,8 @@ export std::string get_parent_path(const std::string& path) {
   std::wstring wpath(path.begin(), path.end());
   wchar_t parent[MAX_PATH];
   if (PathRemoveFileSpecW(wpath.data())) {
-    int len = WideCharToMultiByte(CP_UTF8, 0, wpath.c_str(), -1, NULL, 0,
-                                   NULL, NULL);
+    int len =
+        WideCharToMultiByte(CP_UTF8, 0, wpath.c_str(), -1, NULL, 0, NULL, NULL);
     std::string result(len - 1, 0);
     WideCharToMultiByte(CP_UTF8, 0, wpath.c_str(), -1, &result[0], len, NULL,
                         NULL);
@@ -105,11 +105,10 @@ export std::string get_filename(const std::string& path) {
   std::wstring wpath(path.begin(), path.end());
   LPWSTR file_name = PathFindFileNameW(wpath.c_str());
   if (file_name) {
-    int len = WideCharToMultiByte(CP_UTF8, 0, file_name, -1, NULL, 0, NULL,
-                                   NULL);
+    int len =
+        WideCharToMultiByte(CP_UTF8, 0, file_name, -1, NULL, 0, NULL, NULL);
     std::string result(len - 1, 0);
-    WideCharToMultiByte(CP_UTF8, 0, file_name, -1, &result[0], len, NULL,
-                        NULL);
+    WideCharToMultiByte(CP_UTF8, 0, file_name, -1, &result[0], len, NULL, NULL);
     return result;
   }
   return "";
@@ -141,18 +140,18 @@ export std::string get_stem(const std::string& path) {
     if (dot) {
       *dot = L'\0';
     }
-    int len = WideCharToMultiByte(CP_UTF8, 0, file_name, -1, NULL, 0, NULL,
-                                   NULL);
+    int len =
+        WideCharToMultiByte(CP_UTF8, 0, file_name, -1, NULL, 0, NULL, NULL);
     std::string result(len - 1, 0);
-    WideCharToMultiByte(CP_UTF8, 0, file_name, -1, &result[0], len, NULL,
-                        NULL);
+    WideCharToMultiByte(CP_UTF8, 0, file_name, -1, &result[0], len, NULL, NULL);
     return result;
   }
   return "";
 }
 
 /**
- * @brief Get the file stem (without extension) from a path (wide string version)
+ * @brief Get the file stem (without extension) from a path (wide string
+ * version)
  * @param path Path to extract stem from
  * @return File stem
  */
@@ -429,8 +428,8 @@ export std::string current_path() {
   if (len == 0 || len > MAX_PATH) {
     return "";
   }
-  int utf8_len = WideCharToMultiByte(CP_UTF8, 0, buffer, -1, NULL, 0, NULL,
-                                      NULL);
+  int utf8_len =
+      WideCharToMultiByte(CP_UTF8, 0, buffer, -1, NULL, 0, NULL, NULL);
   std::string result(utf8_len - 1, 0);
   WideCharToMultiByte(CP_UTF8, 0, buffer, -1, &result[0], utf8_len, NULL, NULL);
   return result;
@@ -458,12 +457,11 @@ export std::string get_executable_path(const char* argv0) {
   int path_length = MultiByteToWideChar(CP_UTF8, 0, argv0, -1, NULL, 0);
   std::wstring wself_path(path_length, 0);
   MultiByteToWideChar(CP_UTF8, 0, argv0, -1, &wself_path[0], path_length);
-  int utf8_len =
-      WideCharToMultiByte(CP_UTF8, 0, wself_path.c_str(), -1, NULL, 0, NULL,
-                          NULL);
+  int utf8_len = WideCharToMultiByte(CP_UTF8, 0, wself_path.c_str(), -1, NULL,
+                                     0, NULL, NULL);
   std::string result(utf8_len - 1, 0);
-  WideCharToMultiByte(CP_UTF8, 0, wself_path.c_str(), -1, &result[0],
-                      utf8_len, NULL, NULL);
+  WideCharToMultiByte(CP_UTF8, 0, wself_path.c_str(), -1, &result[0], utf8_len,
+                      NULL, NULL);
   return result;
 }
 

--- a/src/utils/wildcard.cppm
+++ b/src/utils/wildcard.cppm
@@ -91,8 +91,8 @@ export std::vector<std::string> expand_wildcard(
     }
 
     // Convert filename to UTF-8
-    int filename_len = WideCharToMultiByte(CP_UTF8, 0, find_data.cFileName,
-                                          -1, NULL, 0, NULL, NULL);
+    int filename_len = WideCharToMultiByte(CP_UTF8, 0, find_data.cFileName, -1,
+                                           NULL, 0, NULL, NULL);
     if (filename_len <= 0) {
       continue;
     }

--- a/tests/unit/cut/cut_unit_test.cpp
+++ b/tests/unit/cut/cut_unit_test.cpp
@@ -1,0 +1,66 @@
+#include "framework/winuxtest.h"
+
+TEST(cut, cut_basic_fields_default_tab) {
+  TempDir tmp;
+  tmp.write("a.txt", "a\tb\tc\n1\t2\t3\n");
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"cut.exe", {L"-f", L"1,3", L"a.txt"});
+  auto r = p.run();
+
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_EQ_TEXT(r.stdout_text, "a\tc\n1\t3\n");
+}
+
+TEST(cut, cut_with_delimiter_and_range) {
+  TempDir tmp;
+  tmp.write("a.txt", "x,y,z\nm,n,o\n");
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"cut.exe", {L"-d", L",", L"-f", L"2-3", L"a.txt"});
+  auto r = p.run();
+
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_EQ_TEXT(r.stdout_text, "y,z\nn,o\n");
+}
+
+TEST(cut, cut_only_delimited_skips) {
+  TempDir tmp;
+  tmp.write("a.txt", "no_delim\nhas:delim\n");
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"cut.exe", {L"-d", L":", L"-f", L"2", L"-s", L"a.txt"});
+  auto r = p.run();
+
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_EQ_TEXT(r.stdout_text, "delim\n");
+}
+
+TEST(cut, cut_zero_terminated) {
+  TempDir tmp;
+  std::string data = std::string("a:b\0c:d", 7);
+  tmp.write_bytes("a.txt", std::vector<char>(data.begin(), data.end()));
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"cut.exe", {L"-z", L"-d", L":", L"-f", L"2", L"a.txt"});
+  auto r = p.run();
+
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_EQ(r.stdout_text, std::string("b\0d\0", 4));
+}
+
+TEST(cut, cut_unsupported_bytes) {
+  TempDir tmp;
+  tmp.write("a.txt", "abc\n");
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"cut.exe", {L"-b", L"1", L"a.txt"});
+  auto r = p.run();
+
+  EXPECT_EQ(r.exit_code, 2);
+}

--- a/tests/unit/env/env_unit_test.cpp
+++ b/tests/unit/env/env_unit_test.cpp
@@ -1,0 +1,42 @@
+#include "framework/winuxtest.h"
+
+TEST(env, env_lists_current) {
+  Pipeline p;
+  p.set_env(L"FOO", L"BAR");
+  p.add(L"env.exe", {});
+  auto r = p.run();
+
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_TRUE(r.stdout_text.find("FOO=BAR") != std::string::npos);
+}
+
+TEST(env, env_ignore_environment_and_set) {
+  Pipeline p;
+  p.set_env(L"SHOULD_NOT", L"SEE");
+  p.add(L"env.exe", {L"-i", L"X=1"});
+  auto r = p.run();
+
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_TRUE(r.stdout_text.find("X=1") != std::string::npos);
+  EXPECT_TRUE(r.stdout_text.find("SHOULD_NOT") == std::string::npos);
+}
+
+TEST(env, env_unset_variable) {
+  Pipeline p;
+  p.set_env(L"KEEP", L"1");
+  p.set_env(L"DROP", L"1");
+  p.add(L"env.exe", {L"-u", L"DROP", L"KEEP=2"});
+  auto r = p.run();
+
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_TRUE(r.stdout_text.find("DROP=") == std::string::npos);
+  EXPECT_TRUE(r.stdout_text.find("KEEP=2") != std::string::npos);
+}
+
+TEST(env, env_command_not_supported) {
+  Pipeline p;
+  p.add(L"env.exe", {L"FOO=1", L"cmd"});
+  auto r = p.run();
+
+  EXPECT_EQ(r.exit_code, 2);
+}

--- a/tests/unit/find/find_unit_test.cpp
+++ b/tests/unit/find/find_unit_test.cpp
@@ -1,0 +1,97 @@
+/*
+ *  Copyright © 2026 [caomengxuan666]
+ *  
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the “Software”), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is furnished
+ *  to do so, subject to the following conditions:
+ *  
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *  
+ *  THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *  
+ *  - File: find_unit_test.cpp
+ *  - Username: Administrator
+ *  - CopyrightYear: 2026
+ */
+#include "framework/winuxtest.h"
+
+TEST(find, find_name_pattern) {
+  TempDir tmp;
+  std::filesystem::create_directories(tmp.path / "src");
+  tmp.write("src/a.cpp", "");
+  tmp.write("src/b.txt", "");
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"find.exe", {L"src", L"-name", L"*.cpp"});
+
+  auto r = p.run();
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_TRUE(r.stdout_text.find("src/a.cpp") != std::string::npos);
+  EXPECT_TRUE(r.stdout_text.find("src/b.txt") == std::string::npos);
+}
+
+TEST(find, find_iname_and_type) {
+  TempDir tmp;
+  std::filesystem::create_directories(tmp.path / "Dir");
+  tmp.write("Dir/ReadMe.MD", "");
+  tmp.write("Dir/file.txt", "");
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"find.exe", {L"Dir", L"-type", L"f", L"-iname", L"readme.*"});
+
+  auto r = p.run();
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_TRUE(r.stdout_text.find("Dir/ReadMe.MD") != std::string::npos);
+  EXPECT_TRUE(r.stdout_text.find("file.txt") == std::string::npos);
+}
+
+TEST(find, find_maxdepth) {
+  TempDir tmp;
+  std::filesystem::create_directories(tmp.path / "a" / "b");
+  tmp.write("a/top.txt", "");
+  tmp.write("a/b/deep.txt", "");
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"find.exe", {L"a", L"-maxdepth", L"1", L"-name", L"*.txt"});
+
+  auto r = p.run();
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_TRUE(r.stdout_text.find("a/top.txt") != std::string::npos);
+  EXPECT_TRUE(r.stdout_text.find("a/b/deep.txt") == std::string::npos);
+}
+
+TEST(find, find_missing_path_returns_error) {
+  TempDir tmp;
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"find.exe", {L"not_exists", L"-name", L"*.txt"});
+
+  auto r = p.run();
+  EXPECT_EQ(r.exit_code, 1);
+}
+
+TEST(find, find_unsupported_delete) {
+  TempDir tmp;
+  tmp.write("a.txt", "x");
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"find.exe", {L".", L"-delete"});
+
+  auto r = p.run();
+  EXPECT_EQ(r.exit_code, 1);
+}

--- a/tests/unit/grep/grep_unit_test.cpp
+++ b/tests/unit/grep/grep_unit_test.cpp
@@ -1,0 +1,117 @@
+/*
+ *  Copyright © 2026 [caomengxuan666]
+ *  
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the “Software”), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is furnished
+ *  to do so, subject to the following conditions:
+ *  
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *  
+ *  THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *  
+ *  - File: grep_unit_test.cpp
+ *  - Username: Administrator
+ *  - CopyrightYear: 2026
+ */
+#include "framework/winuxtest.h"
+
+TEST(grep, grep_basic_match) {
+  TempDir tmp;
+  tmp.write("a.txt", "alpha\nbeta\nalpha beta\n");
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"grep.exe", {L"alpha", L"a.txt"});
+
+  auto r = p.run();
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_EQ_TEXT(r.stdout_text, "alpha\nalpha beta\n");
+}
+
+TEST(grep, grep_ignore_case_and_line_number) {
+  TempDir tmp;
+  tmp.write("a.txt", "One\nTWO\nthree\nTwo again\n");
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"grep.exe", {L"-i", L"-n", L"two", L"a.txt"});
+
+  auto r = p.run();
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_EQ_TEXT(r.stdout_text, "2:TWO\n4:Two again\n");
+}
+
+TEST(grep, grep_count_and_files_with_matches) {
+  TempDir tmp;
+  tmp.write("a.txt", "x\ny\nx\n");
+  tmp.write("b.txt", "z\n");
+
+  Pipeline p1;
+  p1.set_cwd(tmp.wpath());
+  p1.add(L"grep.exe", {L"-c", L"x", L"a.txt", L"b.txt"});
+  auto r1 = p1.run();
+
+  EXPECT_EQ(r1.exit_code, 0);
+  EXPECT_TRUE(r1.stdout_text.find("a.txt:2") != std::string::npos);
+  EXPECT_TRUE(r1.stdout_text.find("b.txt:0") != std::string::npos);
+
+  Pipeline p2;
+  p2.set_cwd(tmp.wpath());
+  p2.add(L"grep.exe", {L"-l", L"x", L"a.txt", L"b.txt"});
+  auto r2 = p2.run();
+
+  EXPECT_EQ(r2.exit_code, 0);
+  EXPECT_EQ_TEXT(r2.stdout_text, "a.txt\n");
+}
+
+TEST(grep, grep_recursive_search) {
+  TempDir tmp;
+  std::filesystem::create_directories(tmp.path / "d1" / "d2");
+  tmp.write("d1/a.txt", "needle\n");
+  tmp.write("d1/d2/b.txt", "none\nneedle\n");
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"grep.exe", {L"-r", L"needle", L"d1"});
+
+  auto r = p.run();
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_TRUE(r.stdout_text.find("needle") != std::string::npos);
+  EXPECT_TRUE(r.stdout_text.find("a.txt") != std::string::npos);
+  EXPECT_TRUE(r.stdout_text.find("b.txt") != std::string::npos);
+}
+
+TEST(grep, grep_only_matching) {
+  TempDir tmp;
+  tmp.write("a.txt", "abc123def123\n");
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"grep.exe", {L"-o", L"123", L"a.txt"});
+
+  auto r = p.run();
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_EQ_TEXT(r.stdout_text, "123\n123\n");
+}
+
+TEST(grep, grep_unsupported_perl_regexp) {
+  TempDir tmp;
+  tmp.write("a.txt", "x\n");
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"grep.exe", {L"-P", L"x", L"a.txt"});
+
+  auto r = p.run();
+  EXPECT_EQ(r.exit_code, 2);
+}

--- a/tests/unit/head/head_unit_test.cpp
+++ b/tests/unit/head/head_unit_test.cpp
@@ -1,0 +1,77 @@
+/*
+ *  Copyright © 2026 [caomengxuan666]
+ *  
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the “Software”), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is furnished
+ *  to do so, subject to the following conditions:
+ *  
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *  
+ *  THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *  
+ *  - File: head_unit_test.cpp
+ *  - Username: Administrator
+ *  - CopyrightYear: 2026
+ */
+#include "framework/winuxtest.h"
+
+TEST(head, head_default_first_10_lines) {
+  TempDir tmp;
+  tmp.write("a.txt", "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n");
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"head.exe", {L"a.txt"});
+  auto r = p.run();
+
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_EQ_TEXT(r.stdout_text, "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n");
+}
+
+TEST(head, head_n_and_c_options) {
+  TempDir tmp;
+  tmp.write("a.txt", "alpha\nbeta\ngamma\n");
+
+  Pipeline p1;
+  p1.set_cwd(tmp.wpath());
+  p1.add(L"head.exe", {L"-n", L"2", L"a.txt"});
+  auto r1 = p1.run();
+
+  EXPECT_EQ(r1.exit_code, 0);
+  EXPECT_EQ_TEXT(r1.stdout_text, "alpha\nbeta\n");
+
+  Pipeline p2;
+  p2.set_cwd(tmp.wpath());
+  p2.add(L"head.exe", {L"-c", L"5", L"a.txt"});
+  auto r2 = p2.run();
+
+  EXPECT_EQ(r2.exit_code, 0);
+  EXPECT_EQ_TEXT(r2.stdout_text, "alpha");
+}
+
+TEST(head, head_verbose_header_multi_files) {
+  TempDir tmp;
+  tmp.write("a.txt", "A1\nA2\n");
+  tmp.write("b.txt", "B1\nB2\n");
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"head.exe", {L"-n", L"1", L"-v", L"a.txt", L"b.txt"});
+  auto r = p.run();
+
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_TRUE(r.stdout_text.find("==> a.txt <==") != std::string::npos);
+  EXPECT_TRUE(r.stdout_text.find("==> b.txt <==") != std::string::npos);
+  EXPECT_TRUE(r.stdout_text.find("A1\n") != std::string::npos);
+  EXPECT_TRUE(r.stdout_text.find("B1\n") != std::string::npos);
+}

--- a/tests/unit/rmdir/rmdir_unit_test.cpp
+++ b/tests/unit/rmdir/rmdir_unit_test.cpp
@@ -1,0 +1,80 @@
+/*
+ *  Copyright © 2026 [caomengxuan666]
+ *  
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the “Software”), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is furnished
+ *  to do so, subject to the following conditions:
+ *  
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *  
+ *  THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *  
+ *  - File: rmdir_unit_test.cpp
+ *  - Username: Administrator
+ *  - CopyrightYear: 2026
+ */
+#include "framework/winuxtest.h"
+
+TEST(rmdir, rmdir_basic_empty_directory) {
+  TempDir tmp;
+  std::filesystem::create_directory(tmp.path / "empty");
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"rmdir.exe", {L"empty"});
+
+  auto r = p.run();
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_TRUE(!std::filesystem::exists(tmp.path / "empty"));
+}
+
+TEST(rmdir, rmdir_non_empty_fails) {
+  TempDir tmp;
+  std::filesystem::create_directory(tmp.path / "dir");
+  tmp.write("dir/file.txt", "content");
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"rmdir.exe", {L"dir"});
+
+  auto r = p.run();
+  EXPECT_EQ(r.exit_code, 1);
+  EXPECT_TRUE(std::filesystem::exists(tmp.path / "dir"));
+}
+
+TEST(rmdir, rmdir_ignore_non_empty) {
+  TempDir tmp;
+  std::filesystem::create_directory(tmp.path / "dir");
+  tmp.write("dir/file.txt", "content");
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"rmdir.exe", {L"--ignore-fail-on-non-empty", L"dir"});
+
+  auto r = p.run();
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_TRUE(std::filesystem::exists(tmp.path / "dir"));
+}
+
+TEST(rmdir, rmdir_parents_option) {
+  TempDir tmp;
+  std::filesystem::create_directories(tmp.path / "a" / "b" / "c");
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"rmdir.exe", {L"-p", L"a/b/c"});
+
+  auto r = p.run();
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_TRUE(!std::filesystem::exists(tmp.path / "a"));
+}

--- a/tests/unit/sort/sort_unit_test.cpp
+++ b/tests/unit/sort/sort_unit_test.cpp
@@ -1,0 +1,91 @@
+/*
+ *  Copyright © 2026 [caomengxuan666]
+ *  
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the “Software”), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is furnished
+ *  to do so, subject to the following conditions:
+ *  
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *  
+ *  THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *  
+ *  - File: sort_unit_test.cpp
+ *  - Username: Administrator
+ *  - CopyrightYear: 2026
+ */
+#include "framework/winuxtest.h"
+
+TEST(sort, sort_basic_lexicographic) {
+  TempDir tmp;
+  tmp.write("a.txt", "pear\napple\nbanana\n");
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"sort.exe", {L"a.txt"});
+  auto r = p.run();
+
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_EQ_TEXT(r.stdout_text, "apple\nbanana\npear\n");
+}
+
+TEST(sort, sort_numeric_reverse_unique) {
+  TempDir tmp;
+  tmp.write("n.txt", "2\n10\n2\n1\n");
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"sort.exe", {L"-n", L"-r", L"-u", L"n.txt"});
+  auto r = p.run();
+
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_EQ_TEXT(r.stdout_text, "10\n2\n1\n");
+}
+
+TEST(sort, sort_ignore_case_and_key) {
+  TempDir tmp;
+  tmp.write("k.txt", "b 2\nA 3\na 1\n");
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"sort.exe", {L"-f", L"-k", L"1", L"k.txt"});
+  auto r = p.run();
+
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_EQ_TEXT(r.stdout_text, "A 3\na 1\nb 2\n");
+}
+
+TEST(sort, sort_output_file_option) {
+  TempDir tmp;
+  tmp.write("in.txt", "z\nx\ny\n");
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"sort.exe", {L"-o", L"out.txt", L"in.txt"});
+  auto r = p.run();
+
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_EQ_TEXT(r.stdout_text, "");
+  EXPECT_EQ_TEXT(tmp.read("out.txt"), "x\ny\nz\n");
+}
+
+TEST(sort, sort_unsupported_merge) {
+  TempDir tmp;
+  tmp.write("a.txt", "x\n");
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"sort.exe", {L"-m", L"a.txt"});
+  auto r = p.run();
+
+  EXPECT_EQ(r.exit_code, 2);
+}

--- a/tests/unit/tail/tail_unit_test.cpp
+++ b/tests/unit/tail/tail_unit_test.cpp
@@ -1,0 +1,72 @@
+/*
+ *  Copyright © 2026 [caomengxuan666]
+ *  
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the “Software”), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is furnished
+ *  to do so, subject to the following conditions:
+ *  
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *  
+ *  THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *  
+ *  - File: tail_unit_test.cpp
+ *  - Username: Administrator
+ *  - CopyrightYear: 2026
+ */
+#include "framework/winuxtest.h"
+
+TEST(tail, tail_default_last_10_lines) {
+  TempDir tmp;
+  tmp.write("a.txt", "1\n2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n");
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"tail.exe", {L"a.txt"});
+  auto r = p.run();
+
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_EQ_TEXT(r.stdout_text, "2\n3\n4\n5\n6\n7\n8\n9\n10\n11\n");
+}
+
+TEST(tail, tail_plus_lines_and_bytes) {
+  TempDir tmp;
+  tmp.write("a.txt", "alpha\nbeta\ngamma\n");
+
+  Pipeline p1;
+  p1.set_cwd(tmp.wpath());
+  p1.add(L"tail.exe", {L"-n", L"+2", L"a.txt"});
+  auto r1 = p1.run();
+
+  EXPECT_EQ(r1.exit_code, 0);
+  EXPECT_EQ_TEXT(r1.stdout_text, "beta\ngamma\n");
+
+  Pipeline p2;
+  p2.set_cwd(tmp.wpath());
+  p2.add(L"tail.exe", {L"-c", L"+3", L"a.txt"});
+  auto r2 = p2.run();
+
+  EXPECT_EQ(r2.exit_code, 0);
+  EXPECT_EQ_TEXT(r2.stdout_text, "pha\nbeta\ngamma\n");
+}
+
+TEST(tail, tail_not_supported_follow) {
+  TempDir tmp;
+  tmp.write("a.txt", "abc\n");
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"tail.exe", {L"-f", L"a.txt"});
+  auto r = p.run();
+
+  EXPECT_EQ(r.exit_code, 1);
+}

--- a/tests/unit/touch/touch_unit_test.cpp
+++ b/tests/unit/touch/touch_unit_test.cpp
@@ -1,0 +1,69 @@
+/*
+ *  Copyright © 2026 [caomengxuan666]
+ *  
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the “Software”), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is furnished
+ *  to do so, subject to the following conditions:
+ *  
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *  
+ *  THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *  
+ *  - File: touch_unit_test.cpp
+ *  - Username: Administrator
+ *  - CopyrightYear: 2026
+ */
+#include "framework/winuxtest.h"
+
+TEST(touch, touch_creates_file) {
+  TempDir tmp;
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"touch.exe", {L"new.txt"});
+
+  auto r = p.run();
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_TRUE(std::filesystem::exists(tmp.path / "new.txt"));
+}
+
+TEST(touch, touch_no_create_option) {
+  TempDir tmp;
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"touch.exe", {L"-c", L"missing.txt"});
+
+  auto r = p.run();
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_TRUE(!std::filesystem::exists(tmp.path / "missing.txt"));
+}
+
+TEST(touch, touch_reference_updates_target_time) {
+  TempDir tmp;
+  tmp.write("ref.txt", "ref");
+  tmp.write("target.txt", "target");
+
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"touch.exe", {L"-r", L"ref.txt", L"target.txt"});
+
+  auto r = p.run();
+  EXPECT_EQ(r.exit_code, 0);
+
+  auto ref_time = std::filesystem::last_write_time(tmp.path / "ref.txt");
+  auto target_time = std::filesystem::last_write_time(tmp.path / "target.txt");
+  EXPECT_EQ(ref_time, target_time);
+}

--- a/tests/unit/uniq/uniq_unit_test.cpp
+++ b/tests/unit/uniq/uniq_unit_test.cpp
@@ -1,0 +1,97 @@
+/*
+ *  Copyright © 2026 [caomengxuan666]
+ *  
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the “Software”), to deal
+ *  in the Software without restriction, including without limitation the rights
+ *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ *  copies of the Software, and to permit persons to whom the Software is furnished
+ *  to do so, subject to the following conditions:
+ *  
+ *  The above copyright notice and this permission notice shall be included in all
+ *  copies or substantial portions of the Software.
+ *  
+ *  THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ *  SOFTWARE.
+ *  
+ *  - File: uniq_unit_test.cpp
+ *  - Username: Administrator
+ *  - CopyrightYear: 2026
+ */
+#include "framework/winuxtest.h"
+
+TEST(uniq, uniq_basic_adjacent_behavior) {
+  TempDir tmp;
+  tmp.write("a.txt", "a\na\nb\na\n");
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"uniq.exe", {L"a.txt"});
+  auto r = p.run();
+
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_EQ_TEXT(r.stdout_text, "a\nb\na\n");
+}
+
+TEST(uniq, uniq_count) {
+  TempDir tmp;
+  tmp.write("a.txt", "x\nx\ny\n");
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"uniq.exe", {L"-c", L"a.txt"});
+  auto r = p.run();
+
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_TRUE(r.stdout_text.find("2 x") != std::string::npos);
+  EXPECT_TRUE(r.stdout_text.find("1 y") != std::string::npos);
+}
+
+TEST(uniq, uniq_repeated_and_unique_filters) {
+  TempDir tmp;
+  tmp.write("a.txt", "a\na\nb\nc\nc\n");
+
+  Pipeline p1;
+  p1.set_cwd(tmp.wpath());
+  p1.add(L"uniq.exe", {L"-d", L"a.txt"});
+  auto r1 = p1.run();
+  EXPECT_EQ(r1.exit_code, 0);
+  EXPECT_EQ_TEXT(r1.stdout_text, "a\nc\n");
+
+  Pipeline p2;
+  p2.set_cwd(tmp.wpath());
+  p2.add(L"uniq.exe", {L"-u", L"a.txt"});
+  auto r2 = p2.run();
+  EXPECT_EQ(r2.exit_code, 0);
+  EXPECT_EQ_TEXT(r2.stdout_text, "b\n");
+}
+
+TEST(uniq, uniq_ignore_case_skip_fields_chars) {
+  TempDir tmp;
+  tmp.write("a.txt", "id1 Same\nid2 same\nid3 diff\n");
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"uniq.exe", {L"-i", L"-f", L"1", L"-s", L"1", L"a.txt"});
+  auto r = p.run();
+
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_EQ_TEXT(r.stdout_text, "id1 Same\nid3 diff\n");
+}
+
+TEST(uniq, uniq_unsupported_all_repeated) {
+  TempDir tmp;
+  tmp.write("a.txt", "x\n");
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"uniq.exe", {L"-D", L"a.txt"});
+  auto r = p.run();
+
+  EXPECT_EQ(r.exit_code, 2);
+}

--- a/tests/unit/which/which_unit_test.cpp
+++ b/tests/unit/which/which_unit_test.cpp
@@ -1,0 +1,44 @@
+#include "framework/winuxtest.h"
+
+TEST(which, which_finds_first_match) {
+  TempDir tmp;
+  tmp.write("tool.exe", "");
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.set_env(L"PATH", tmp.wpath());
+  p.add(L"which.exe", {L"tool"});
+  auto r = p.run();
+
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_TRUE(r.stdout_text.find("tool.exe") != std::string::npos);
+}
+
+TEST(which, which_all_lists_multiple) {
+  TempDir tmp;
+  tmp.write("a.exe", "");
+  tmp.write("a.cmd", "");
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.set_env(L"PATH", tmp.wpath());
+  p.add(L"which.exe", {L"-a", L"a"});
+  auto r = p.run();
+
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_TRUE(r.stdout_text.find("a.exe") != std::string::npos);
+  EXPECT_TRUE(r.stdout_text.find("a.cmd") != std::string::npos);
+}
+
+TEST(which, which_missing_returns_nonzero) {
+  TempDir tmp;
+  tmp.write("present.exe", "");
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.set_env(L"PATH", tmp.wpath());
+  p.add(L"which.exe", {L"absent"});
+  auto r = p.run();
+
+  EXPECT_EQ(r.exit_code, 1);
+}


### PR DESCRIPTION
- add head implementation with -n/-c/-q/--silent/-v/-z options plus tests
  - add tail implementation with -n/-c/-z parsing; follow/pid/retry marked [NOT SUPPORT]; tests
  - add find with name/iname/type/mindepth/maxdepth/print/print0/P/quit; unsupported exec/delete/etc; tests
  - add grep with E/F/G regex modes, files/includes/excludes, context and counting flags; mark -P unsupported; tests
  - add cut supporting -d/-f/-s/-z; mark -b/-c/output-delimiter unsupported; tests
  - add which with PATH/PATHEXT search, -a flag; skip/show dot/tilde parsed as [NOT SUPPORT]; tests
  - add env with -i/-u/-0 and NAME=VALUE handling; command exec/chdir/split-string marked [NOT SUPPORT]; tests
  - add touch, rmdir, sort, uniq implementations and corresponding unit tests
  - update pipeline env block handling and shared utils (opt, console, pch) for new commands
  - update bilingual README to list all implemented commands and supported flags