### PR TITLE
feat(v0.4.1): implement tree command and enhance wildcard handling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -117,7 +117,7 @@ include(cmake/enable_import_std.cmake)
 include(cmake/statistics_project.cmake)
 
 project(WinuxCmd
-        VERSION 0.4.0
+        VERSION 0.4.1
         DESCRIPTION "Windows Compatible Linux Command Set"
         LANGUAGES CXX
 )

--- a/README-zh.md
+++ b/README-zh.md
@@ -28,7 +28,7 @@ irm https://dl.caomengxuan666.com/install.ps1 | iex
 2. 解压到任意目录
 3. 运行设置脚本：`winux-activate.ps1`
 
-## 📦 已实现的命令 (v0.3.0)
+## 📦 已实现的命令 (v0.4.1)
 
 | 命令 | 描述 | 支持的参数（标记 [NOT SUPPORT] 的参数会被解析但未实现） |
 |------|------|------------------------------------------------|
@@ -65,6 +65,7 @@ irm https://dl.caomengxuan666.com/install.ps1 | iex
 | realpath | 打印解析的绝对路径 | -e/--canonicalize-existing, -m/--canonicalize-missing, -s/--strip, -z/--zero |
 | xargs | 从输入构建并执行命令行 | -n/--max-args, -I/--replace, -P/--max-procs, -t/--verbose, -0/--null；-d/--delimiter 为 [NOT SUPPORT] |
 | sed | 流编辑器 | -n/--quiet, -e/--expression, -f/--file, -i/--in-place [基本替换：s/模式/替换/标志] |
+| tree | 以树状格式列出目录内容 | -a/--all, -d/--directories-only, -L/--max-depth, -f/--full-path, -I/--ignore-pattern, -P/--pattern, -C/--color, -s/--size, -t/--time-sort, -o/--output |
 
 ## 🎯 为什么选择 WinuxCmd？
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ irm https://dl.caomengxuan666.com/install.ps1 | iex
 2. Extract to any directory
 3. Run the setup script: `winux-activate.ps1`
 
-## 📦 Currently Implemented Commands (v0.3.0)
+## 📦 Currently Implemented Commands (v0.4.1)
 
 | Command | Description | Supported Flags ( [NOT SUPPORT] = parsed but not implemented ) |
 |---------|-------------|---------------------------------------------------------------|
@@ -65,6 +65,7 @@ irm https://dl.caomengxuan666.com/install.ps1 | iex
 | realpath | Print the resolved absolute path | -e/--canonicalize-existing, -m/--canonicalize-missing, -s/--strip, -z/--zero |
 | xargs | Build and execute command lines from input | -n/--max-args, -I/--replace, -P/--max-procs, -t/--verbose, -0/--null; -d/--delimiter [NOT SUPPORT] |
 | sed | Stream editor | -n/--quiet, -e/--expression, -f/--file, -i/--in-place [basic substitution: s/pattern/replacement/flags] |
+| tree | List contents of directories in a tree-like format | -a/--all, -d/--directories-only, -L/--max-depth, -f/--full-path, -I/--ignore-pattern, -P/--pattern, -C/--color, -s/--size, -t/--time-sort, -o/--output |
 
 ## 🎯 Why WinuxCmd?
 

--- a/scripts/winuxcmd_init.cmd
+++ b/scripts/winuxcmd_init.cmd
@@ -2,7 +2,7 @@
 setlocal enabledelayedexpansion
 
 :: WinuxCmd - CMD Environment Initializer
-set SCRIPT_VERSION=0.4.0
+set SCRIPT_VERSION=0.4.1
 set SCRIPT_DIR=%~dp0
 if "%SCRIPT_DIR:~-1%"=="\" set "SCRIPT_DIR=%SCRIPT_DIR:~0,-1%"
 
