### PR TITLE
feat(completion): modular native completion DB + cached user extensions + README sync

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -41,10 +41,64 @@ irm https://dl.caomengxuan666.com/install.ps1 | iex
 5. 将 `bin` 目录加入 PATH
 
 ### 自动补全功能
-<video width="320" height="240" controls>
-    <source src="DOCS\images\autoComplete.mp4" type="video/mp4">
-</video>
-目前支持当前项目实现的命令,后续会提供原生Windows命令的补全
+![自动补全演示](DOCS/images/auto.gif)
+
+WinuxCmd 现在的补全包含：
+
+- 项目内置命令
+- Windows 系统命令（内置白名单 + 说明）
+- 常见 Windows 命令参数补全（例如：`dir`、`taskkill`、`netstat`、`findstr`、`ipconfig`）
+
+默认不再扫描 PATH 中第三方可执行文件，避免补全列表噪声。
+
+#### 用户可扩展补全（第三方命令）
+
+你可以通过文本文件自行扩展命令和参数补全。
+
+默认用户文件路径：
+
+`%USERPROFILE%\.winuxcmd\completions\user-completions.txt`
+
+也可以通过环境变量指定自定义文件：
+
+```powershell
+# 临时设置（仅当前终端）
+$env:WINUXCMD_COMPLETION_FILE = "C:\path\to\user-completions.txt"
+
+# 持久设置（当前用户）
+[Environment]::SetEnvironmentVariable(
+  "WINUXCMD_COMPLETION_FILE",
+  "C:\path\to\user-completions.txt",
+  "User"
+)
+```
+
+文件格式：
+
+```text
+# 添加命令：cmd|<command>|<description>
+cmd|git|Distributed version control
+
+# 添加参数：opt|<command>|<option>|<description>
+opt|git|pull|Fetch from and integrate with another repository
+opt|git|push|Update remote refs along with associated objects
+```
+
+参考模板：`scripts/user-completions.sample.txt`
+
+#### 补全缓存（更快启动）
+
+用户补全文本会在首次解析后生成二进制缓存文件：
+
+- 源文件：`<你的补全文件>`
+- 缓存文件：`<你的补全文件>.cache.bin`
+
+例如：
+
+- `C:\Users\<你>\.winuxcmd\completions\user-completions.txt`
+- `C:\Users\<你>\.winuxcmd\completions\user-completions.txt.cache.bin`
+
+当源文件元数据（修改时间 + 文件大小）未变化时，会直接命中缓存；源文件变化后会自动重建缓存。
 
 ### Shell 集成说明（PowerShell + CMD）
 
