### PR TITLE
fix(rm,ps,ls): handle Windows reserved names, encoding & option parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ build-asan/
 build-minsize/
 build-test/
 build-profile/
+build-local/
 
 .idea/
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ irm https://dl.caomengxuan666.com/install.ps1 | iex
 | env | Print/modify environment | -i/--ignore-environment, -u NAME, -0/--null; -S/--split-string, -C/--chdir, running COMMAND [NOT SUPPORT] |
 | wc | Count lines/words/bytes | -c, -l, -w, -m, -L |
 | pwd | Print working directory | -L (logical), -P (physical) |
-| ps | Report process status | -e/-A/-a/-x (all processes), -f (full format), -l (long format), -u USER (user format), -w (wide output), --no-headers, --sort=KEY (sort by column) |
+| ps | Report process status | -e/-A/-a/-x (all processes), -f (full format), -l (long format), -u (user format), --user USER (filter by user), -w (wide output), --no-headers, --sort=KEY (sort by column) |
 | tee | Read from stdin and write to stdout and files | -a/--append, -i/--ignore-interrupts, -p/--diagnose |
 | chmod | Change file mode bits | -c/--changes, -f/--silent/--quiet, -v/--verbose, -R/--recursive, --reference |
 | date | Print or set system date/time | -d/--date, -u/--utc, +FORMAT; -s/--set [NOT SUPPORT] |

