### PR TITLE
Fix PowerShell profile reload instruction

### DIFF
--- a/scripts/winux-activate.ps1
+++ b/scripts/winux-activate.ps1
@@ -513,7 +513,7 @@ if (Install-WinuxToProfile -BinDir $binDir) {
     Write-Host "  - Works with multiple installed versions"
     Write-Host ""
     Write-Color "Cyan" "Next steps:"
-    Write-Host "1. RESTART PowerShell or run: . `$PROFILE"
+    Write-Host "1. RESTART PowerShell or run: . `$PROFILE.CurrentUserAllHosts"
     Write-Host "2. Test with: winux"
     Write-Host "3. If you have winux.ps1, copy it to WinuxCmd bin directory"
     Write-Host "4. Optional: winux activate (if winux.ps1 exists)"


### PR DESCRIPTION
Fix PowerShell profile reload instruction

Related to #54.

This updates the `winux-activate.ps1` success message so the immediate reload command matches the profile file that the script actually writes.

`Install-WinuxToProfile` writes the wrapper to `$PROFILE.CurrentUserAllHosts`, but the printed next step currently says to run `. $PROFILE`, which resolves to the current-host profile path. On a fresh install this can reload the wrong file or fail when the current-host profile does not exist.

The new message uses:

```powershell
. $PROFILE.CurrentUserAllHosts
```

Verification:

```powershell
powershell -NoProfile -Command "`$null = [scriptblock]::Create((Get-Content -Raw 'scripts\winux-activate.ps1')); 'parse ok'"
```