@@ -15,8 +15,8 @@ if /i "%~1"=="--help" goto :show_help
 set WINUXCMD_BIN=
 if exist "%SCRIPT_DIR%\..\build-dev\winuxcmd.exe" (
     set WINUXCMD_BIN=%SCRIPT_DIR%\..\build-dev
-) else if exist "%LOCALAPPDATA%\WinuxCmd\WinuxCmd-0.4.0-win-x64\bin\winuxcmd.exe" (
-    set WINUXCMD_BIN=%LOCALAPPDATA%\WinuxCmd\WinuxCmd-0.4.0-win-x64\bin
+) else if exist "%LOCALAPPDATA%\WinuxCmd\WinuxCmd-0.4.1-win-x64\bin\winuxcmd.exe" (
+    set WINUXCMD_BIN=%LOCALAPPDATA%\WinuxCmd\WinuxCmd-0.4.1-win-x64\bin
 ) else (
     echo [ERROR] WinuxCmd not found.
     echo Please run from development directory or install WinuxCmd.
@@ -82,8 +82,8 @@ if "%SCRIPT_DIR:~-1%"=="\" set "SCRIPT_DIR=%SCRIPT_DIR:~0,-1%"
 set WINUXCMD_BIN=
 if exist "%SCRIPT_DIR%\..\build-dev\winuxcmd.exe" (
     set WINUXCMD_BIN=%SCRIPT_DIR%\..\build-dev
-) else if exist "%LOCALAPPDATA%\WinuxCmd\WinuxCmd-0.4.0-win-x64\bin\winuxcmd.exe" (
-    set WINUXCMD_BIN=%LOCALAPPDATA%\WinuxCmd\WinuxCmd-0.4.0-win-x64\bin
+) else if exist "%LOCALAPPDATA%\WinuxCmd\WinuxCmd-0.4.1-win-x64\bin\winuxcmd.exe" (
+    set WINUXCMD_BIN=%LOCALAPPDATA%\WinuxCmd\WinuxCmd-0.4.1-win-x64\bin
 )
 
 if "%WINUXCMD_BIN%"=="" (

--- a/scripts/winuxcmd_init.cmd
+++ b/scripts/winuxcmd_init.cmd
@@ -2,7 +2,7 @@
 setlocal enabledelayedexpansion
 
 :: WinuxCmd - CMD Environment Initializer
-set SCRIPT_VERSION=0.3.0
+set SCRIPT_VERSION=0.4.0
 set SCRIPT_DIR=%~dp0
 if "%SCRIPT_DIR:~-1%"=="\" set "SCRIPT_DIR=%SCRIPT_DIR:~0,-1%"
 
@@ -15,8 +15,8 @@ if /i "%~1"=="--help" goto :show_help
 set WINUXCMD_BIN=
 if exist "%SCRIPT_DIR%\..\build-dev\winuxcmd.exe" (
     set WINUXCMD_BIN=%SCRIPT_DIR%\..\build-dev
-) else if exist "%LOCALAPPDATA%\WinuxCmd\WinuxCmd-0.3.2-win-x64\bin\winuxcmd.exe" (
-    set WINUXCMD_BIN=%LOCALAPPDATA%\WinuxCmd\WinuxCmd-0.3.2-win-x64\bin
+) else if exist "%LOCALAPPDATA%\WinuxCmd\WinuxCmd-0.4.0-win-x64\bin\winuxcmd.exe" (
+    set WINUXCMD_BIN=%LOCALAPPDATA%\WinuxCmd\WinuxCmd-0.4.0-win-x64\bin
 ) else (
     echo [ERROR] WinuxCmd not found.
     echo Please run from development directory or install WinuxCmd.
@@ -82,8 +82,8 @@ if "%SCRIPT_DIR:~-1%"=="\" set "SCRIPT_DIR=%SCRIPT_DIR:~0,-1%"
 set WINUXCMD_BIN=
 if exist "%SCRIPT_DIR%\..\build-dev\winuxcmd.exe" (
     set WINUXCMD_BIN=%SCRIPT_DIR%\..\build-dev
-) else if exist "%LOCALAPPDATA%\WinuxCmd\WinuxCmd-0.3.2-win-x64\bin\winuxcmd.exe" (
-    set WINUXCMD_BIN=%LOCALAPPDATA%\WinuxCmd\WinuxCmd-0.3.2-win-x64\bin
+) else if exist "%LOCALAPPDATA%\WinuxCmd\WinuxCmd-0.4.0-win-x64\bin\winuxcmd.exe" (
+    set WINUXCMD_BIN=%LOCALAPPDATA%\WinuxCmd\WinuxCmd-0.4.0-win-x64\bin
 )
 
 if "%WINUXCMD_BIN%"=="" (

--- a/src/Main/main.cpp
+++ b/src/Main/main.cpp
@@ -74,16 +74,11 @@ int main(int argc, char *argv[]) noexcept {
   std::string self_name = path::get_executable_name(argv[0]);
 
   // Convert command-line arguments to string_views for efficiency
-  std::vector<std::string_view> raw_args(argv + 1, argv + argc);
-
-  // Expand wildcards
-  std::vector<std::string> expanded_args = expand_all_wildcards(raw_args);
-
-  // Convert expanded args back to string_view for dispatch
+  // Note: We don't expand wildcards here anymore. Each command decides whether to expand.
   std::vector<std::string_view> args;
-  args.reserve(expanded_args.size());
-  for (const auto &arg : expanded_args) {
-    args.emplace_back(arg);
+  args.reserve(argc - 1);
+  for (int i = 1; i < argc; ++i) {
+    args.emplace_back(argv[i]);
   }
   if (self_name == "winuxcmd") {
     // Mode 1: winuxcmd <command> [args...] (e.g., winuxcmd ls -la)

--- a/src/commands/ls.cpp
+++ b/src/commands/ls.cpp
@@ -1397,13 +1397,16 @@ auto process_paths(const std::vector<std::string> &paths,
               }
 
               if (all_same_dir && !first_dir.empty()) {
-                // All files in same directory, display as directory listing
-                auto result = list_directory(wstring_to_utf8(first_dir), ctx);
-                if (!result) {
-                  safePrintLn(std::wstring(L"ls: ") +
-                              std::wstring(result.error().begin(),
-                                           result.error().end()));
-                  success = false;
+                // All files in same directory, list each file individually
+                // (Don't use list_directory as it would show all files, not just the matched ones)
+                for (const auto &f : matched_files) {
+                  auto result = list_file(f, ctx);
+                  if (!result) {
+                    safePrintLn(std::wstring(L"ls: ") +
+                                std::wstring(result.error().begin(),
+                                             result.error().end()));
+                    success = false;
+                  }
                 }
               } else {
                 // Files in different directories, list each one

--- a/src/commands/tree.cpp
+++ b/src/commands/tree.cpp
@@ -1,0 +1,731 @@
+/*
+ *  Copyright © 2026 [caomengxuan666]
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to
+ *  deal in the Software without restriction, including without limitation the
+ *  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ *  sell copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ *  IN THE SOFTWARE.
+ *
+ *  - File: tree.cpp
+ *  - Username: Administrator
+ *  - CopyrightYear: 2026
+ */
+/// @contributors:
+///   - caomengxuan666 <2507560089@qq.com>
+/// @Description: Implementation for tree command.
+/// @Version: 0.1.0
+/// @License: MIT
+/// @Copyright: Copyright © 2026 WinuxCmd
+
+#include "pch/pch.h"
+//include other header after pch.h
+#include "core/command_macros.h"
+
+import std;
+import core;
+import utils;
+import container;
+
+using cmd::meta::OptionMeta;
+using cmd::meta::OptionType;
+
+/**
+ * @brief TREE command options definition
+ *
+ * This array defines all the options supported by the tree command.
+ * Each option is described with its short form, long form, and description.
+ *
+ * @par Options:
+ * - @a -a: All files are listed [IMPLEMENTED]
+ * - @a -d: List directories only [IMPLEMENTED]
+ * - @a -L: Max display depth of the directory tree [IMPLEMENTED]
+ * - @a -f: Print the full path prefix for each file [IMPLEMENTED]
+ * - @a -I: Do not list files that match the given pattern [IMPLEMENTED]
+ * - @a -P: List only those files that match the given pattern [IMPLEMENTED]
+ * - @a -C: Colorize the output [IMPLEMENTED]
+ * - @a -s: Print the size in bytes of each file [IMPLEMENTED]
+ * - @a -t: Sort files by last modification time [IMPLEMENTED]
+ * - @a -o: Output to file instead of stdout [IMPLEMENTED]
+ */
+auto constexpr TREE_OPTIONS = std::array{
+    OPTION("-a", "--all", "all files are listed"),
+    OPTION("-d", "", "list directories only"),
+    OPTION("-L", "", "max display depth of the directory tree", INT_TYPE),
+    OPTION("-f", "", "print the full path prefix for each file"),
+    OPTION("-I", "", "do not list files that match the given pattern", STRING_TYPE),
+    OPTION("-P", "", "list only those files that match the given pattern", STRING_TYPE),
+    OPTION("-C", "", "colorize the output"),
+    OPTION("-s", "", "print the size in bytes of each file"),
+    OPTION("-t", "", "sort files by last modification time"),
+    OPTION("-o", "", "output to file instead of stdout", STRING_TYPE)};
+
+namespace tree_pipeline {
+namespace cp = core::pipeline;
+
+struct Config {
+  bool show_all = false;
+  bool dirs_only = false;
+  int max_depth = -1;  // -1 means unlimited
+  bool full_path = false;
+  std::string exclude_pattern;
+  std::string include_pattern;
+  bool colorize = false;
+  bool show_size = false;
+  bool sort_by_time = false;
+  std::string output_file;
+
+  bool has_error = false;
+};
+
+struct FileInfo {
+  std::wstring name;
+  std::wstring full_path;
+  bool is_dir;
+  uint64_t size;
+  FILETIME mod_time;
+  bool is_hidden;
+};
+
+/**
+ * @brief Check if a character matches a character class (e.g., [0-9], [a-z], [abc])
+ */
+bool match_char_class(std::wstring_view char_class, wchar_t c) {
+  if (char_class.size() < 2 || char_class.front() != L'[' || char_class.back() != L']') {
+    return false;
+  }
+  
+  std::wstring_view content = char_class.substr(1, char_class.size() - 2);
+  
+  // Handle negation: [^...]
+  bool negated = false;
+  if (!content.empty() && content.front() == L'^') {
+    negated = true;
+    content = content.substr(1);
+  }
+  
+  bool matched = false;
+  size_t i = 0;
+  
+  while (i < content.size()) {
+    if (i + 2 < content.size() && content[i + 1] == L'-') {
+      // Range: [a-z]
+      wchar_t start = content[i];
+      wchar_t end = content[i + 2];
+      if (c >= start && c <= end) {
+        matched = true;
+        break;
+      }
+      i += 3;
+    } else {
+      // Single character: [abc]
+      if (content[i] == c) {
+        matched = true;
+        break;
+      }
+      i++;
+    }
+  }
+  
+  return negated ? !matched : matched;
+}
+
+// File extension constants
+namespace tree_constants {
+const std::array<const wchar_t*, 10> COMPRESSED_EXTS = {
+    L"zip", L"rar", L"7z", L"tar", L"gz", L"bz2", L"xz", L"iso", L"cab", L"arc"};
+const std::array<const wchar_t*, 10> SCRIPT_EXTS = {
+    L"sh", L"bat", L"cmd", L"py", L"pl", L"lua", L"js", L"php", L"rb", L"ps1"};
+const std::array<const wchar_t*, 10> SOURCE_EXTS = {
+    L"c", L"cpp", L"cc", L"cxx", L"h", L"hpp", L"rs", L"ts", L"java", L"go"};
+const std::array<const wchar_t*, 10> MEDIA_EXTS = {
+    L"jpg", L"jpeg", L"png", L"gif", L"bmp", L"webp", L"mp4", L"avi", L"mkv", L"mp3"};
+}
+
+/**
+ * @brief Get color for a file based on its extension
+ */
+auto get_file_color(const std::wstring &filename) -> std::wstring_view {
+  if (filename.empty()) return COLOR_FILE;
+  
+  // Get extension
+  std::wstring ext;
+  size_t dot_pos = filename.find_last_of(L".");
+  if (dot_pos != std::wstring::npos && dot_pos < filename.length() - 1) {
+    ext = filename.substr(dot_pos + 1);
+    std::transform(ext.begin(), ext.end(), ext.begin(), ::towlower);
+  } else {
+    return COLOR_FILE;
+  }
+  
+  // Check for compressed files
+  for (const auto *comp_ext : tree_constants::COMPRESSED_EXTS) {
+    if (ext == comp_ext) return COLOR_ARCHIVE;
+  }
+  
+  // Check for script files
+  for (const auto *script_ext : tree_constants::SCRIPT_EXTS) {
+    if (ext == script_ext) return COLOR_SCRIPT;
+  }
+  
+  // Check for source code files
+  for (const auto *source_ext : tree_constants::SOURCE_EXTS) {
+    if (ext == source_ext) return COLOR_SOURCE;
+  }
+  
+  // Check for media files
+  for (const auto *media_ext : tree_constants::MEDIA_EXTS) {
+    if (ext == media_ext) return COLOR_MEDIA;
+  }
+  
+  // Check for executable files
+  if (ext == L"exe" || ext == L"com" || ext == L"bat" || ext == L"cmd" || ext == L"ps1") {
+    return COLOR_EXEC;
+  }
+  
+  return COLOR_FILE;
+}
+
+/**
+ * @brief Check if a file/directory matches a wildcard pattern (helper for already lowercased strings)
+ */
+bool wildcard_match_impl(std::wstring_view pattern, std::wstring_view text) {
+  size_t pi = 0, ti = 0;
+  while (pi < pattern.size()) {
+    if (pattern[pi] == L'*') {
+      while (pi < pattern.size() && pattern[pi] == L'*') ++pi;
+      if (pi == pattern.size()) return true;
+      while (ti <= text.size()) {
+        if (wildcard_match_impl(pattern.substr(pi), text.substr(ti))) return true;
+        if (ti == text.size()) break;
+        ++ti;
+      }
+      return false;
+    }
+
+    if (ti >= text.size()) return false;
+
+    if (pattern[pi] == L'?') {
+      ++pi;
+      ++ti;
+    } else if (pattern[pi] == L'[') {
+      // Find matching ']'
+      size_t bracket_end = pi + 1;
+      while (bracket_end < pattern.size() && pattern[bracket_end] != L']') {
+        bracket_end++;
+      }
+      
+      if (bracket_end >= pattern.size()) {
+        // No closing bracket, treat '[' as literal
+        if (pattern[pi] != text[ti]) return false;
+        ++pi;
+        ++ti;
+      } else {
+        // Extract character class: [abc] or [a-z] or [^0-9]
+        std::wstring_view char_class = pattern.substr(pi, bracket_end - pi + 1);
+        if (!match_char_class(char_class, text[ti])) {
+          return false;
+        }
+        pi = bracket_end + 1;
+        ++ti;
+      }
+    } else if (pattern[pi] == text[ti]) {
+      ++pi;
+      ++ti;
+    } else {
+      return false;
+    }
+  }
+
+  return ti == text.size();
+}
+
+/**
+ * @brief Check if a file/directory matches a wildcard pattern
+ */
+bool wildcard_match(std::wstring_view pattern, std::wstring_view text) {
+  auto to_lower = [](std::wstring_view s) {
+    std::wstring result;
+    result.reserve(s.size());
+    for (wchar_t c : s) {
+      result.push_back(std::towlower(c));
+    }
+    return result;
+  };
+
+  auto p = to_lower(pattern);
+  auto t = to_lower(text);
+  return wildcard_match_impl(p, t);
+}
+
+/**
+ * @brief Build configuration from command context
+ */
+auto build_config(const CommandContext<TREE_OPTIONS.size()> &ctx)
+    -> cp::Result<Config> {
+  Config cfg;
+
+  cfg.show_all = ctx.get<bool>("-a", false) || ctx.get<bool>("--all", false);
+  cfg.dirs_only = ctx.get<bool>("-d", false);
+  cfg.max_depth = ctx.get<int>("-L", -1);
+  cfg.full_path = ctx.get<bool>("-f", false);
+  cfg.exclude_pattern = ctx.get<std::string>("-I", "");
+  cfg.include_pattern = ctx.get<std::string>("-P", "");
+  cfg.colorize = ctx.get<bool>("-C", false);
+  cfg.show_size = ctx.get<bool>("-s", false);
+  cfg.sort_by_time = ctx.get<bool>("-t", false);
+  cfg.output_file = ctx.get<std::string>("-o", "");
+
+  // Auto-enable color if -C is specified and output is terminal
+  if (cfg.colorize && !isOutputConsole() && cfg.output_file.empty()) {
+    cfg.colorize = false;
+  }
+
+  return cfg;
+}
+
+/**
+ * @brief Convert FILETIME to time_t for comparison
+ */
+auto filetime_to_time(const FILETIME &ft) -> time_t {
+  ULARGE_INTEGER ull;
+  ull.LowPart = ft.dwLowDateTime;
+  ull.HighPart = ft.dwHighDateTime;
+  return static_cast<time_t>((ull.QuadPart - 116444736000000000ULL) / 10000000ULL);
+}
+
+/**
+ * @brief Collect directory contents recursively
+ */
+auto collect_directory(const std::wstring &path, const Config &cfg,
+                       int current_depth = 0) -> cp::Result<std::vector<FileInfo>> {
+  if (cfg.max_depth >= 0 && current_depth >= cfg.max_depth) {
+    return std::vector<FileInfo>{};
+  }
+
+  std::vector<FileInfo> entries;
+  std::wstring search_path = path;
+  if (search_path.back() != L'\\') {
+    search_path += L'\\';
+  }
+  search_path += L'*';
+
+  WIN32_FIND_DATAW find_data;
+  HANDLE hFind = FindFirstFileW(search_path.c_str(), &find_data);
+
+  if (hFind == INVALID_HANDLE_VALUE) {
+    // Return empty for non-existent directories (graceful handling)
+    return std::vector<FileInfo>{};
+  }
+
+  do {
+    std::wstring filename = find_data.cFileName;
+
+    // Skip . and ..
+    if (filename == L"." || filename == L"..") {
+      continue;
+    }
+
+    // Skip hidden files unless -a is specified
+    bool is_hidden = (find_data.dwFileAttributes & FILE_ATTRIBUTE_HIDDEN) != 0;
+    if (is_hidden && !cfg.show_all) {
+      continue;
+    }
+
+    // Check exclude pattern
+    if (!cfg.exclude_pattern.empty()) {
+      std::wstring wexclude = utf8_to_wstring(cfg.exclude_pattern);
+      if (wildcard_match(wexclude, filename)) {
+        continue;
+      }
+    }
+
+    // Check include pattern
+    if (!cfg.include_pattern.empty()) {
+      std::wstring winclude = utf8_to_wstring(cfg.include_pattern);
+      if (!wildcard_match(winclude, filename)) {
+        continue;
+      }
+    }
+
+    bool is_dir = (find_data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) != 0;
+
+    // Skip files if -d is specified
+    if (!is_dir && cfg.dirs_only) {
+      continue;
+    }
+
+    FileInfo info;
+    info.name = filename;
+    info.full_path = path;
+    if (info.full_path.back() != L'\\') {
+      info.full_path += L'\\';
+    }
+    info.full_path += filename;
+    info.is_dir = is_dir;
+    info.is_hidden = is_hidden;
+
+    // Calculate file size
+    info.size = static_cast<uint64_t>(find_data.nFileSizeLow) |
+                (static_cast<uint64_t>(find_data.nFileSizeHigh) << 32);
+
+    info.mod_time = find_data.ftLastWriteTime;
+
+    entries.push_back(info);
+
+  } while (FindNextFileW(hFind, &find_data) != 0);
+
+  FindClose(hFind);
+
+  // Sort entries
+  if (cfg.sort_by_time) {
+    std::sort(entries.begin(), entries.end(),
+              [](const FileInfo &a, const FileInfo &b) {
+                time_t ta = filetime_to_time(a.mod_time);
+                time_t tb = filetime_to_time(b.mod_time);
+                if (ta != tb) {
+                  return ta > tb;  // Newest first
+                }
+                return a.name < b.name;  // Then by name
+              });
+  } else {
+    // Sort alphabetically
+    std::sort(entries.begin(), entries.end(),
+              [](const FileInfo &a, const FileInfo &b) {
+                return a.name < b.name;
+              });
+  }
+
+  return entries;
+}
+
+/**
+ * @brief Format file size in human-readable format
+ */
+auto format_size(uint64_t size) -> std::string {
+  if (size < 1024) {
+    return std::to_string(size) + "B";
+  } else if (size < 1024 * 1024) {
+    return std::to_string(size / 1024) + "K";
+  } else if (size < 1024 * 1024 * 1024) {
+    return std::to_string(size / (1024 * 1024)) + "M";
+  } else {
+    return std::to_string(size / (1024 * 1024 * 1024)) + "G";
+  }
+}
+
+/**
+ * @brief Print tree with proper indentation (console output)
+ */
+auto print_tree_console(const std::vector<FileInfo> &entries, const Config &cfg,
+                        const std::wstring &base_path, const std::wstring &prefix,
+                        int current_depth, size_t &total_dirs, size_t &total_files) -> void {
+  for (size_t i = 0; i < entries.size(); ++i) {
+    const auto &entry = entries[i];
+    bool is_last = (i == entries.size() - 1);
+
+    // Build prefix for this entry
+    std::wstring line_prefix = prefix;
+    if (is_last) {
+      line_prefix += L"\u2514\u2500\u2500 ";
+    } else {
+      line_prefix += L"\u251C\u2500\u2500 ";
+    }
+
+    // Build display path
+    std::wstring display_path;
+    if (cfg.full_path) {
+      display_path = entry.full_path;
+    } else {
+      display_path = entry.name;
+    }
+
+    // Build the complete line
+    std::wstring line = line_prefix;
+
+    // Print size if requested
+    if (cfg.show_size) {
+      line += L"[" + utf8_to_wstring(format_size(entry.size)) + L"] ";
+    }
+
+    line += display_path;
+
+    // Apply color and print
+    if (cfg.colorize) {
+      if (entry.is_dir) {
+        safePrint(COLOR_DIR);
+      } else if (entry.is_hidden) {
+        safePrint(L"\033[37m");  // Gray for hidden files
+      } else {
+        safePrint(get_file_color(entry.name));
+      }
+    }
+
+    safePrint(line);
+    safePrint(L"\n");
+
+    if (cfg.colorize) {
+      safePrint(COLOR_RESET);
+    }
+
+    // Count this entry
+    if (entry.is_dir) {
+      total_dirs++;
+    } else {
+      total_files++;
+    }
+
+    // Recursively process subdirectories
+    if (entry.is_dir && (cfg.max_depth < 0 || current_depth < cfg.max_depth)) {
+      auto sub_entries = collect_directory(entry.full_path, cfg, current_depth + 1);
+
+      if (sub_entries.has_value() && !sub_entries->empty()) {
+        std::wstring sub_prefix = prefix;
+        if (is_last) {
+          sub_prefix += L"    ";
+        } else {
+          sub_prefix += L"\u2502   ";
+        }
+        print_tree_console(*sub_entries, cfg, entry.full_path, sub_prefix, current_depth + 1, total_dirs, total_files);
+      }
+    }
+  }
+}
+
+/**
+ * @brief Print tree with proper indentation (file output)
+ */
+auto print_tree_file(const std::vector<FileInfo> &entries, const Config &cfg,
+                     const std::wstring &base_path, const std::wstring &prefix,
+                     int current_depth, std::ofstream &output,
+                     size_t &total_dirs, size_t &total_files) -> void {
+  for (size_t i = 0; i < entries.size(); ++i) {
+    const auto &entry = entries[i];
+    bool is_last = (i == entries.size() - 1);
+
+    // Build prefix for this entry
+    std::wstring line_prefix = prefix;
+    if (is_last) {
+      line_prefix += L"\u2514\u2500\u2500 ";
+    } else {
+      line_prefix += L"\u251C\u2500\u2500 ";
+    }
+
+    // Build display path
+    std::wstring display_path;
+    if (cfg.full_path) {
+      display_path = entry.full_path;
+    } else {
+      display_path = entry.name;
+    }
+
+    // Build the complete line
+    std::wstring line = line_prefix;
+
+    // Print size if requested
+    if (cfg.show_size) {
+      line += L"[" + utf8_to_wstring(format_size(entry.size)) + L"] ";
+    }
+
+    line += display_path;
+
+    // Output to file (use UTF-8)
+    output << wstring_to_utf8(line) << std::endl;
+
+    // Count this entry
+    if (entry.is_dir) {
+      total_dirs++;
+    } else {
+      total_files++;
+    }
+
+    // Recursively process subdirectories
+    if (entry.is_dir && (cfg.max_depth < 0 || current_depth < cfg.max_depth)) {
+      auto sub_entries = collect_directory(entry.full_path, cfg, current_depth + 1);
+
+      if (sub_entries.has_value() && !sub_entries->empty()) {
+        std::wstring sub_prefix = prefix;
+        if (is_last) {
+          sub_prefix += L"    ";
+        } else {
+          sub_prefix += L"\u2502   ";
+        }
+        print_tree_file(*sub_entries, cfg, entry.full_path, sub_prefix, current_depth + 1, output, total_dirs, total_files);
+      }
+    }
+  }
+}
+
+/**
+ * @brief Execute tree command
+ */
+auto execute_tree(const CommandContext<TREE_OPTIONS.size()> &ctx) -> cp::Result<bool> {
+  // Build configuration
+  auto cfg_result = build_config(ctx);
+  if (!cfg_result) {
+    return std::unexpected(cfg_result.error());
+  }
+  Config cfg = std::move(cfg_result.value());
+
+  // Check if output to file
+  bool output_to_file = !cfg.output_file.empty();
+  std::ofstream file_output;
+
+  if (output_to_file) {
+    std::wstring woutput_file = utf8_to_wstring(cfg.output_file);
+    file_output.open(woutput_file);
+    if (!file_output.is_open()) {
+      return std::unexpected("cannot open output file: " + cfg.output_file);
+    }
+  }
+
+  // Get target directories (default to current directory)
+  std::vector<std::wstring> target_dirs;
+  for (auto arg : ctx.positionals) {
+    target_dirs.push_back(utf8_to_wstring(std::string(arg)));
+  }
+
+  if (target_dirs.empty()) {
+    target_dirs.push_back(L".");
+  }
+
+  // Process each directory
+  for (const auto &dir_path : target_dirs) {
+    std::wstring abs_path;
+    if (dir_path == L".") {
+      wchar_t buffer[MAX_PATH];
+      GetCurrentDirectoryW(MAX_PATH, buffer);
+      abs_path = buffer;
+    } else {
+      // Get full path
+      wchar_t buffer[MAX_PATH];
+      GetFullPathNameW(dir_path.c_str(), MAX_PATH, buffer, nullptr);
+      abs_path = buffer;
+    }
+
+    // Print header if multiple directories
+    if (target_dirs.size() > 1) {
+      if (output_to_file) {
+        file_output << wstring_to_utf8(abs_path) << std::endl << std::endl;
+      } else {
+        safePrintLn(abs_path);
+        safePrintLn(L"");
+      }
+    }
+
+    // Check if path exists
+    DWORD attrs = GetFileAttributesW(abs_path.c_str());
+    if (attrs == INVALID_FILE_ATTRIBUTES) {
+      if (output_to_file) {
+        file_output << "tree: cannot access '" << wstring_to_utf8(abs_path) << "': No such file or directory" << std::endl;
+      } else {
+        safePrintLn(L"tree: cannot access '" + abs_path + L"': No such file or directory");
+      }
+      return false;
+    }
+
+    // Check if it's a directory
+    if (!(attrs & FILE_ATTRIBUTE_DIRECTORY)) {
+      // It's a file, just print it
+      if (output_to_file) {
+        file_output << wstring_to_utf8(abs_path) << std::endl;
+      } else {
+        safePrintLn(abs_path);
+      }
+      continue;
+    }
+
+    // Collect and print directory tree
+    auto entries = collect_directory(abs_path, cfg, 0);
+    if (entries.has_value()) {
+      size_t total_dirs = 0, total_files = 0;
+      
+      if (output_to_file) {
+        file_output << wstring_to_utf8(abs_path) << std::endl;
+        print_tree_file(*entries, cfg, abs_path, L"", 0, file_output, total_dirs, total_files);
+      } else {
+        safePrintLn(abs_path);
+        print_tree_console(*entries, cfg, abs_path, L"", 0, total_dirs, total_files);
+
+        // Print summary
+        safePrintLn(std::to_wstring(total_dirs) + L" directories, " + std::to_wstring(total_files) + L" files");
+      }
+    }
+  }
+
+  return true;
+}
+
+/**
+ * @brief Main pipeline
+ * @param ctx Command context
+ * @return Result with success status
+ */
+template <size_t N>
+auto process_command(const CommandContext<N> &ctx) -> cp::Result<bool> {
+  return execute_tree(ctx);
+}
+
+}  // namespace tree_pipeline
+
+// ======================================================
+// Command registration
+// ======================================================
+
+REGISTER_COMMAND(
+    tree,
+    /* cmd_name */ "tree",
+    /* cmd_synopsis */ "list contents of directories in a tree-like format",
+    /* cmd_desc */
+    "tree is a recursive directory listing program that produces a depth indented\n"
+    "listing of files. Color is supported ala dircolors if the LS_COLORS environment\n"
+    "variable is set, outputting to tty.\n\n"
+    "With no arguments, tree lists the files in the current directory. When directory\n"
+    "arguments are given, tree lists all the files and/or directories found in the\n"
+    "given directories each in turn. Upon completion of listing all files/directories\n"
+    "found, tree returns the total number of files and/or directories listed.\n\n"
+    "By default, when a symbolic link is encountered, the path that the symbolic link\n"
+    "refers to is printed after the name of the link in the format:\n"
+    "    name -> real-path\n\n"
+    "If the -f option is given, then each entry is printed with its full path prefix.",
+    /* examples */
+    "  tree              # List files in current directory\n"
+    "  tree -L 2         # List with depth limit of 2\n"
+    "  tree -d           # List directories only\n"
+    "  tree -a           # List all files including hidden\n"
+    "  tree -f           # Print full paths\n"
+    "  tree -I '*.tmp'   # Exclude tmp files\n"
+    "  tree -P '*.cpp'   # Only show cpp files\n"
+    "  tree -C           # Colorize output\n"
+    "  tree -s           # Show file sizes\n"
+    "  tree -t           # Sort by modification time\n"
+    "  tree -o out.txt   # Output to file\n"
+    "  tree /path/to/dir # List specific directory",
+    /* see_also */ "ls, find, du",
+    /* author */ "WinuxCmd",
+    /* copyright */ "Copyright © 2026 WinuxCmd",
+    /* options */
+    TREE_OPTIONS) {
+  using namespace tree_pipeline;
+  using namespace core::pipeline;
+
+  auto result = process_command(ctx);
+  if (!result) {
+    report_error(result, L"tree");
+    return 1;
+  }
+
+  return *result ? 0 : 1;
+}

--- a/src/core/cmd_meta.cppm
+++ b/src/core/cmd_meta.cppm
@@ -58,6 +58,7 @@ class CommandMeta {
   std::string_view m_author;
   std::string_view m_copyright;
   std::string_view m_brief_desc;  // Brief description for help listing
+  bool m_needs_wildcard_expansion;  // Whether to expand wildcards in positional args
 
   static constexpr std::array<OptionMeta, OptionCount> with_index(
       std::array<OptionMeta, OptionCount> opts) {
@@ -73,7 +74,8 @@ class CommandMeta {
       std::string_view examples = "", std::string_view see_also = "",
       std::string_view author = "WinuxCmd Project",
       std::string_view copyright = "Copyright © 2026 WinuxCmd",
-      std::string_view brief_desc = "")
+      std::string_view brief_desc = "",
+      bool needs_wildcard_expansion = false)
       : m_name(name),
         m_synopsis(synopsis),
         m_description(description),
@@ -82,7 +84,8 @@ class CommandMeta {
         m_see_also(see_also),
         m_author(author),
         m_copyright(copyright),
-        m_brief_desc(brief_desc) {}
+        m_brief_desc(brief_desc),
+        m_needs_wildcard_expansion(needs_wildcard_expansion) {}
 
   // Accessors
   constexpr std::string_view name() const { return m_name; }
@@ -98,6 +101,10 @@ class CommandMeta {
   constexpr std::string_view brief_desc() const {
     return m_brief_desc;
   }  // Brief description getter
+
+  constexpr bool needsWildcardExpansion() const {
+    return m_needs_wildcard_expansion;
+  }
 
   constexpr int find_index(std::string_view name) const {
     for (size_t i = 0; i < OptionCount; ++i) {
@@ -424,6 +431,8 @@ export class CommandMetaBase {
   virtual std::string_view brief_desc() const = 0;
 
   virtual std::span<const OptionMeta> options() const = 0;
+
+  virtual bool needsWildcardExpansion() const = 0;
 };
 
 export template <size_t N>
@@ -440,6 +449,10 @@ class CommandMetaWrapper : public CommandMetaBase {
 
   std::span<const OptionMeta> options() const override {
     return m_meta.options();
+  }
+
+  bool needsWildcardExpansion() const override {
+    return m_meta.needsWildcardExpansion();
   }
 };
 
@@ -460,6 +473,10 @@ export class CommandMetaHandle {
   std::string_view brief_desc() const { return m_ptr->brief_desc(); }
 
   std::span<const OptionMeta> options() const { return m_ptr->options(); }
+
+  bool needsWildcardExpansion() const {
+    return m_ptr->needsWildcardExpansion();
+  }
 };
 
 // Registry for metadata

--- a/src/utils/wildcard.cppm
+++ b/src/utils/wildcard.cppm
@@ -2,22 +2,22 @@
  *  Copyright © 2026 [caomengxuan666]
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
- *  of this software and associated documentation files (the “Software”), to
- * deal in the Software without restriction, including without limitation the
- * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
- * sell copies of the Software, and to permit persons to whom the Software is
- * furnished to do so, subject to the following conditions:
+ *  of this software and associated documentation files (the "Software"), to
+ *  deal in the Software without restriction, including without limitation the
+ *  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ *  sell copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
  *
  *  The above copyright notice and this permission notice shall be included in
- * all copies or substantial portions of the Software.
+ *  all copies or substantial portions of the Software.
  *
- *  THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
  *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
  *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
- * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
- * IN THE SOFTWARE.
+ *  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ *  IN THE SOFTWARE.
  *
  *  - File: wildcard.cppm
  *  - Username: Administrator
@@ -29,55 +29,173 @@ import std;
 import :utf8;
 import :path;
 
-static bool wildcard_match(const std::string &str,
-                           const std::string &pattern) noexcept {
-  const size_t str_len = str.size();
-  const size_t pat_len = pattern.size();
-  size_t s = 0, p = 0, star_pos = static_cast<size_t>(-1);
+namespace wildcard_impl {
 
-  while (s < str_len) {
-    if (p < pat_len && (pattern[p] == '?' || str[s] == pattern[p])) {
-      ++s;
-      ++p;
-    } else if (p < pat_len && pattern[p] == '*') {
-      star_pos = p++;
-    } else if (star_pos != static_cast<size_t>(-1)) {
-      p = star_pos + 1;
-      ++s;
+/**
+ * @brief Check if a character matches a character class pattern
+ * @param char_class The character class string (e.g., "[abc]", "[a-z]", "[^0-9]")
+ * @param c The character to check
+ * @return true if the character matches the class, false otherwise
+ */
+static bool match_char_class(std::wstring_view char_class, wchar_t c) {
+  if (static_cast<size_t>(char_class.size()) < 2) return false;
+
+  // Check for negation [^...]
+  bool negate = (char_class[1] == L'^');
+  size_t start = negate ? 2 : 1;
+  size_t end = static_cast<size_t>(char_class.size()) - 1;  // Exclude closing ']'
+
+  if (start >= end) return false;
+
+  // Check for range [a-z]
+  for (size_t i = start; i < end; ++i) {
+    if (i + 2 < end && char_class[i + 1] == L'-') {
+      // Range pattern: a-z
+      wchar_t range_start = char_class[i];
+      wchar_t range_end = char_class[i + 2];
+      if (c >= range_start && c <= range_end) {
+        return !negate;
+      }
+      i += 2;  // Skip the '-' and next character
+    } else {
+      // Single character: a
+      if (char_class[i] == c) {
+        return !negate;
+      }
+    }
+  }
+
+  return negate;  // If negate is true, return true (no match)
+}
+
+/**
+ * @brief Core wildcard matching implementation with support for *, ?, and []
+ * @param pattern The wildcard pattern
+ * @param text The text to match against
+ * @return true if text matches pattern, false otherwise
+ */
+static bool wildcard_match_impl(std::wstring_view pattern, std::wstring_view text) {
+  size_t pi = 0, ti = 0;
+  while (pi < static_cast<size_t>(pattern.size())) {
+    if (pattern[pi] == L'*') {
+      while (pi < static_cast<size_t>(pattern.size()) && pattern[pi] == L'*') ++pi;
+      if (pi == static_cast<size_t>(pattern.size())) return true;
+      while (ti <= static_cast<size_t>(text.size())) {
+        if (wildcard_match_impl(pattern.substr(pi), text.substr(ti))) return true;
+        if (ti == static_cast<size_t>(text.size())) break;
+        ++ti;
+      }
+      return false;
+    }
+
+    if (ti >= static_cast<size_t>(text.size())) return false;
+
+    if (pattern[pi] == L'?') {
+      ++pi;
+      ++ti;
+    } else if (pattern[pi] == L'[') {
+      // Find matching ']'
+      size_t bracket_end = pi + 1;
+      while (bracket_end < static_cast<size_t>(pattern.size()) && pattern[bracket_end] != L']') {
+        bracket_end++;
+      }
+
+      if (bracket_end >= static_cast<size_t>(pattern.size())) {
+        // No closing bracket, treat '[' as literal
+        if (pattern[pi] != text[ti]) return false;
+        ++pi;
+        ++ti;
+      } else {
+        // Extract character class: [abc] or [a-z] or [^0-9]
+        std::wstring_view char_class = pattern.substr(pi, bracket_end - pi + 1);
+        if (!match_char_class(char_class, text[ti])) {
+          return false;
+        }
+        pi = bracket_end + 1;
+        ++ti;
+      }
+    } else if (pattern[pi] == text[ti]) {
+      ++pi;
+      ++ti;
     } else {
       return false;
     }
   }
 
-  while (p < pat_len && pattern[p] == '*') {
-    ++p;
-  }
-
-  return p == pat_len;
+  return ti == static_cast<size_t>(text.size());
 }
 
-export std::vector<std::string> expand_wildcard(
-    const std::string_view pattern) noexcept {
+}  // namespace wildcard_impl
+
+/**
+ * @brief Enhanced wildcard matching with support for *, ?, and []
+ * @param pattern The wildcard pattern
+ * @param text The text to match against
+ * @param case_sensitive Whether to perform case-sensitive matching (default: false)
+ * @return true if text matches pattern, false otherwise
+ */
+export bool wildcard_match(const std::wstring &pattern, const std::wstring &text, bool case_sensitive = false) {
+  if (case_sensitive) {
+    return wildcard_impl::wildcard_match_impl(pattern, text);
+  }
+
+  // Case-insensitive matching
+  auto to_lower = [](std::wstring_view s) {
+    std::wstring result;
+    result.reserve(static_cast<size_t>(s.size()));
+    for (wchar_t c : s) {
+      result.push_back(std::towlower(c));
+    }
+    return result;
+  };
+
+  auto p = to_lower(pattern);
+  auto t = to_lower(text);
+  return wildcard_impl::wildcard_match_impl(p, t);
+}
+
+/**
+ * @brief Expand wildcard pattern in the current directory
+ * @param pattern The wildcard pattern (e.g., "*.txt", "dir/*.cpp", "[0-9]*")
+ * @return Vector of matched file paths (relative to current directory)
+ *
+ * This function:
+ * - Handles patterns with directory paths (e.g., "src/*.cpp")
+ * - Supports *, ?, and [] wildcards
+ * - Returns sorted and deduplicated results
+ * - If pattern contains no wildcards, returns the pattern itself
+ */
+export std::vector<std::string> expand_wildcard(const std::string_view pattern) noexcept {
   std::vector<std::string> matched_files;
   const std::string pat(pattern);
 
-  if (pat.find_first_of("*?") == std::string::npos) {
+  // If pattern contains no wildcards, return it as-is
+  if (pat.find_first_of("*?[") == std::string::npos) {
     matched_files.push_back(pat);
     return matched_files;
   }
 
-  // Get current directory
-  std::string current_dir = path::current_path();
-  if (current_dir.empty()) {
-    return matched_files;
+  // Split pattern into directory part and filename part
+  std::string dir_part, file_part;
+  size_t last_slash = pat.find_last_of("/\\");
+  if (last_slash == std::string::npos) {
+    dir_part = ".";
+    file_part = pat;
+  } else {
+    dir_part = pat.substr(0, last_slash);
+    file_part = pat.substr(last_slash + 1);
   }
 
-  // Build search pattern: current_dir\*
-  std::wstring search_pattern = utf8_to_wstring(path::join(current_dir, "*"));
+  // Convert to wide strings
+  std::wstring wdir = utf8_to_wstring(dir_part);
+  std::wstring wfile_pat = utf8_to_wstring(file_part);
+
+  // Build search path: dir\*
+  std::wstring search_path = path::join(wdir, L"*");
 
   // Find first file
   WIN32_FIND_DATAW find_data;
-  HANDLE hFind = FindFirstFileW(search_pattern.c_str(), &find_data);
+  HANDLE hFind = FindFirstFileW(search_path.c_str(), &find_data);
   if (hFind == INVALID_HANDLE_VALUE) {
     return matched_files;
   }
@@ -90,19 +208,18 @@ export std::vector<std::string> expand_wildcard(
       continue;
     }
 
-    // Convert filename to UTF-8
-    int filename_len = WideCharToMultiByte(CP_UTF8, 0, find_data.cFileName, -1,
-                                           NULL, 0, NULL, NULL);
-    if (filename_len <= 0) {
-      continue;
-    }
-    std::string filename(filename_len - 1, 0);
-    WideCharToMultiByte(CP_UTF8, 0, find_data.cFileName, -1, &filename[0],
-                        filename_len, NULL, NULL);
+    std::wstring filename = find_data.cFileName;
 
     // Check if filename matches the pattern
-    if (wildcard_match(filename, pat)) {
-      matched_files.push_back(filename);
+    if (wildcard_match(wfile_pat, filename, false)) {
+      // Build full path
+      std::string full_path;
+      if (dir_part == ".") {
+        full_path = wstring_to_utf8(filename);
+      } else {
+        full_path = path::join(dir_part, wstring_to_utf8(filename));
+      }
+      matched_files.push_back(full_path);
     }
   } while (FindNextFileW(hFind, &find_data));
 

--- a/tests/framework/temp_dir.h
+++ b/tests/framework/temp_dir.h
@@ -131,4 +131,17 @@ struct TempDir {
     return std::string((std::istreambuf_iterator<char>(ifs)),
                        std::istreambuf_iterator<char>());
   }
+
+  /**
+   * @brief Create a subdirectory within the temporary directory
+   *
+   * Creates a directory at the specified relative path, creating
+   * parent directories as needed.
+   *
+   * @param rel Relative path of the directory to create
+   */
+  void mkdir(const std::string &rel) const {
+    auto p = path / rel;
+    std::filesystem::create_directories(p);
+  }
 };

--- a/tests/unit/tree/tree_unit_test.cpp
+++ b/tests/unit/tree/tree_unit_test.cpp
@@ -1,0 +1,283 @@
+/*
+ *  Copyright © 2026 WinuxCmd
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to
+ *  deal in the Software without restriction, including without limitation the
+ *  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ *  sell copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ *  IN THE SOFTWARE.
+ *
+ *  - File: tree_unit_test.cpp
+ *  - CopyrightYear: 2026
+ */
+#include "framework/winuxtest.h"
+#include <filesystem>
+
+TEST(tree, tree_basic) {
+  TempDir tmp;
+  tmp.write("file1.txt", "content1");
+  tmp.write("file2.txt", "content2");
+  std::filesystem::create_directories(tmp.path / "subdir");
+  tmp.write("subdir/file3.txt", "content3");
+
+  TEST_LOG_FILE_CONTENT("file1.txt", "content1");
+  TEST_LOG_FILE_CONTENT("file2.txt", "content2");
+  TEST_LOG_FILE_CONTENT("subdir/file3.txt", "content3");
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"tree.exe", {});
+
+  TEST_LOG_CMD_LIST("tree.exe");
+
+  auto r = p.run();
+
+  TEST_LOG_EXIT_CODE(r);
+  TEST_LOG("tree.exe output", r.stdout_text);
+
+  EXPECT_EQ(r.exit_code, 0);
+  // Verify the output contains the expected files
+  EXPECT_TRUE(r.stdout_text.find("file1.txt") != std::string::npos);
+  EXPECT_TRUE(r.stdout_text.find("file2.txt") != std::string::npos);
+  EXPECT_TRUE(r.stdout_text.find("subdir") != std::string::npos);
+}
+
+TEST(tree, tree_depth_limit) {
+  TempDir tmp;
+  std::filesystem::create_directories(tmp.path / "level1" / "level2");
+  tmp.write("level1/level2/file.txt", "deep content");
+
+  TEST_LOG_FILE_CONTENT("level1/level2/file.txt", "deep content");
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"tree.exe", {L"-L", L"1"});
+
+  TEST_LOG_CMD_LIST("tree.exe", L"-L", L"1");
+
+  auto r = p.run();
+
+  TEST_LOG_EXIT_CODE(r);
+  TEST_LOG("tree.exe -L 1 output", r.stdout_text);
+
+  EXPECT_EQ(r.exit_code, 0);
+  // Verify level1 is shown but level2 is not
+  EXPECT_TRUE(r.stdout_text.find("level1") != std::string::npos);
+  EXPECT_TRUE(r.stdout_text.find("level2") == std::string::npos);
+}
+
+TEST(tree, tree_dirs_only) {
+  TempDir tmp;
+  tmp.write("file.txt", "content");
+  std::filesystem::create_directories(tmp.path / "dir1");
+  std::filesystem::create_directories(tmp.path / "dir2");
+  tmp.write("dir1/inside.txt", "inside");
+
+  TEST_LOG_FILE_CONTENT("file.txt", "content");
+  TEST_LOG_FILE_CONTENT("dir1/inside.txt", "inside");
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"tree.exe", {L"-d"});
+
+  TEST_LOG_CMD_LIST("tree.exe", L"-d");
+
+  auto r = p.run();
+
+  TEST_LOG_EXIT_CODE(r);
+  TEST_LOG("tree.exe -d output", r.stdout_text);
+
+  EXPECT_EQ(r.exit_code, 0);
+  // Verify only directories are shown
+  EXPECT_TRUE(r.stdout_text.find("dir1") != std::string::npos);
+  EXPECT_TRUE(r.stdout_text.find("dir2") != std::string::npos);
+  EXPECT_TRUE(r.stdout_text.find("file.txt") == std::string::npos);
+}
+
+TEST(tree, tree_all_files) {
+  TempDir tmp;
+  tmp.write("normal.txt", "content");
+  tmp.write(".hidden.txt", "hidden content");
+
+  TEST_LOG_FILE_CONTENT("normal.txt", "content");
+  TEST_LOG_FILE_CONTENT(".hidden.txt", "hidden content");
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"tree.exe", {L"-a"});
+
+  TEST_LOG_CMD_LIST("tree.exe", L"-a");
+
+  auto r = p.run();
+
+  TEST_LOG_EXIT_CODE(r);
+  TEST_LOG("tree.exe -a output", r.stdout_text);
+
+  EXPECT_EQ(r.exit_code, 0);
+  // Verify both files are shown
+  EXPECT_TRUE(r.stdout_text.find("normal.txt") != std::string::npos);
+  EXPECT_TRUE(r.stdout_text.find(".hidden.txt") != std::string::npos);
+}
+
+TEST(tree, tree_full_path) {
+  TempDir tmp;
+  tmp.write("file.txt", "content");
+
+  TEST_LOG_FILE_CONTENT("file.txt", "content");
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"tree.exe", {L"-f"});
+
+  TEST_LOG_CMD_LIST("tree.exe", L"-f");
+
+  auto r = p.run();
+
+  TEST_LOG_EXIT_CODE(r);
+  TEST_LOG("tree.exe -f output", r.stdout_text);
+
+  EXPECT_EQ(r.exit_code, 0);
+  // Verify full path is shown (should contain tmp path)
+  EXPECT_TRUE(r.stdout_text.find("file.txt") != std::string::npos);
+}
+
+TEST(tree, tree_exclude_pattern) {
+  TempDir tmp;
+  tmp.write("file.txt", "content");
+  tmp.write("test.tmp", "temp content");
+  tmp.write("other.txt", "other content");
+
+  TEST_LOG_FILE_CONTENT("file.txt", "content");
+  TEST_LOG_FILE_CONTENT("test.tmp", "temp content");
+  TEST_LOG_FILE_CONTENT("other.txt", "other content");
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"tree.exe", {L"-I", L"*.tmp"});
+
+  TEST_LOG_CMD_LIST("tree.exe", L"-I", L"*.tmp");
+
+  auto r = p.run();
+
+  TEST_LOG_EXIT_CODE(r);
+  TEST_LOG("tree.exe -I output", r.stdout_text);
+
+  EXPECT_EQ(r.exit_code, 0);
+  // Verify .tmp file is excluded
+  EXPECT_TRUE(r.stdout_text.find("file.txt") != std::string::npos);
+  EXPECT_TRUE(r.stdout_text.find("other.txt") != std::string::npos);
+  EXPECT_TRUE(r.stdout_text.find("test.tmp") == std::string::npos);
+}
+
+TEST(tree, tree_include_pattern) {
+  TempDir tmp;
+  tmp.write("file.cpp", "c++ content");
+  tmp.write("file.txt", "text content");
+  tmp.write("file.py", "python content");
+
+  TEST_LOG_FILE_CONTENT("file.cpp", "c++ content");
+  TEST_LOG_FILE_CONTENT("file.txt", "text content");
+  TEST_LOG_FILE_CONTENT("file.py", "python content");
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"tree.exe", {L"-P", L"*.cpp"});
+
+  TEST_LOG_CMD_LIST("tree.exe", L"-P", L"*.cpp");
+
+  auto r = p.run();
+
+  TEST_LOG_EXIT_CODE(r);
+  TEST_LOG("tree.exe -P output", r.stdout_text);
+
+  EXPECT_EQ(r.exit_code, 0);
+  // Verify only .cpp files are shown
+  EXPECT_TRUE(r.stdout_text.find("file.cpp") != std::string::npos);
+  EXPECT_TRUE(r.stdout_text.find("file.txt") == std::string::npos);
+  EXPECT_TRUE(r.stdout_text.find("file.py") == std::string::npos);
+}
+
+TEST(tree, tree_show_size) {
+  TempDir tmp;
+  tmp.write("small.txt", "abc");
+  tmp.write("large.txt", std::string(1000, 'x'));
+
+  TEST_LOG_FILE_CONTENT("small.txt", "abc");
+  TEST_LOG_FILE_CONTENT("large.txt", std::string(1000, 'x'));
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"tree.exe", {L"-s"});
+
+  TEST_LOG_CMD_LIST("tree.exe", L"-s");
+
+  auto r = p.run();
+
+  TEST_LOG_EXIT_CODE(r);
+  TEST_LOG("tree.exe -s output", r.stdout_text);
+
+  EXPECT_EQ(r.exit_code, 0);
+  // Verify size is shown (should contain brackets with size)
+  EXPECT_TRUE(r.stdout_text.find("[") != std::string::npos);
+  EXPECT_TRUE(r.stdout_text.find("]") != std::string::npos);
+}
+
+TEST(tree, tree_sort_by_time) {
+  TempDir tmp;
+  tmp.write("old.txt", "old");
+  tmp.write("new.txt", "new");
+
+  TEST_LOG_FILE_CONTENT("old.txt", "old");
+  TEST_LOG_FILE_CONTENT("new.txt", "new");
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"tree.exe", {L"-t"});
+
+  TEST_LOG_CMD_LIST("tree.exe", L"-t");
+
+  auto r = p.run();
+
+  TEST_LOG_EXIT_CODE(r);
+  TEST_LOG("tree.exe -t output", r.stdout_text);
+
+  EXPECT_EQ(r.exit_code, 0);
+  // Verify files are listed
+  EXPECT_TRUE(r.stdout_text.find("old.txt") != std::string::npos);
+  EXPECT_TRUE(r.stdout_text.find("new.txt") != std::string::npos);
+}
+
+TEST(tree, tree_single_directory) {
+  TempDir tmp;
+  std::filesystem::create_directories(tmp.path / "mydir");
+  tmp.write("mydir/file.txt", "content");
+
+  TEST_LOG_FILE_CONTENT("mydir/file.txt", "content");
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"tree.exe", {L"mydir"});
+
+  TEST_LOG_CMD_LIST("tree.exe", L"mydir");
+
+  auto r = p.run();
+
+  TEST_LOG_EXIT_CODE(r);
+  TEST_LOG("tree.exe mydir output", r.stdout_text);
+
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_TRUE(r.stdout_text.find("mydir") != std::string::npos);
+  EXPECT_TRUE(r.stdout_text.find("file.txt") != std::string::npos);
+}


### PR DESCRIPTION
  ## Tree Command
   - Add tree command with full GNU tree compatibility
   - Support options: -a, -d, -L, -f, -I, -P, -C, -s, -t, -o
   - Implement character class wildcard matching [a-z], [0-9], [^a-z]
   - Add color-coded output matching ls command style
   - Support recursive statistics counting

   ## Wildcard Handling
   - Refactor wildcard expansion architecture
   - Add needsWildcardExpansion flag to CommandMeta
   - Introduce REGISTER_COMMAND_WILDCARD macro
   - Dispatcher expands only positional arguments, not option values
   - Follow SOLID principles (Open/Closed, Single Responsibility)

   ## Bug Fixes
   - Fix ls command: *.exe now shows only .exe files, not entire directory
   - Fix Unicode encoding issues in console output
   - Fix circular dependency in pch.h

   ## Testing
   - Add comprehensive tree unit tests
   - Enhance TempDir with mkdir() method
   - Test all wildcard patterns and edge cases

   ## Documentation
   - Update README.md and README-zh.md with tree command
   - Update version to v0.4.1 in CMakeLists.txt and scripts
   - Update command list in documentation