--- a/src/commands/ls.cpp
+++ b/src/commands/ls.cpp
@@ -518,7 +518,10 @@ auto print_columns(const std::vector<std::wstring> &entries,
   // "always" or any other value enables color
 
   // Get terminal width or use specified width
-  int width = ctx.get<int>("-w", 0) || ctx.get<int>("--width", 0);
+  int width = ctx.get<int>("-w", 0);
+  if (width <= 0) {
+    width = ctx.get<int>("--width", 0);
+  }
   if (width <= 0) {
     width = get_terminal_width();
   }

--- a/src/commands/ps.cpp
+++ b/src/commands/ps.cpp
@@ -52,7 +52,8 @@ auto constexpr PS_OPTIONS = std::array{
     OPTION("-a", "", "select all processes except session leaders and not associated with a terminal"),
     OPTION("-f", "", "do full-format listing"),
     OPTION("-l", "", "long format"),
-    OPTION("-u", "", "display user-oriented format", STRING_TYPE),
+    OPTION("-u", "", "display user-oriented format"),
+    OPTION("", "--user", "filter processes by user name", STRING_TYPE),
     OPTION("-x", "", "lift the BSD-style \"must have a tty\" restriction"),
     OPTION("-w", "", "wide output (do not truncate command lines)"),
     OPTION("", "--no-headers", "print no header line"),
@@ -327,8 +328,8 @@ auto build_config(const CommandContext<PS_OPTIONS.size()>& ctx)
 
   cfg.full_format = ctx.get<bool>("-f", false);
   cfg.long_format = ctx.get<bool>("-l", false);
-  cfg.user_format = !ctx.get<std::string>("-u", "").empty();
-  cfg.user_filter = ctx.get<std::string>("-u", "");
+  cfg.user_format = ctx.get<bool>("-u", false);
+  cfg.user_filter = ctx.get<std::string>("--user", "");
   cfg.wide_output = ctx.get<bool>("-w", false);
   cfg.no_headers = ctx.get<bool>("--no-headers", false);
   cfg.sort_key = ctx.get<std::string>("--sort", "");

--- a/src/commands/rm.cpp
+++ b/src/commands/rm.cpp
@@ -95,20 +95,53 @@ constexpr auto RM_OPTIONS = std::array{
 namespace rm_pipeline {
 namespace cp = core::pipeline;
 
+auto get_system_error_message(DWORD error) -> std::wstring {
+  LPWSTR raw = nullptr;
+  DWORD flags = FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM |
+                FORMAT_MESSAGE_IGNORE_INSERTS;
+  // Use English to avoid multibyte encoding issues in non-Unicode console paths
+  DWORD len = FormatMessageW(flags, nullptr, error,
+                             MAKELANGID(LANG_ENGLISH, SUBLANG_ENGLISH_US),
+                             (LPWSTR)&raw, 0, nullptr);
+  if (len == 0 || raw == nullptr) {
+    // Fallback to system default language
+    len = FormatMessageW(flags, nullptr, error,
+                         MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT),
+                         (LPWSTR)&raw, 0, nullptr);
+  }
+  if (len == 0 || raw == nullptr) {
+    return L"unknown error";
+  }
+
+  std::wstring message(raw, len);
+  LocalFree(raw);
+  while (!message.empty() &&
+         (message.back() == L'\r' || message.back() == L'\n' ||
+          message.back() == L' ' || message.back() == L'\t')) {
+    message.pop_back();
+  }
+  return message;
+}
+
 /**
- * @brief Helper function to convert wstring to UTF-8 string
- * @param wstr Wide string to convert
- * @return UTF-8 string
+ * @brief Convert a path to Windows extended-length path (\\?\) format.
+ *
+ * This bypasses reserved device name resolution (nul, con, prn, aux, com*, lpt*)
+ * and also removes the MAX_PATH limit. The path is first resolved to an
+ * absolute path via GetFullPathNameW, then prefixed with "\\?\\\\". If
+ * resolution fails the original path is returned unchanged.
  */
-auto wstringToUtf8(const std::wstring& wstr) -> std::string {
-  int size = WideCharToMultiByte(CP_UTF8, 0, wstr.c_str(), -1, nullptr, 0,
-                                 nullptr, nullptr);
-  if (size == 0) return "";
-  std::string result(size, 0);
-  WideCharToMultiByte(CP_UTF8, 0, wstr.c_str(), -1, &result[0], size, nullptr,
-                      nullptr);
-  result.pop_back();  // Remove trailing null character
-  return result;
+auto to_extended_path(const std::wstring& path) -> std::wstring {
+  // Already in extended form
+  if (path.size() >= 4 && path.compare(0, 4, L"\\\\?\\" ) == 0) {
+    return path;
+  }
+  wchar_t abs_buf[32768];
+  DWORD len = GetFullPathNameW(path.c_str(), 32768, abs_buf, nullptr);
+  if (len == 0 || len >= 32768) {
+    return path;  // fallback: use original
+  }
+  return L"\\\\?\\" + std::wstring(abs_buf, len);
 }
 
 /**
@@ -132,7 +165,10 @@ auto check_paths(const std::vector<std::string>& paths)
  */
 auto remove_path(const std::string& path,
                  const CommandContext<RM_OPTIONS.size()>& ctx) -> bool {
-  std::wstring wpath = utf8_to_wstring(path);
+  // Use extended-length path to bypass Windows reserved device names
+  // (nul, con, prn, aux, com0-9, lpt0-9) which would otherwise redirect
+  // file operations to the corresponding device instead of the actual file.
+  std::wstring wpath = to_extended_path(utf8_to_wstring(path));
   DWORD attr = GetFileAttributesW(wpath.c_str());
 
   bool force = ctx.get<bool>("--force", false) || ctx.get<bool>("-f", false);
@@ -204,11 +240,8 @@ auto remove_path(const std::string& path,
             // Delete file
             if (!DeleteFileW(itemPath.c_str())) {
               DWORD error = GetLastError();
-              char errorMsg[256];
-              FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM, NULL, error, 0,
-                             errorMsg, sizeof(errorMsg), NULL);
-              // OPTIMIZED: Direct conversion and avoid multiple conversions
               std::string itemPathStr = wstring_to_utf8(itemPath);
+              std::wstring errorMsg = get_system_error_message(error);
               safeErrorPrint("rm: cannot remove file '");
               safeErrorPrint(itemPathStr);
               safeErrorPrint("': ");
@@ -243,11 +276,8 @@ auto remove_path(const std::string& path,
       // Finally, remove the directory itself
       if (!RemoveDirectoryW(dirPath.c_str())) {
         DWORD error = GetLastError();
-        char errorMsg[256];
-        FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM, NULL, error, 0, errorMsg,
-                       sizeof(errorMsg), NULL);
-        // OPTIMIZED: Direct conversion
         std::string dirPathStr = wstring_to_utf8(dirPath);
+        std::wstring errorMsg = get_system_error_message(error);
         safeErrorPrint("rm: cannot remove directory '");
         safeErrorPrint(dirPathStr);
         safeErrorPrint("': ");
@@ -274,9 +304,7 @@ auto remove_path(const std::string& path,
     BOOL success = DeleteFileW(wpath.c_str());
     if (!success) {
       DWORD error = GetLastError();
-      char errorMsg[256];
-      FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM, NULL, error, 0, errorMsg,
-                     sizeof(errorMsg), NULL);
+      std::wstring errorMsg = get_system_error_message(error);
       // OPTIMIZED: Avoid redundant conversions
       safeErrorPrint("rm: cannot remove file '");
       safeErrorPrint(path);


### PR DESCRIPTION
## Changes

### rm: fix `rm nul` / reserved device name removal
- Add `to_extended_path()` helper that resolves paths to absolute form and prefixes them with the Win32 extended-length path prefix `\\?\`.
- Apply `to_extended_path()` in `remove_path()` before every Win32 API call (GetFileAttributesW, DeleteFileW, RemoveDirectoryW, FindFirstFileW).
- This bypasses Windows built-in reserved device name resolution so that files literally named `nul`, `con`, `prn`, `aux`, `com*`, `lpt*` can be deleted like any ordinary file. Previously these calls silently operated on the corresponding device and returned ERROR_INVALID_PARAMETER ("The parameter is incorrect.").
- As a side-effect, this fix also lifts the MAX_PATH (260-char) limit for paths handled by rm.

### rm: fix garbled error messages on Simplified-Chinese Windows (GBK consoles)
- Replace `FormatMessageW(LANG_NEUTRAL)` with an English-first strategy: try LANG_ENGLISH/SUBLANG_ENGLISH_US first, fall back to system locale only if the English message is unavailable.
- When stderr is redirected to a pipe/file, `safeErrorPrint(wstring_view)` writes UTF-8 bytes via WriteFile. CMD.exe interprets those bytes as GBK, producing mojibake for Chinese system error strings. ASCII-only English messages are unaffected by any code-page mismatch.

### ps: separate `-u` (user-format flag) from `--user` (filter option)
- `-u` was incorrectly typed as STRING_TYPE, causing it to consume the next token as a username instead of acting as a boolean display-format flag.
- Restore `-u` to a plain boolean flag (user-oriented output format) per POSIX ps.
- Add a dedicated `--user <NAME>` string option for filtering processes by owner.
- Update README.md and README-zh.md option tables accordingly.

### ls: fix `-w`/`--width` option parsing
- `ctx.get<int>("-w", 0) || ctx.get<int>("--width", 0)` evaluated as a boolean OR (always yielding 0 or 1) instead of selecting the non-zero value.
- Replace with an explicit two-step check: prefer `-w`, fall back to `--width`.

### .gitignore
- Add `build-local/` to ignored directories.