@@ -71,7 +125,7 @@ if ($Host.Name -eq 'ConsoleHost' -and -not $isNonInteractiveLaunch -and $env:WIN
 ```
 2. 对于 CMD，推荐使用专用启动入口：
 在Windows terminal的启动参数更改为:
-![示例](DOCS\images\WindowsTerminal.png)
+![示例](DOCS/images/WindowsTerminal.png)
 ```bat
 %SystemRoot%\System32\cmd.exe /k winuxcmd
 ```

--- a/README.md
+++ b/README.md
@@ -50,11 +50,66 @@ irm https://dl.caomengxuan666.com/install.ps1 | iex
 
 ### Auto Completion
 
-<video width="320" height="240" controls>
-    <source src="DOCS\images\autoComplete.mp4" type="video/mp4">
-</video>
+![Auto Completion Demo](DOCS/images/auto.gif)
 
-Currently supports commands implemented in this project. Native Windows command completion will be added later.
+WinuxCmd completion now includes:
+
+- Project commands implemented by WinuxCmd
+- Built-in Windows system commands (curated list with descriptions)
+- Windows option completion for common commands (for example: `dir`, `taskkill`, `netstat`, `findstr`, `ipconfig`)
+
+By default, third-party executables in PATH are not auto-listed to avoid noisy suggestions.
+
+#### User-Extensible Completion (Third-Party Commands)
+
+You can add your own command/option completions with a text file.
+
+Default user file path:
+
+`%USERPROFILE%\.winuxcmd\completions\user-completions.txt`
+
+Or set an environment variable to use a custom file:
+
+```powershell
+# Temporary (current shell only)
+$env:WINUXCMD_COMPLETION_FILE = "C:\path\to\user-completions.txt"
+
+# Persistent (current user)
+[Environment]::SetEnvironmentVariable(
+  "WINUXCMD_COMPLETION_FILE",
+  "C:\path\to\user-completions.txt",
+  "User"
+)
+```
+
+File format:
+
+```text
+# Add command: cmd|<command>|<description>
+cmd|git|Distributed version control
+
+# Add option: opt|<command>|<option>|<description>
+opt|git|pull|Fetch from and integrate with another repository
+opt|git|push|Update remote refs along with associated objects
+```
+
+Reference template:
+
+`scripts/user-completions.sample.txt`
+
+#### Completion Cache (Fast Startup)
+
+User completion text is parsed once and persisted as a binary cache:
+
+- Source file: `<your-completions-file>`
+- Cache file: `<your-completions-file>.cache.bin`
+
+Examples:
+
+- `C:\Users\<you>\.winuxcmd\completions\user-completions.txt`
+- `C:\Users\<you>\.winuxcmd\completions\user-completions.txt.cache.bin`
+
+Cache is reused when source file metadata matches (`last write time + file size`), and rebuilt automatically when the source changes.
 
 ### Shell Integration Notes (PowerShell + CMD)
 
@@ -86,7 +141,7 @@ if ($Host.Name -eq 'ConsoleHost' -and -not $isNonInteractiveLaunch -and $env:WIN
 2. For CMD, the recommended startup entry is:
 
 Set Windows Terminal startup command to:
-![Example](DOCS\images\WindowsTerminal.png)
+![Example](DOCS/images/WindowsTerminal.png)
 
 ```bat
 %SystemRoot%\System32\cmd.exe /k winuxcmd

--- a/scripts/user-completions.sample.txt
+++ b/scripts/user-completions.sample.txt
@@ -1,0 +1,22 @@
+# WinuxCmd user completion extension file
+# Copy to:
+#   %USERPROFILE%\.winuxcmd\completions\user-completions.txt
+# or set:
+#   WINUXCMD_COMPLETION_FILE=<absolute path>
+#
+# Format:
+#   cmd|<command>|<description>
+#   opt|<command>|<option>|<description>
+
+# Example third-party command
+cmd|git|Distributed version control
+opt|git|clone|Clone a repository into a new directory
+opt|git|checkout|Switch branches or restore working tree files
+opt|git|pull|Fetch from and integrate with another repository
+opt|git|push|Update remote refs along with associated objects
+
+# Example for curl
+cmd|curl|Transfer data from or to a server
+opt|curl|-I|Show response headers only
+opt|curl|-L|Follow redirects
+opt|curl|-o|Write output to file

--- a/src/Main/main.cpp
+++ b/src/Main/main.cpp
@@ -1,8 +1,8 @@
 /*
- *  Copyright © 2026 [caomengxuan666]
+ *  Copyright (c) 2026 [caomengxuan666]
  *
  *  Permission is hereby granted, free of charge, to any person obtaining a copy
- *  of this software and associated documentation files (the “Software”), to
+ *  of this software and associated documentation files (the "Software"), to
  * deal in the Software without restriction, including without limitation the
  * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
  * sell copies of the Software, and to permit persons to whom the Software is
@@ -11,7 +11,7 @@
  *  The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
  *
- *  THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
  *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
@@ -30,6 +30,66 @@ import core;
 import utils;
 import wildcard_handler;
 import readline;
+import native_completion;
+
+namespace {
+
+static std::string toLowerAscii(std::string s) {
+  std::ranges::transform(s, s.begin(), [](unsigned char c) {
+    return static_cast<char>(std::tolower(c));
+  });
+  return s;
+}
+
+static bool startsWithCaseInsensitive(std::string_view text,
+                                      std::string_view prefix) {
+  if (prefix.size() > text.size()) return false;
+  for (size_t i = 0; i < prefix.size(); ++i) {
+    unsigned char a = static_cast<unsigned char>(text[i]);
+    unsigned char b = static_cast<unsigned char>(prefix[i]);
+    if (std::tolower(a) != std::tolower(b)) return false;
+  }
+  return true;
+}
+
+static std::vector<CompletionItem>
+getCommandCompletions(std::string_view prefix) {
+  std::vector<CompletionItem> items;
+  auto all = CommandRegistry::getAllCommands();
+  items.reserve(all.size() + 64);
+
+  std::unordered_set<std::string> seen;
+  seen.reserve(all.size() * 2 + 128);
+
+  for (auto &[name, desc] : all) {
+    if (!startsWithCaseInsensitive(name, prefix)) continue;
+    std::string key(name);
+    if (seen.insert(toLowerAscii(key)).second)
+      items.push_back({std::move(key), std::string(desc)});
+  }
+
+  auto native = queryNativeCommandCompletions(prefix);
+  for (const auto &item : native) {
+    if (seen.insert(toLowerAscii(item.text)).second)
+      items.push_back({item.text, item.hint});
+  }
+
+  std::ranges::sort(items, {}, &CompletionItem::text);
+  return items;
+}
+
+static std::vector<CompletionItem>
+getWindowsOptionCompletions(std::string_view cmd_name, std::string_view prefix) {
+  std::vector<CompletionItem> items;
+  auto native = queryNativeOptionCompletions(cmd_name, prefix);
+  items.reserve(native.size());
+  for (const auto &item : native) {
+    items.push_back({item.text, item.hint});
+  }
+  return items;
+}
+
+}  // namespace
 
 /**
  * @brief Print help information
@@ -96,54 +156,69 @@ static int runNativeFallback(const std::string &line) noexcept {
   return static_cast<int>(exit_code);
 }
 
-// ─────────────────────────────────────────────────────────────────────────────
+// -----------------------------------------------------------------------------
 // Interactive REPL
-// ─────────────────────────────────────────────────────────────────────────────
+// -----------------------------------------------------------------------------
 
 /// Build a completer function that suggests command names (prefix match) and
 /// command options (after a space).
 static Completer makeCompleter() {
   return [](std::string_view input) -> std::vector<CompletionItem> {
-    // Find the first space to decide whether we're completing a command name
-    // or an option for an already-typed command.
-    auto space = input.find(' ');
+    // Complete only the segment after the last pipe.
+    std::string full_input(input);
+    size_t      seg_start = 0;
+    if (auto pipe_pos = full_input.rfind('|'); pipe_pos != std::string::npos) {
+      seg_start = pipe_pos + 1;
+      while (seg_start < full_input.size() && full_input[seg_start] == ' ')
+        ++seg_start;
+    }
 
-    if (space == std::string_view::npos) {
-      // ── Complete command name ──
-      auto all = CommandRegistry::getAllCommands();
-      std::vector<CompletionItem> items;
-      for (auto &[name, desc] : all) {
-        if (name.starts_with(input))
-          items.push_back({std::string(name), std::string(desc)});
-      }
-      std::ranges::sort(items, {}, &CompletionItem::text);
+    std::string prefix_before = full_input.substr(0, seg_start);
+    std::string segment = full_input.substr(seg_start);
+    auto        space = segment.find(' ');
+
+    if (space == std::string::npos) {
+      auto items = getCommandCompletions(segment);
+      for (auto &item : items) item.text = prefix_before + item.text;
       return items;
     }
 
-    // ── Complete option for a known command ──
-    std::string_view cmd_name  = input.substr(0, space);
-    std::string_view opt_input = input.substr(space + 1);
-    // Skip extra spaces
-    while (!opt_input.empty() && opt_input.front() == ' ')
-      opt_input.remove_prefix(1);
+    std::string cmd_name = segment.substr(0, space);
+    std::string rest = segment.substr(space + 1);
+    while (!rest.empty() && rest.front() == ' ')
+      rest.erase(rest.begin());
 
-    auto opts = CommandRegistry::getCommandOptions(cmd_name);
+    size_t token_start_in_rest = 0;
+    if (auto pos = rest.find_last_of(" \t"); pos != std::string::npos)
+      token_start_in_rest = pos + 1;
+    std::string current_token = rest.substr(token_start_in_rest);
+
+    auto buildFullText = [&](std::string_view replacement) {
+      std::string replaced = segment.substr(0, space + 1);
+      replaced += rest.substr(0, token_start_in_rest);
+      replaced += replacement;
+      return prefix_before + replaced;
+    };
+
     std::vector<CompletionItem> items;
-
+    auto opts = CommandRegistry::getCommandOptions(cmd_name);
     for (auto &opt : opts) {
-      // Check both short and long forms
       for (const std::string *form : {&opt.short_name, &opt.long_name}) {
         if (form->empty()) continue;
-        if (opt_input.empty() || form->starts_with(opt_input)) {
-          std::string full = std::string(cmd_name) + " " + *form;
-          items.push_back({std::move(full), opt.description});
+        if (current_token.empty() || form->starts_with(current_token)) {
+          items.push_back({buildFullText(*form), opt.description});
         }
       }
+    }
+    if (!items.empty()) return items;
+
+    auto nativeOpts = getWindowsOptionCompletions(cmd_name, current_token);
+    for (auto &opt : nativeOpts) {
+      items.push_back({buildFullText(opt.text), opt.hint});
     }
     return items;
   };
 }
-
 /// Run WinuxCmd in interactive REPL mode.
 static void runReplMode() noexcept {
   safePrintLn(
@@ -229,23 +304,19 @@ int main(int argc, char *argv[]) noexcept {
       return printHelp();
     }
 
-    // ── Machine-readable completion query: winuxcmd --complete-cmd [prefix] ──
+    // Machine-readable completion query: winuxcmd --complete-cmd [prefix]
     if (args[0] == "--complete-cmd") {
       std::string_view prefix = args.size() >= 2 ? args[1] : "";
-      auto all = CommandRegistry::getAllCommands();
-      std::vector<std::pair<std::string_view, std::string_view>> sorted(all.begin(), all.end());
-      std::ranges::sort(sorted, {}, [](const auto &p) { return p.first; });
-      for (auto &[name, desc] : sorted) {
-        if (name.starts_with(prefix)) {
-          safePrint(name);
-          safePrint("\t");
-          safePrintLn(desc);
-        }
+      auto items = getCommandCompletions(prefix);
+      for (const auto &item : items) {
+        safePrint(item.text);
+        safePrint("\t");
+        safePrintLn(item.hint);
       }
       return 0;
     }
 
-    // ── Machine-readable option query: winuxcmd --complete-opt <cmd> [prefix] ──
+    // Machine-readable option query: winuxcmd --complete-opt <cmd> [prefix]
     if (args[0] == "--complete-opt" && args.size() >= 2) {
       std::string_view cmd    = args[1];
       std::string_view prefix = args.size() >= 3 ? args[2] : "";
@@ -258,6 +329,14 @@ int main(int argc, char *argv[]) noexcept {
             safePrint("\t");
             safePrintLn(opt.description);
           }
+        }
+      }
+      if (opts.empty()) {
+        auto items = getWindowsOptionCompletions(cmd, prefix);
+        for (const auto& item : items) {
+          safePrint(item.text);
+          safePrint("\t");
+          safePrintLn(item.hint);
         }
       }
       return 0;

--- a/src/Main/main.cpp
+++ b/src/Main/main.cpp
@@ -148,7 +148,11 @@ static int runNativeFallback(const std::string &line) noexcept {
     return 127;
   }
 
+  // While waiting for native child process, ignore Ctrl+C in parent so only
+  // the child (e.g. ping) handles the interrupt and winuxcmd REPL survives.
+  SetConsoleCtrlHandler(nullptr, TRUE);
   WaitForSingleObject(pi.hProcess, INFINITE);
+  SetConsoleCtrlHandler(nullptr, FALSE);
   DWORD exit_code = 0;
   GetExitCodeProcess(pi.hProcess, &exit_code);
   CloseHandle(pi.hThread);
@@ -224,7 +228,7 @@ static void runReplMode() noexcept {
   safePrintLn(
       L"WinuxCmd " + utf8_to_wstring(std::string("0.4.5")) +
       L"  (interactive)  Type 'exit' to quit, '--help' for command list.");
-  safePrintLn(L"Use \u2191\u2193 arrows or Tab to navigate completions.\n");
+  safePrintLn(L"Use Tab for completions; \u2191\u2193 for history; \u2190\u2192 to move cursor.\n");
 
   auto completer = makeCompleter();
 

--- a/src/Main/native_completion.cppm
+++ b/src/Main/native_completion.cppm
@@ -1,0 +1,411 @@
+/*
+ *  Copyright (c) 2026 [caomengxuan666]
+ *  @author [arookieofc] <2128194521@qq.com>
+ */
+export module native_completion;
+
+import std;
+
+export struct NativeCompletionItem {
+  std::string text;
+  std::string hint;
+};
+
+namespace {
+
+struct UserOptionItem {
+  std::string command_lower;
+  std::string option;
+  std::string hint;
+};
+
+struct UserCompletionData {
+  std::vector<NativeCompletionItem> commands;
+  std::vector<UserOptionItem>       options;
+};
+
+struct BuiltinOptionDef {
+  std::string_view command;
+  std::string_view option;
+  std::string_view hint;
+};
+
+constexpr std::pair<std::string_view, std::string_view> kBuiltinCommands[] = {
+    {"arp", "Display and modify ARP cache"},
+    {"assoc", "Display or modify file extension associations"},
+    {"attrib", "Display or change file attributes"},
+    {"bcdedit", "Manage boot configuration data"},
+    {"cd", "Change current directory"},
+    {"chcp", "Display or set active code page"},
+    {"chkdsk", "Check a disk and display status report"},
+    {"cls", "Clear screen"},
+    {"copy", "Copy one or more files"},
+    {"date", "Display or set system date"},
+    {"del", "Delete one or more files"},
+    {"dir", "List files and directories"},
+    {"diskpart", "Disk partition management"},
+    {"driverquery", "Display installed device drivers"},
+    {"echo", "Display text"},
+    {"findstr", "Search for strings in files"},
+    {"hostname", "Display host name"},
+    {"ipconfig", "Display and manage IP configuration"},
+    {"mklink", "Create symbolic links"},
+    {"move", "Move files"},
+    {"net", "Network and service management command set"},
+    {"netsh", "Network configuration shell"},
+    {"netstat", "Display network connections and ports"},
+    {"pathping", "Trace route and packet loss"},
+    {"ping", "Send ICMP echo requests"},
+    {"powercfg", "Power settings management"},
+    {"reg", "Registry query and edit tool"},
+    {"ren", "Rename files"},
+    {"robocopy", "Robust file copy utility"},
+    {"route", "Display and modify routing table"},
+    {"sfc", "System file checker"},
+    {"shutdown", "Shutdown or restart computer"},
+    {"start", "Start a program or command"},
+    {"systeminfo", "Display OS and hardware information"},
+    {"taskkill", "Terminate processes"},
+    {"tasklist", "Display running processes"},
+    {"time", "Display or set system time"},
+    {"tree", "Display directory tree"},
+    {"type", "Display text file contents"},
+    {"where", "Locate files in PATH"},
+    {"whoami", "Display current user info"},
+    {"xcopy", "Copy files and directory trees"},
+};
+
+constexpr BuiltinOptionDef kBuiltinOptions[] = {
+    {"dir", "/a", "Show files with specified attributes"},
+    {"dir", "/b", "Bare format (no heading/summary)"},
+    {"dir", "/o", "Sort order (n/e/s/d/g/-)"},
+    {"dir", "/s", "Include subdirectories"},
+    {"dir", "/p", "Pause after each screen"},
+    {"dir", "/w", "Wide list format"},
+    {"copy", "/a", "Treat source/destination as ASCII"},
+    {"copy", "/b", "Treat source/destination as binary"},
+    {"copy", "/v", "Verify written files"},
+    {"copy", "/y", "Suppress overwrite confirmation"},
+    {"copy", "/-y", "Force overwrite confirmation"},
+    {"del", "/p", "Prompt before deleting each file"},
+    {"del", "/f", "Force delete read-only files"},
+    {"del", "/s", "Delete matching files in subdirectories"},
+    {"del", "/q", "Quiet mode"},
+    {"xcopy", "/s", "Copy directories and subdirectories except empty"},
+    {"xcopy", "/e", "Copy all subdirectories including empty"},
+    {"xcopy", "/y", "Suppress overwrite prompt"},
+    {"xcopy", "/i", "Assume destination is directory"},
+    {"xcopy", "/d", "Copy files changed on/after date"},
+    {"xcopy", "/h", "Copy hidden/system files"},
+    {"robocopy", "/e", "Copy subdirectories including empty"},
+    {"robocopy", "/mir", "Mirror a complete directory tree"},
+    {"robocopy", "/xo", "Exclude older files"},
+    {"robocopy", "/xn", "Exclude newer files"},
+    {"robocopy", "/mt", "Multi-threaded copy"},
+    {"robocopy", "/r", "Retry count for failed copies"},
+    {"robocopy", "/w", "Wait time between retries"},
+    {"tasklist", "/fi", "Filter with condition"},
+    {"tasklist", "/fo", "Output format TABLE/LIST/CSV"},
+    {"tasklist", "/nh", "No header"},
+    {"tasklist", "/v", "Verbose output"},
+    {"tasklist", "/svc", "Show hosted services"},
+    {"taskkill", "/pid", "Terminate by process ID"},
+    {"taskkill", "/im", "Terminate by image name"},
+    {"taskkill", "/f", "Force termination"},
+    {"taskkill", "/t", "Terminate child process tree"},
+    {"taskkill", "/fi", "Apply filter"},
+    {"where", "/r", "Recursive search from root"},
+    {"where", "/q", "Quiet mode"},
+    {"findstr", "/i", "Case-insensitive search"},
+    {"findstr", "/n", "Show line numbers"},
+    {"findstr", "/r", "Use regular expressions"},
+    {"findstr", "/s", "Search matching files in current dir and subdirs"},
+    {"ping", "-t", "Ping until stopped"},
+    {"ping", "-n", "Number of echo requests"},
+    {"ping", "-l", "Send buffer size"},
+    {"ping", "-w", "Timeout in milliseconds"},
+    {"ping", "-4", "Force IPv4"},
+    {"ping", "-6", "Force IPv6"},
+    {"ipconfig", "/all", "Full configuration details"},
+    {"ipconfig", "/release", "Release IPv4 address"},
+    {"ipconfig", "/renew", "Renew IPv4 address"},
+    {"ipconfig", "/flushdns", "Flush DNS resolver cache"},
+    {"ipconfig", "/displaydns", "Display DNS resolver cache"},
+    {"netstat", "-a", "Display all active connections and listening ports"},
+    {"netstat", "-n", "Show addresses and port numbers numerically"},
+    {"netstat", "-o", "Show owning process ID"},
+    {"netstat", "-b", "Show executable involved in each connection"},
+    {"netstat", "-r", "Display routing table"},
+};
+
+constexpr uint32_t kCacheMagic   = 0x57434331u;  // WCC1
+constexpr uint32_t kCacheVersion = 1u;
+
+static std::string toLowerAscii(std::string s) {
+  std::ranges::transform(s, s.begin(), [](unsigned char c) {
+    return static_cast<char>(std::tolower(c));
+  });
+  return s;
+}
+
+static bool startsWithCaseInsensitive(std::string_view text,
+                                      std::string_view prefix) {
+  if (prefix.size() > text.size()) return false;
+  for (size_t i = 0; i < prefix.size(); ++i) {
+    unsigned char a = static_cast<unsigned char>(text[i]);
+    unsigned char b = static_cast<unsigned char>(prefix[i]);
+    if (std::tolower(a) != std::tolower(b)) return false;
+  }
+  return true;
+}
+
+static bool equalsCaseInsensitive(std::string_view a, std::string_view b) {
+  if (a.size() != b.size()) return false;
+  return startsWithCaseInsensitive(a, b);
+}
+
+static std::string trimAscii(std::string s) {
+  auto is_ws = [](unsigned char c) {
+    return c == ' ' || c == '\t' || c == '\r' || c == '\n';
+  };
+  while (!s.empty() && is_ws(static_cast<unsigned char>(s.front())))
+    s.erase(s.begin());
+  while (!s.empty() && is_ws(static_cast<unsigned char>(s.back())))
+    s.pop_back();
+  return s;
+}
+
+static std::vector<std::string> splitString(std::string_view s, char delimiter) {
+  std::vector<std::string> out;
+  size_t                   pos = 0;
+  while (pos <= s.size()) {
+    size_t next = s.find(delimiter, pos);
+    if (next == std::string_view::npos) next = s.size();
+    out.emplace_back(s.substr(pos, next - pos));
+    if (next == s.size()) break;
+    pos = next + 1;
+  }
+  return out;
+}
+
+static std::filesystem::path getUserCompletionFilePath() {
+  const char* overridePath = std::getenv("WINUXCMD_COMPLETION_FILE");
+  if (overridePath && *overridePath) {
+    return std::filesystem::path(overridePath);
+  }
+  const char* userProfile = std::getenv("USERPROFILE");
+  if (!userProfile || !*userProfile) return {};
+  return std::filesystem::path(userProfile) / ".winuxcmd" / "completions" /
+         "user-completions.txt";
+}
+
+static std::filesystem::path getUserCompletionCachePath(
+    const std::filesystem::path& sourcePath) {
+  auto p = sourcePath;
+  p += ".cache.bin";
+  return p;
+}
+
+static bool writeString(std::ofstream& out, const std::string& s) {
+  uint32_t len = static_cast<uint32_t>(s.size());
+  out.write(reinterpret_cast<const char*>(&len), sizeof(len));
+  if (!out.good()) return false;
+  if (len > 0) out.write(s.data(), len);
+  return out.good();
+}
+
+static bool readString(std::ifstream& in, std::string& s) {
+  uint32_t len = 0;
+  in.read(reinterpret_cast<char*>(&len), sizeof(len));
+  if (!in.good()) return false;
+  s.resize(len);
+  if (len > 0) in.read(s.data(), len);
+  return in.good();
+}
+
+static UserCompletionData parseUserCompletionFile(
+    const std::filesystem::path& path) {
+  UserCompletionData data;
+  std::ifstream      in(path);
+  if (!in.is_open()) return data;
+
+  std::string line;
+  while (std::getline(in, line)) {
+    line = trimAscii(line);
+    if (line.empty() || line.starts_with('#')) continue;
+
+    auto parts = splitString(line, '|');
+    for (auto& p : parts) p = trimAscii(std::move(p));
+    if (parts.empty()) continue;
+
+    std::string kind = toLowerAscii(parts[0]);
+    if (kind == "cmd" && parts.size() >= 3) {
+      data.commands.push_back({parts[1], parts[2]});
+    } else if (kind == "opt" && parts.size() >= 4) {
+      data.options.push_back({toLowerAscii(parts[1]), parts[2], parts[3]});
+    }
+  }
+  return data;
+}
+
+static bool loadUserCompletionCache(const std::filesystem::path& cachePath,
+                                    uint64_t expectedMtime,
+                                    uint64_t expectedSize,
+                                    UserCompletionData& out) {
+  std::ifstream in(cachePath, std::ios::binary);
+  if (!in.is_open()) return false;
+
+  uint32_t magic = 0, version = 0;
+  uint64_t sourceMtime = 0, sourceSize = 0;
+  uint32_t cmdCount = 0, optCount = 0;
+  in.read(reinterpret_cast<char*>(&magic), sizeof(magic));
+  in.read(reinterpret_cast<char*>(&version), sizeof(version));
+  in.read(reinterpret_cast<char*>(&sourceMtime), sizeof(sourceMtime));
+  in.read(reinterpret_cast<char*>(&sourceSize), sizeof(sourceSize));
+  in.read(reinterpret_cast<char*>(&cmdCount), sizeof(cmdCount));
+  in.read(reinterpret_cast<char*>(&optCount), sizeof(optCount));
+  if (!in.good()) return false;
+  if (magic != kCacheMagic || version != kCacheVersion) return false;
+  if (sourceMtime != expectedMtime || sourceSize != expectedSize) return false;
+
+  out = {};
+  out.commands.reserve(cmdCount);
+  out.options.reserve(optCount);
+
+  for (uint32_t i = 0; i < cmdCount; ++i) {
+    std::string c, h;
+    if (!readString(in, c) || !readString(in, h)) return false;
+    out.commands.push_back({std::move(c), std::move(h)});
+  }
+  for (uint32_t i = 0; i < optCount; ++i) {
+    std::string c, o, h;
+    if (!readString(in, c) || !readString(in, o) || !readString(in, h))
+      return false;
+    out.options.push_back(
+        {toLowerAscii(std::move(c)), std::move(o), std::move(h)});
+  }
+
+  return true;
+}
+
+static void saveUserCompletionCache(const std::filesystem::path& cachePath,
+                                    uint64_t sourceMtime,
+                                    uint64_t sourceSize,
+                                    const UserCompletionData& data) {
+  std::error_code ec;
+  std::filesystem::create_directories(cachePath.parent_path(), ec);
+  if (ec) return;
+
+  auto tmpPath = cachePath;
+  tmpPath += ".tmp";
+
+  std::ofstream out(tmpPath, std::ios::binary | std::ios::trunc);
+  if (!out.is_open()) return;
+
+  uint32_t magic = kCacheMagic;
+  uint32_t version = kCacheVersion;
+  uint32_t cmdCount = static_cast<uint32_t>(data.commands.size());
+  uint32_t optCount = static_cast<uint32_t>(data.options.size());
+  out.write(reinterpret_cast<const char*>(&magic), sizeof(magic));
+  out.write(reinterpret_cast<const char*>(&version), sizeof(version));
+  out.write(reinterpret_cast<const char*>(&sourceMtime), sizeof(sourceMtime));
+  out.write(reinterpret_cast<const char*>(&sourceSize), sizeof(sourceSize));
+  out.write(reinterpret_cast<const char*>(&cmdCount), sizeof(cmdCount));
+  out.write(reinterpret_cast<const char*>(&optCount), sizeof(optCount));
+
+  for (const auto& c : data.commands) {
+    if (!writeString(out, c.text) || !writeString(out, c.hint)) return;
+  }
+  for (const auto& o : data.options) {
+    if (!writeString(out, o.command_lower) || !writeString(out, o.option) ||
+        !writeString(out, o.hint))
+      return;
+  }
+  out.flush();
+  if (!out.good()) return;
+  out.close();
+
+  std::filesystem::rename(tmpPath, cachePath, ec);
+  if (ec) std::filesystem::remove(tmpPath, ec);
+}
+
+static UserCompletionData loadUserCompletionDataFromCacheOrText() {
+  UserCompletionData data;
+  auto               sourcePath = getUserCompletionFilePath();
+  if (sourcePath.empty()) return data;
+
+  std::error_code ec;
+  if (!std::filesystem::exists(sourcePath, ec) || ec) return data;
+
+  auto sourceSize = std::filesystem::file_size(sourcePath, ec);
+  if (ec) return data;
+  auto sourceMtimeRaw = std::filesystem::last_write_time(sourcePath, ec);
+  if (ec) return data;
+  uint64_t sourceMtime =
+      static_cast<uint64_t>(sourceMtimeRaw.time_since_epoch().count());
+  uint64_t sourceSize64 = static_cast<uint64_t>(sourceSize);
+
+  auto cachePath = getUserCompletionCachePath(sourcePath);
+  if (loadUserCompletionCache(cachePath, sourceMtime, sourceSize64, data)) {
+    return data;
+  }
+
+  data = parseUserCompletionFile(sourcePath);
+  saveUserCompletionCache(cachePath, sourceMtime, sourceSize64, data);
+  return data;
+}
+
+static const UserCompletionData& getUserCompletionData() {
+  static const UserCompletionData data = loadUserCompletionDataFromCacheOrText();
+  return data;
+}
+
+}  // namespace
+
+export std::vector<NativeCompletionItem>
+queryNativeCommandCompletions(std::string_view prefix) noexcept {
+  std::vector<NativeCompletionItem> items;
+  std::unordered_set<std::string>   seenLower;
+  seenLower.reserve(128);
+
+  auto tryAdd = [&](std::string_view cmd, std::string_view hint) {
+    if (!startsWithCaseInsensitive(cmd, prefix)) return;
+    std::string key = toLowerAscii(std::string(cmd));
+    if (!seenLower.insert(key).second) return;
+    items.push_back({std::string(cmd), std::string(hint)});
+  };
+
+  for (const auto& [cmd, hint] : kBuiltinCommands) tryAdd(cmd, hint);
+  for (const auto& c : getUserCompletionData().commands) tryAdd(c.text, c.hint);
+
+  std::ranges::sort(items, {}, &NativeCompletionItem::text);
+  return items;
+}
+
+export std::vector<NativeCompletionItem>
+queryNativeOptionCompletions(std::string_view command,
+                             std::string_view prefix) noexcept {
+  std::vector<NativeCompletionItem> items;
+  std::unordered_set<std::string>   seenLower;
+  seenLower.reserve(64);
+
+  std::string commandLower = toLowerAscii(std::string(command));
+  auto tryAdd = [&](std::string_view opt, std::string_view hint) {
+    if (!startsWithCaseInsensitive(opt, prefix)) return;
+    std::string key = toLowerAscii(std::string(opt));
+    if (!seenLower.insert(key).second) return;
+    items.push_back({std::string(opt), std::string(hint)});
+  };
+
+  for (const auto& def : kBuiltinOptions) {
+    if (equalsCaseInsensitive(def.command, commandLower))
+      tryAdd(def.option, def.hint);
+  }
+  for (const auto& o : getUserCompletionData().options) {
+    if (o.command_lower == commandLower) tryAdd(o.option, o.hint);
+  }
+
+  std::ranges::sort(items, {}, &NativeCompletionItem::text);
+  return items;
+}
+

--- a/src/Main/readline.cppm
+++ b/src/Main/readline.cppm
@@ -62,6 +62,22 @@ struct RenderState {
   int   prev_lines = 0;     // how many completion rows were drawn last time
 };
 
+// Move to the previous UTF-8 code-point boundary.
+size_t prevUtf8Pos(const std::string& s, size_t pos) noexcept {
+  if (pos == 0) return 0;
+  size_t i = pos - 1;
+  while (i > 0 && (static_cast<unsigned char>(s[i]) & 0xC0) == 0x80) --i;
+  return i;
+}
+
+// Move to the next UTF-8 code-point boundary.
+size_t nextUtf8Pos(const std::string& s, size_t pos) noexcept {
+  if (pos >= s.size()) return s.size();
+  size_t i = pos + 1;
+  while (i < s.size() && (static_cast<unsigned char>(s[i]) & 0xC0) == 0x80) ++i;
+  return i;
+}
+
 void scrollUp(HANDLE hOut, SHORT width, SHORT height, SHORT lines,
               WORD fillAttr) noexcept {
   if (lines <= 0 || width <= 0 || height <= 0) return;
@@ -106,7 +122,7 @@ void writeAt(HANDLE hOut, COORD pos, const std::wstring& text,
 
 // Redraw the input line and the completion popup.
 void redraw(HANDLE hOut, RenderState& state, const std::string& buffer,
-            const std::vector<CompletionItem>& completions,
+            size_t cursor_bytes, const std::vector<CompletionItem>& completions,
             int selected) noexcept {
   CONSOLE_SCREEN_BUFFER_INFO csbi;
   GetConsoleScreenBufferInfo(hOut, &csbi);
@@ -151,15 +167,7 @@ void redraw(HANDLE hOut, RenderState& state, const std::string& buffer,
     }
   }
 
-  // ── 4. Save the cursor position (this is the user's editing caret) ──
-  COORD caretPos;
-  {
-    CONSOLE_SCREEN_BUFFER_INFO tmp;
-    GetConsoleScreenBufferInfo(hOut, &tmp);
-    caretPos = tmp.dwCursorPosition;
-  }
-
-  // ── 5. Draw completions ──
+  // ── 4. Draw completions ──
   int available = H - state.input_start.Y - 1;
   int count = std::min({(int)completions.size(), MAX_COMPLETIONS, available});
 
@@ -184,8 +192,17 @@ void redraw(HANDLE hOut, RenderState& state, const std::string& buffer,
 
   state.prev_lines = count;
 
-  // ── 6. Restore caret ──
-  moveTo(hOut, caretPos.X, caretPos.Y);
+  // ── 5. Restore caret to the requested UTF-8 cursor position ──
+  moveTo(hOut, state.input_start.X, state.input_start.Y);
+  {
+    std::string  prefix = buffer.substr(0, std::min(cursor_bytes, buffer.size()));
+    std::wstring wprefix = utf8_to_wstring(prefix);
+    if (!wprefix.empty()) {
+      DWORD written = 0;
+      WriteConsoleW(hOut, wprefix.c_str(), (DWORD)wprefix.size(), &written,
+                    nullptr);
+    }
+  }
 }
 
 }  // namespace
@@ -224,9 +241,12 @@ export std::string readInteractiveLine(const std::wstring& prompt,
   // Raw-ish key input: keep most existing flags and only disable line/echo
   // buffering so we can process keys while preserving host behavior.
   DWORD inModeInteractive = inModeOrig;
-  inModeInteractive &= ~(ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT);
+  // Disable processed input so Ctrl+C is delivered as a key event instead of
+  // a process-level CTRL_C_EVENT that terminates winuxcmd.
+  inModeInteractive &= ~(ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT |
+                         ENABLE_PROCESSED_INPUT);
   inModeInteractive |= (ENABLE_EXTENDED_FLAGS | ENABLE_WINDOW_INPUT |
-                        ENABLE_MOUSE_INPUT | ENABLE_PROCESSED_INPUT);
+                        ENABLE_MOUSE_INPUT);
   SetConsoleMode(hIn, inModeInteractive);
   // Enable virtual-terminal processing so ANSI codes work in the host.
   SetConsoleMode(hOut, outModeOrig | ENABLE_VIRTUAL_TERMINAL_PROCESSING);
@@ -247,8 +267,37 @@ export std::string readInteractiveLine(const std::wstring& prompt,
   }
 
   std::string                buffer;
+  size_t                     cursor = 0;
   int                        selected = -1;
   std::vector<CompletionItem> completions;
+  static std::vector<std::string> history;
+  std::optional<size_t>      history_index;
+  std::string                history_draft;
+  auto historyUp = [&]() {
+    if (history.empty()) return;
+    if (!history_index.has_value()) {
+      history_draft = buffer;
+      history_index = history.size();
+    }
+    if (*history_index > 0) {
+      --(*history_index);
+      buffer = history[*history_index];
+      cursor = buffer.size();
+      selected = -1;
+    }
+  };
+  auto historyDown = [&]() {
+    if (!history_index.has_value()) return;
+    if (*history_index + 1 < history.size()) {
+      ++(*history_index);
+      buffer = history[*history_index];
+    } else {
+      history_index.reset();
+      buffer = history_draft;
+    }
+    cursor = buffer.size();
+    selected = -1;
+  };
 
   // ── Main input loop ──
   while (true) {
@@ -258,7 +307,7 @@ export std::string readInteractiveLine(const std::wstring& prompt,
     else
       completions.clear();
 
-    redraw(hOut, state, buffer, completions, selected);
+    redraw(hOut, state, buffer, cursor, completions, selected);
 
     // Read one raw input event.
     INPUT_RECORD ir;
@@ -279,10 +328,16 @@ export std::string readInteractiveLine(const std::wstring& prompt,
     if (vk == VK_RETURN) {
       if (selected >= 0 && selected < (int)completions.size())
         buffer = completions[selected].text;
+      cursor = buffer.size();
       // Clear popup, advance to next line.
-      redraw(hOut, state, buffer, {}, -1);
+      redraw(hOut, state, buffer, cursor, {}, -1);
       DWORD written = 0;
       WriteConsoleW(hOut, L"\r\n", 2, &written, nullptr);
+      bool has_non_ws = std::ranges::any_of(buffer, [](unsigned char c) {
+        return c != ' ' && c != '\t' && c != '\r' && c != '\n';
+      });
+      if (has_non_ws && (history.empty() || history.back() != buffer))
+        history.push_back(buffer);
       break;
     }
 
@@ -292,25 +347,47 @@ export std::string readInteractiveLine(const std::wstring& prompt,
       continue;
     }
 
-    // ── Arrow up: move selection up ──
+    // ── Arrow up: completion selection OR history ──
     if (vk == VK_UP) {
-      if (!completions.empty()) {
-        if (selected <= 0)
-          selected = (int)completions.size() - 1;
-        else
-          --selected;
+      if (!completions.empty() && selected > 0) {
+        --selected;
+      } else if (!completions.empty() && selected == 0) {
+        // Leaving completion list from top falls back to history behavior.
+        selected = -1;
+        historyUp();
+      } else {
+        historyUp();
       }
       continue;
     }
 
-    // ── Arrow down: move selection down ──
+    // ── Arrow down: enter/continue completion selection OR history ──
     if (vk == VK_DOWN) {
       if (!completions.empty()) {
-        if (selected < 0 || selected >= (int)completions.size() - 1)
+        if (selected < 0)
           selected = 0;
-        else
+        else if (selected < (int)completions.size() - 1)
           ++selected;
+        else {
+          // Leaving completion list from bottom falls back to history.
+          selected = -1;
+          historyDown();
+        }
+      } else {
+        historyDown();
       }
+      continue;
+    }
+
+    // ── Arrow left / right: move caret inside line ──
+    if (vk == VK_LEFT) {
+      cursor = prevUtf8Pos(buffer, cursor);
+      selected = -1;
+      continue;
+    }
+    if (vk == VK_RIGHT) {
+      cursor = nextUtf8Pos(buffer, cursor);
+      selected = -1;
       continue;
     }
 
@@ -319,19 +396,21 @@ export std::string readInteractiveLine(const std::wstring& prompt,
       if (!completions.empty()) {
         int idx = (selected >= 0) ? selected : 0;
         buffer  = completions[idx].text + " ";
+        cursor = buffer.size();
         selected = -1;
+        history_index.reset();
       }
       continue;
     }
 
     // ── Backspace ──
     if (vk == VK_BACK) {
-      if (!buffer.empty()) {
-        // Strip the last UTF-8 code-point (handle multi-byte sequences).
-        while (!buffer.empty() && (buffer.back() & 0xC0) == 0x80)
-          buffer.pop_back();
-        if (!buffer.empty()) buffer.pop_back();
+      if (!buffer.empty() && cursor > 0) {
+        size_t prev = prevUtf8Pos(buffer, cursor);
+        buffer.erase(prev, cursor - prev);
+        cursor = prev;
         selected = -1;
+        history_index.reset();
       }
       continue;
     }
@@ -339,7 +418,7 @@ export std::string readInteractiveLine(const std::wstring& prompt,
     // ── Ctrl+C: abort ──
     if (vk == 'C' &&
         (ctrl & (LEFT_CTRL_PRESSED | RIGHT_CTRL_PRESSED))) {
-      redraw(hOut, state, "", {}, -1);
+      redraw(hOut, state, "", 0, {}, -1);
       DWORD written = 0;
       WriteConsoleW(hOut, L"^C\r\n", 4, &written, nullptr);
       SetConsoleMode(hIn, inModeOrig);
@@ -351,7 +430,7 @@ export std::string readInteractiveLine(const std::wstring& prompt,
     if (vk == 'D' &&
         (ctrl & (LEFT_CTRL_PRESSED | RIGHT_CTRL_PRESSED))) {
       if (buffer.empty()) {
-        redraw(hOut, state, "", {}, -1);
+        redraw(hOut, state, "", 0, {}, -1);
         DWORD written = 0;
         WriteConsoleW(hOut, L"\r\n", 2, &written, nullptr);
         SetConsoleMode(hIn, inModeOrig);
@@ -367,8 +446,10 @@ export std::string readInteractiveLine(const std::wstring& prompt,
       char mb[4] = {};
       int  len =
           WideCharToMultiByte(CP_UTF8, 0, &ch, 1, mb, 4, nullptr, nullptr);
-      for (int i = 0; i < len; ++i) buffer += mb[i];
+      buffer.insert(cursor, mb, static_cast<size_t>(len));
+      cursor += static_cast<size_t>(len);
       selected = -1;
+      history_index.reset();
       continue;
     }
   }


### PR DESCRIPTION
Summary
This PR refactors completion to keep WinuxCmd aligned with our core goals: small, fast, and low-memory. improves interactive REPL usability by implementing dual-mode arrow key behavior and fixing Ctrl+C interruption issues.

It moves native completion data out of main.cpp, adds cached user extension loading, and updates docs (EN/ZH) to match the new behavior.

What Changed
Added new module: src/Main/native_completion.cppm
Compiled-in static completion tables for curated Windows system commands and common options
Public query APIs used by REPL and machine-readable completion endpoints
Slimmed src/Main/main.cpp
Delegates native command/option completion lookup to native_completion
Keeps orchestration and interactive logic only
Added user extension caching
Source file: user-completions.txt (default path or env override)
Cache file: <source>.cache.bin
Rebuild condition: source metadata changed (last_write_time + file_size)
Added sample extension file
scripts/user-completions.sample.txt
Updated docs
README.md
README-zh.md
Documents:
completion sources (project + curated Windows + user extensions)
WINUXCMD_COMPLETION_FILE usage
cache behavior and path convention
Replaced video usage with GitHub-renderable GIF reference (DOCS/images/auto.gif)
Why
Avoid bloating main.cpp as completion data grows
Keep startup and runtime overhead low
Avoid noisy completion lists from full PATH scanning
Provide an explicit, user-controlled extension mechanism for third-party commands
Ensure README behavior matches implementation and GitHub rendering constraints
Behavior Notes
Default completion scope:
WinuxCmd project commands
Curated Windows system commands
User-defined commands/options
Third-party executables are not auto-scanned from PATH by default.
User extension file:
Default: %USERPROFILE%\.winuxcmd\completions\user-completions.txt
Override: WINUXCMD_COMPLETION_FILE=<absolute-path>
Validation
Built with MSVC in PowerShell (msvc activated)
Verified winuxcmd build success
Verified completion query outputs for:
native commands (netsh, netstat, etc.)
native options (netstat -a/-n/-o/...)
user-defined entries via sample file
Verified cache file generation and reuse:
<source>.cache.bin created
cache reused when source metadata unchanged
Files
src/Main/native_completion.cppm (new)
src/Main/main.cpp
scripts/user-completions.sample.txt (new)
README.md
README-zh.md
Added dual-mode ↑/↓ behavior in interactive input:
History navigation when not in completion selection
Completion item navigation when selection is active
Automatic fallback from completion edges back to history logic
Added ←/→ in-line cursor movement support
Improved editing model:
Cursor-aware insertion/deletion (UTF-8 safe boundaries)
Proper caret restoration in redraw logic
Added command history support in REPL:
Up/Down browsing
Draft restore when leaving history browsing
Fixed Ctrl+C behavior in two layers:
Input mode: disabled ENABLE_PROCESSED_INPUT so Ctrl+C is handled as key event, not process-kill event
Native fallback execution: parent temporarily ignores Ctrl+C while waiting child process (e.g. ping) so REPL survives child interrupt
Updated REPL hint text in startup banner to reflect new key behavior
Why
Previous behavior lacked history and in-line cursor movement
Arrow keys could not distinguish user intent between completion selection and history browsing
Ctrl+C could terminate/interrupt winuxcmd unexpectedly during native command execution
User-visible Behavior
Tab: complete/accept suggestion
↑/↓:
History by default
Completion navigation when in completion mode
At completion top/bottom, continuing direction exits completion and resumes history logic
←/→: move caret inside current line
Ctrl+C:
Cancels current input without exiting REPL
During native child commands (e.g. ping), interrupts child command while keeping REPL alive
Files
src/Main/readline.cppm
src/Main/main.cpp
Validation
Built with MSVC successfully
Verified:
dual-mode Up/Down behavior
left/right caret movement
history browse + draft restore
Ctrl+C handling in input and native fallback paths
