### PR TITLE
fix(cat,console): stop early on broken pipe and stream passthrough for large-input pipelines

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -341,6 +341,13 @@ message(STATUS "Commands library created with ${COMMAND_SOURCES_COUNT} files")
 # Link commands library to main executable
 target_link_libraries(winuxcmd PRIVATE winuxcmd-commands winuxcmd-modules)
 
+# Keep all command registration translation units from static library.
+# Without WHOLEARCHIVE, MSVC may discard unreferenced objects and leave
+# the command registry empty at runtime.
+if(MSVC)
+    target_link_options(winuxcmd PRIVATE "/WHOLEARCHIVE:winuxcmd-commands.lib")
+endif()
+
 # ====================================================
 # Main executable modules and configuration
 # ====================================================

--- a/src/commands/cat.cpp
+++ b/src/commands/cat.cpp
@@ -127,6 +127,23 @@ REGISTER_COMMAND(cat, "cat",
   using namespace cat_pipeline;
   using namespace core::pipeline;
 
+  const bool fast_passthrough =
+      !ctx.get<bool>("--show-all", false) &&
+      !ctx.get<bool>("--number-nonblank", false) &&
+      !ctx.get<bool>("-b", false) &&
+      !ctx.get<bool>("--show-ends", false) &&
+      !ctx.get<bool>("-E", false) &&
+      !ctx.get<bool>("--number", false) &&
+      !ctx.get<bool>("-n", false) &&
+      !ctx.get<bool>("--squeeze-blank", false) &&
+      !ctx.get<bool>("-s", false) &&
+      !ctx.get<bool>("--show-tabs", false) &&
+      !ctx.get<bool>("-T", false) &&
+      !ctx.get<bool>("--show-nonprinting", false) &&
+      !ctx.get<bool>("-v", false) &&
+      !ctx.get<bool>("-e", false) &&
+      !ctx.get<bool>("-t", false);
+
   // ----------------------------------------------
   // Empty line check (unchanged)
   // ----------------------------------------------
@@ -233,6 +250,18 @@ REGISTER_COMMAND(cat, "cat",
   auto process_stream = [&](std::istream &stream,
                             const CommandContext<CAT_OPTIONS.size()> &ctx,
                             size_t &line_num) {
+    if (fast_passthrough) {
+      std::array<char, 8192> buffer{};
+      while (stream.good()) {
+        stream.read(buffer.data(), static_cast<std::streamsize>(buffer.size()));
+        auto got = stream.gcount();
+        if (got <= 0) break;
+        safePrint(std::string_view(buffer.data(), static_cast<size_t>(got)));
+        if (is_stdout_pipe_closed()) break;
+      }
+      return;
+    }
+
     std::string line;
     bool last_line_empty = false;
     bool squeeze_blank = ctx.get<bool>("--squeeze-blank", false);
@@ -246,6 +275,12 @@ REGISTER_COMMAND(cat, "cat",
 
       last_line_empty = empty;
       process_line(line, ctx, line_num);
+
+      // Downstream (for example `head`) may close the pipe early.
+      // Stop reading immediately instead of scanning the rest of huge inputs.
+      if (is_stdout_pipe_closed()) {
+        break;
+      }
     }
   };
 
@@ -293,8 +328,12 @@ REGISTER_COMMAND(cat, "cat",
 
   int exit_code = 0;
   size_t line_num = 1;
+  clear_pipe_closed_flags();
 
   for (const auto &file : files) {
+    if (is_stdout_pipe_closed()) {
+      break;
+    }
     if (!process_file(file, ctx, line_num)) {
       exit_code = 1;
     }

--- a/src/commands/head.cpp
+++ b/src/commands/head.cpp
@@ -87,11 +87,6 @@ struct HeadConfig {
   char delimiter = '\n';
 };
 
-auto read_all(std::istream& in) -> std::string {
-  return std::string(std::istreambuf_iterator<char>(in),
-                     std::istreambuf_iterator<char>());
-}
-
 auto parse_uint(std::string_view text) -> std::optional<std::uintmax_t> {
   if (text.empty()) return std::nullopt;
   std::uintmax_t value = 0;
@@ -126,77 +121,97 @@ auto parse_count_spec(std::string spec_text, std::string_view opt_name)
   return spec;
 }
 
-auto split_records(const std::string& data, char delimiter)
-    -> std::vector<std::pair<size_t, size_t>> {
-  std::vector<std::pair<size_t, size_t>> records;
-  records.reserve(data.size() / 10);  // Estimate: assume ~10 chars per record
-  size_t start = 0;
-  for (size_t i = 0; i < data.size(); ++i) {
-    if (data[i] == delimiter) {
-      records.emplace_back(start, i + 1);
-      start = i + 1;
-    }
+auto stream_all(std::istream& in) -> void {
+  std::array<char, 8192> buffer{};
+  while (in.good()) {
+    in.read(buffer.data(), static_cast<std::streamsize>(buffer.size()));
+    auto got = in.gcount();
+    if (got <= 0) break;
+    safePrint(std::string_view(buffer.data(), static_cast<size_t>(got)));
   }
-  if (start < data.size()) {
-    records.emplace_back(start, data.size());
-  }
-  return records;
 }
 
-auto print_ranges(const std::string& data,
-                  const std::vector<std::pair<size_t, size_t>>& ranges,
-                  size_t first, size_t last) -> void {
-  // Reserve buffer for output to avoid multiple small allocations
-  std::string out;
-  out.reserve((last - first) * 80);  // Assume ~80 chars per record
-  for (size_t i = first; i < last; ++i) {
-    const auto [begin, end] = ranges[i];
-    out.append(data.data() + begin, end - begin);
-  }
-  safePrint(out);
-}
-
-auto output_head(const std::string& data, const HeadConfig& config) -> void {
+auto output_head(std::istream& in, const HeadConfig& config) -> void {
   if (config.by_bytes) {
-    size_t keep = static_cast<size_t>(config.spec.value);
+    size_t n = static_cast<size_t>(config.spec.value);
     if (config.spec.all_but_last) {
-      if (keep >= data.size()) return;
-      safePrint(std::string_view(data.data(), data.size() - keep));
+      if (n == 0) {
+        stream_all(in);
+        return;
+      }
+
+      std::deque<char> trailing;
+      std::array<char, 8192> buffer{};
+      while (in.good()) {
+        in.read(buffer.data(), static_cast<std::streamsize>(buffer.size()));
+        auto got = in.gcount();
+        if (got <= 0) break;
+
+        for (std::streamsize i = 0; i < got; ++i) {
+          trailing.push_back(buffer[static_cast<size_t>(i)]);
+          if (trailing.size() > n) {
+            safePrint(trailing.front());
+            trailing.pop_front();
+          }
+        }
+      }
       return;
     }
 
-    size_t count = std::min(keep, data.size());
-    if (count > 0) {
-      safePrint(std::string_view(data.data(), count));
+    size_t remaining = n;
+    std::array<char, 8192> buffer{};
+    while (remaining > 0 && in.good()) {
+      size_t chunk = std::min(remaining, buffer.size());
+      in.read(buffer.data(), static_cast<std::streamsize>(chunk));
+      auto got = in.gcount();
+      if (got <= 0) break;
+      safePrint(std::string_view(buffer.data(), static_cast<size_t>(got)));
+      remaining -= static_cast<size_t>(got);
     }
     return;
   }
 
-  auto ranges = split_records(data, config.delimiter);
-  if (ranges.empty()) return;
-
-  size_t total = ranges.size();
-  size_t count = static_cast<size_t>(config.spec.value);
-
+  size_t n = static_cast<size_t>(config.spec.value);
   if (config.spec.all_but_last) {
-    if (count >= total) return;
-    print_ranges(data, ranges, 0, total - count);
+    if (n == 0) {
+      stream_all(in);
+      return;
+    }
+
+    std::deque<std::string> trailing_records;
+    std::string current;
+    char ch = '\0';
+    while (in.get(ch)) {
+      current.push_back(ch);
+      if (ch == config.delimiter) {
+        trailing_records.push_back(std::move(current));
+        current.clear();
+        if (trailing_records.size() > n) {
+          safePrint(trailing_records.front());
+          trailing_records.pop_front();
+        }
+      }
+    }
+
+    if (!current.empty()) {
+      trailing_records.push_back(std::move(current));
+      if (trailing_records.size() > n) {
+        safePrint(trailing_records.front());
+        trailing_records.pop_front();
+      }
+    }
     return;
   }
 
-  size_t take = std::min(count, total);
-  print_ranges(data, ranges, 0, take);
-}
-
-auto read_input(std::string_view path) -> cp::Result<std::string> {
-  if (path == "-") return read_all(std::cin);
-
-  std::ifstream file(std::string(path), std::ios::binary);
-  if (!file.is_open()) {
-    return std::unexpected("cannot open '" + std::string(path) + "'");
+  if (n == 0) return;
+  char ch = '\0';
+  while (in.get(ch)) {
+    safePrint(ch);
+    if (ch == config.delimiter) {
+      --n;
+      if (n == 0) break;
+    }
   }
-
-  return read_all(file);
 }
 
 template <size_t N>
@@ -267,14 +282,6 @@ auto config = *config_result;
 
   for (size_t i = 0; i < files.size(); ++i) {
     const auto& file = files[i];
-    auto data_result = read_input(file);
-    if (!data_result) {
-      safeErrorPrint("head: ");
-      safeErrorPrint(data_result.error());
-      safeErrorPrint("\n");
-      any_error = true;
-      continue;
-    }
 
     bool show_header =
         (config.verbose || (multi && !config.quiet)) && file != "-";
@@ -285,7 +292,31 @@ auto config = *config_result;
       safePrint(" <==\n");
     }
 
-    output_head(*data_result, config);
+    if (file == "-") {
+      output_head(std::cin, config);
+      if (std::cin.bad()) {
+        safeErrorPrint("head: error reading '-'\n");
+        any_error = true;
+      }
+    } else {
+      std::ifstream input(file, std::ios::binary);
+      if (!input.is_open()) {
+        safeErrorPrint("head: cannot open '");
+        safeErrorPrint(file);
+        safeErrorPrint("'\n");
+        any_error = true;
+        continue;
+      }
+
+      output_head(input, config);
+      if (input.bad()) {
+        safeErrorPrint("head: error reading '");
+        safeErrorPrint(file);
+        safeErrorPrint("'\n");
+        any_error = true;
+      }
+    }
+
     first_print = false;
   }
 

--- a/src/commands/tail.cpp
+++ b/src/commands/tail.cpp
@@ -116,19 +116,14 @@ struct TailConfig {
   char delimiter = '\n';
 };
 
-auto read_all(std::istream& in) -> std::string {
-  return std::string(std::istreambuf_iterator<char>(in),
-                     std::istreambuf_iterator<char>());
-}
-
-auto read_input(std::string_view path) -> cp::Result<std::string> {
-  if (path == "-") return read_all(std::cin);
-
-  std::ifstream file(std::string(path), std::ios::binary);
-  if (!file.is_open()) {
-    return std::unexpected("cannot open '" + std::string(path) + "'");
+auto stream_all(std::istream& in) -> void {
+  std::array<char, 8192> buffer{};
+  while (in.good()) {
+    in.read(buffer.data(), static_cast<std::streamsize>(buffer.size()));
+    auto got = in.gcount();
+    if (got <= 0) break;
+    safePrint(std::string_view(buffer.data(), static_cast<size_t>(got)));
   }
-  return read_all(file);
 }
 
 auto suffix_multiplier(std::string_view suffix)
@@ -223,74 +218,86 @@ auto parse_count_spec(std::string spec_text, std::string_view opt_name)
   return spec;
 }
 
-auto split_records(const std::string& data, char delimiter)
-    -> std::vector<std::pair<size_t, size_t>> {
-  std::vector<std::pair<size_t, size_t>> records;
-  records.reserve(data.size() / 10);  // Estimate: assume ~10 chars per record
-  size_t start = 0;
-  for (size_t i = 0; i < data.size(); ++i) {
-    if (data[i] == delimiter) {
-      records.emplace_back(start, i + 1);
-      start = i + 1;
-    }
-  }
-  if (start < data.size()) {
-    records.emplace_back(start, data.size());
-  }
-  return records;
-}
-
-auto print_ranges(const std::string& data,
-                  const std::vector<std::pair<size_t, size_t>>& ranges,
-                  size_t first, size_t last) -> void {
-  // Reserve buffer for output to avoid multiple small allocations
-  std::string out;
-  out.reserve((last - first) * 80);  // Assume ~80 chars per record
-  for (size_t i = first; i < last; ++i) {
-    const auto [begin, end] = ranges[i];
-    out.append(data.data() + begin, end - begin);
-  }
-  safePrint(out);
-}
-
-auto output_tail(const std::string& data, const TailConfig& config) -> void {
+auto output_tail(std::istream& in, const TailConfig& config) -> void {
   if (config.by_bytes) {
     size_t n = static_cast<size_t>(config.spec.value);
     if (config.spec.from_start) {
-      size_t offset = n > 0 ? n - 1 : 0;
-      if (offset >= data.size()) return;
-      safePrint(std::string_view(data.data() + offset, data.size() - offset));
+      size_t skip = n > 0 ? n - 1 : 0;
+      std::array<char, 8192> discard{};
+      while (skip > 0 && in.good()) {
+        size_t chunk = std::min(skip, discard.size());
+        in.read(discard.data(), static_cast<std::streamsize>(chunk));
+        auto got = in.gcount();
+        if (got <= 0) return;
+        skip -= static_cast<size_t>(got);
+      }
+      stream_all(in);
       return;
     }
 
-    if (n >= data.size()) {
-      if (!data.empty()) safePrint(std::string_view(data.data(), data.size()));
-      return;
+    if (n == 0) return;
+    std::deque<char> trailing;
+    std::array<char, 8192> buffer{};
+    while (in.good()) {
+      in.read(buffer.data(), static_cast<std::streamsize>(buffer.size()));
+      auto got = in.gcount();
+      if (got <= 0) break;
+      for (std::streamsize i = 0; i < got; ++i) {
+        trailing.push_back(buffer[static_cast<size_t>(i)]);
+        if (trailing.size() > n) trailing.pop_front();
+      }
     }
-
-    safePrint(std::string_view(data.data() + (data.size() - n), n));
+    if (!trailing.empty()) {
+      std::string out;
+      out.reserve(trailing.size());
+      for (char ch : trailing) out.push_back(ch);
+      safePrint(out);
+    }
     return;
   }
 
-  auto ranges = split_records(data, config.delimiter);
-  if (ranges.empty()) return;
-
-  size_t total = ranges.size();
   size_t n = static_cast<size_t>(config.spec.value);
-
   if (config.spec.from_start) {
     size_t start = n > 0 ? n - 1 : 0;
-    if (start >= total) return;
-    print_ranges(data, ranges, start, total);
+    if (start == 0) {
+      stream_all(in);
+      return;
+    }
+
+    size_t record_index = 0;
+    std::string current;
+    char ch = '\0';
+    while (in.get(ch)) {
+      current.push_back(ch);
+      if (ch == config.delimiter) {
+        if (record_index >= start) safePrint(current);
+        current.clear();
+        ++record_index;
+      }
+    }
+    if (!current.empty() && record_index >= start) {
+      safePrint(current);
+    }
     return;
   }
 
-  if (n >= total) {
-    print_ranges(data, ranges, 0, total);
-    return;
+  if (n == 0) return;
+  std::deque<std::string> trailing_records;
+  std::string current;
+  char ch = '\0';
+  while (in.get(ch)) {
+    current.push_back(ch);
+    if (ch == config.delimiter) {
+      trailing_records.push_back(std::move(current));
+      current.clear();
+      if (trailing_records.size() > n) trailing_records.pop_front();
+    }
   }
-
-  print_ranges(data, ranges, total - n, total);
+  if (!current.empty()) {
+    trailing_records.push_back(std::move(current));
+    if (trailing_records.size() > n) trailing_records.pop_front();
+  }
+  for (const auto& rec : trailing_records) safePrint(rec);
 }
 
 template <size_t N>
@@ -388,14 +395,6 @@ auto config = *config_result;
 
   for (size_t i = 0; i < files.size(); ++i) {
     const auto& file = files[i];
-    auto data_result = read_input(file);
-    if (!data_result) {
-      safeErrorPrint("tail: ");
-      safeErrorPrint(data_result.error());
-      safeErrorPrint("\n");
-      any_error = true;
-      continue;
-    }
 
     bool show_header =
         (config.verbose || (multi && !config.quiet)) && file != "-";
@@ -406,7 +405,31 @@ auto config = *config_result;
       safePrint(" <==\n");
     }
 
-    output_tail(*data_result, config);
+    if (file == "-") {
+      output_tail(std::cin, config);
+      if (std::cin.bad()) {
+        safeErrorPrint("tail: error reading '-'\n");
+        any_error = true;
+      }
+    } else {
+      std::ifstream input(file, std::ios::binary);
+      if (!input.is_open()) {
+        safeErrorPrint("tail: cannot open '");
+        safeErrorPrint(file);
+        safeErrorPrint("'\n");
+        any_error = true;
+        continue;
+      }
+
+      output_tail(input, config);
+      if (input.bad()) {
+        safeErrorPrint("tail: error reading '");
+        safeErrorPrint(file);
+        safeErrorPrint("'\n");
+        any_error = true;
+      }
+    }
+
     first_print = false;
   }
 

--- a/src/utils/console.cppm
+++ b/src/utils/console.cppm
@@ -42,6 +42,8 @@ namespace {
 thread_local HANDLE g_cached_stdout = INVALID_HANDLE_VALUE;
 thread_local HANDLE g_cached_stderr = INVALID_HANDLE_VALUE;
 thread_local bool g_handles_valid = false;
+thread_local bool g_stdout_pipe_closed = false;
+thread_local bool g_stderr_pipe_closed = false;
 
 // Capture handles (set by daemon when capturing)
 HANDLE g_capture_stdout_write = nullptr;
@@ -73,6 +75,10 @@ HANDLE getStdErr() {
   }
   return g_cached_stderr;
 }
+
+bool isBrokenPipeError(DWORD err) {
+  return err == ERROR_BROKEN_PIPE || err == ERROR_NO_DATA;
+}
 }  // namespace
 
 // Exported function to set output capture handles
@@ -87,6 +93,15 @@ export void set_output_capture_handles(HANDLE stdout_handle, HANDLE stderr_handl
 // Exported function to invalidate cached handles (call after SetStdHandle)
 export void invalidateCachedHandles() {
   g_handles_valid = false;
+}
+
+export bool is_stdout_pipe_closed() { return g_stdout_pipe_closed; }
+
+export bool is_stderr_pipe_closed() { return g_stderr_pipe_closed; }
+
+export void clear_pipe_closed_flags() {
+  g_stdout_pipe_closed = false;
+  g_stderr_pipe_closed = false;
 }
 
 bool isConsoleHandle(HANDLE h) {
@@ -273,20 +288,32 @@ class wchar_buffer {
 export void safePrint(std::wstring_view wsv) {
   HANDLE h = getStdOut();
   if (isConsoleHandle(h)) {
-    detail::writeConsoleW(h, wsv.data(), wsv.size());
+    if (!detail::writeConsoleW(h, wsv.data(), wsv.size()) &&
+        isBrokenPipeError(GetLastError())) {
+      g_stdout_pipe_closed = true;
+    }
   } else {
     std::string utf8 = wstring_to_utf8(wsv);
-    detail::writeFile(h, utf8.data(), utf8.size());
+    if (!detail::writeFile(h, utf8.data(), utf8.size()) &&
+        isBrokenPipeError(GetLastError())) {
+      g_stdout_pipe_closed = true;
+    }
   }
 }
 
 export void safeErrorPrint(std::wstring_view wsv) {
   HANDLE h = getStdErr();
   if (isConsoleHandle(h)) {
-    detail::writeConsoleW(h, wsv.data(), wsv.size());
+    if (!detail::writeConsoleW(h, wsv.data(), wsv.size()) &&
+        isBrokenPipeError(GetLastError())) {
+      g_stderr_pipe_closed = true;
+    }
   } else {
     std::string utf8 = wstring_to_utf8(wsv);
-    detail::writeFile(h, utf8.data(), utf8.size());
+    if (!detail::writeFile(h, utf8.data(), utf8.size()) &&
+        isBrokenPipeError(GetLastError())) {
+      g_stderr_pipe_closed = true;
+    }
   }
 }
 
@@ -308,10 +335,16 @@ export void safePrint(std::string_view sv) {
   if (isConsoleHandle(h)) {
     detail::wchar_buffer buf(sv);
     if (buf.valid()) {
-      detail::writeConsoleW(h, buf.data(), buf.size());
+      if (!detail::writeConsoleW(h, buf.data(), buf.size()) &&
+          isBrokenPipeError(GetLastError())) {
+        g_stdout_pipe_closed = true;
+      }
     }
   } else {
-    detail::writeFile(h, sv.data(), sv.size());
+    if (!detail::writeFile(h, sv.data(), sv.size()) &&
+        isBrokenPipeError(GetLastError())) {
+      g_stdout_pipe_closed = true;
+    }
   }
 }
 
@@ -320,10 +353,16 @@ export void safeErrorPrint(std::string_view sv) {
   if (isConsoleHandle(h)) {
     detail::wchar_buffer buf(sv);
     if (buf.valid()) {
-      detail::writeConsoleW(h, buf.data(), buf.size());
+      if (!detail::writeConsoleW(h, buf.data(), buf.size()) &&
+          isBrokenPipeError(GetLastError())) {
+        g_stderr_pipe_closed = true;
+      }
     }
   } else {
-    detail::writeFile(h, sv.data(), sv.size());
+    if (!detail::writeFile(h, sv.data(), sv.size()) &&
+        isBrokenPipeError(GetLastError())) {
+      g_stderr_pipe_closed = true;
+    }
   }
 }
 


### PR DESCRIPTION
- add broken-pipe state tracking in console output writes
- make cat stop reading when downstream closes pipe
- add fast passthrough path for plain cat to avoid line-by-line overhead
- keep head/tail large-input behavior stream-oriented