### PR TITLE
Sync script command lists with current commands

### DIFF
--- a/scripts/create_links.ps1
+++ b/scripts/create_links.ps1
@@ -47,21 +47,21 @@ function Escape-WildcardChars {
 # Available commands list (auto-generated from src/commands/*.cpp)
 $Script:Commands = @(
     "arch", "b2sum", "base32", "base64", "basename", "basenc", "cal", "cat",
-    "chmod", "chown", "cksum", "clear", "cmp", "column", "comm", "cp", "cpio", "csplit",
+    "chgrp", "chmod", "chown", "cksum", "clear", "cmp", "col", "column", "comm", "cp", "cpio", "csplit",
     "cut", "cygpath", "d2u", "date", "dd", "df", "diff", "diff3", "dirname",
-    "dos2unix", "du", "echo", "env", "expand", "expr", "factor", "false", "file",
-    "find", "fmt", "fold", "free", "getconf", "grep", "groups", "head",
+    "dir", "dircolors", "dos2unix", "du", "echo", "env", "expand", "expr", "factor", "false", "file",
+    "find", "fmt", "fold", "free", "getconf", "grep", "groups", "head", "hexdump",
     "hmac256", "hostid", "hostname", "id", "infocmp", "install", "join", "jq",
     "kill", "less", "link", "ln", "locale", "logname", "ls", "lsof", "man", "md5sum",
-    "mkdir", "mktemp", "mpicalc", "mv", "nice", "nl", "nohup",
+    "mkdir", "mktemp", "more", "mpicalc", "mv", "nice", "nl", "nohup",
     "nproc", "numfmt", "od", "paste", "patch", "pathchk", "pinky", "pr",
     "printenv", "printf", "ps", "ptx", "pwd", "readlink", "realpath", "reset",
     "rev", "rm", "rmdir", "sdiff", "sed", "seq", "sha1sum", "sha224sum",
     "sha256sum", "sha384sum", "sha512sum", "shred", "shuf", "sleep", "sort",
-    "split", "stat", "stdbuf", "sum", "sync", "tac", "tail", "tee", "test",
+    "split", "stat", "stdbuf", "strings", "stty", "sum", "sync", "tac", "tail", "tee", "test",
     "[", "tic", "timeout", "toe", "top", "touch", "tput", "tr", "tree", "true",
     "truncate", "tsort", "tty", "tzset", "u2d", "uname", "unexpand", "uniq",
-    "unix2dos", "unlink", "uptime", "users", "watch", "wc", "which", "who",
+    "unix2dos", "unlink", "uptime", "users", "vdir", "watch", "wc", "which", "who",
     "whoami", "xargs", "xxd", "yes"
 )
 

--- a/scripts/winux.ps1
+++ b/scripts/winux.ps1
@@ -43,9 +43,13 @@ $CommandMap = @{
     "which"     = "which.exe"
     "env"       = "env.exe"
     "sed"       = "sed.exe"
+    "chgrp"     = "chgrp.exe"
     "chmod"     = "chmod.exe"
     "date"      = "date.exe"
     "diff"      = "diff.exe"
+    "dir"       = "dir.exe"
+    "vdir"      = "vdir.exe"
+    "dircolors" = "dircolors.exe"
     "ln"        = "ln.exe"
     "ps"        = "ps.exe"
     "pwd"       = "pwd.exe"
@@ -70,6 +74,7 @@ $CommandMap = @{
     "dirname"   = "dirname.exe"
     "free"      = "free.exe"
     "column"    = "column.exe"
+    "col"       = "col.exe"
     "seq"       = "seq.exe"
     "stat"      = "stat.exe"
     # New commands added in v0.7.0 - Hash tools
@@ -88,6 +93,7 @@ $CommandMap = @{
     "nl"        = "nl.exe"
     "fold"      = "fold.exe"
     "fmt"       = "fmt.exe"
+    "more"      = "more.exe"
     # New commands added in v0.7.0 - Text conversion
     "expand"    = "expand.exe"
     "unexpand"  = "unexpand.exe"
@@ -170,6 +176,9 @@ $CommandMap = @{
     "tzset"     = "tzset.exe"
     "pinky"     = "pinky.exe"
     "mpicalc"   = "mpicalc.exe"
+    "strings"   = "strings.exe"
+    "stty"      = "stty.exe"
+    "hexdump"   = "hexdump.exe"
     # New commands added in v0.7.0 - Archive tools
     "cpio"      = "cpio.exe"
     # New commands added in v0.7.0 - System utilities


### PR DESCRIPTION
## Summary
- add missing commands to scripts/create_links.ps1
- add the same missing commands to scripts/winux.ps1
- keep the current static-list approach rather than switching to dynamic enumeration

## Validation
- verified the newly added command names are present in both script command lists
- winux.ps1 command map now contains 148 entries
