### PR TITLE
Handle single-argument winux wrapper commands

### DIFF
--- a/scripts/winux-activate.ps1
+++ b/scripts/winux-activate.ps1
@@ -227,7 +227,7 @@ function global:winux {
 
     # Get the first argument as the command
     $Command = $Arguments[0]
-    $RemainingArgs = $Arguments[1..$($Arguments.Count-1)]
+    $RemainingArgs = if ($Arguments.Count -gt 1) { $Arguments[1..($Arguments.Count - 1)] } else { @() }
 
     # Management commands that go to winux.ps1
     $managementCommands = @("activate", "deactivate", "status", "list", "help", "version")


### PR DESCRIPTION
Handle single-argument winux wrapper commands

Fixes #77.

Fixes the generated `winux` wrapper so management commands with no extra arguments produce an empty `$RemainingArgs` array.

Previously the wrapper used:

```powershell
$Arguments[1..$($Arguments.Count-1)]
```

For a single argument, PowerShell expands `1..0` instead of treating it as an empty range, which can forward unexpected values.

Verification:

```powershell
powershell -NoProfile -Command "`$null = [scriptblock]::Create((Get-Content -Raw 'scripts\winux-activate.ps1')); 'parse ok'"
powershell -NoProfile -Command "`$Arguments = @('status'); `$RemainingArgs = if (`$Arguments.Count -gt 1) { `$Arguments[1..(`$Arguments.Count - 1)] } else { @() }; if (`$RemainingArgs.Count -eq 0) { 'single arg ok' } else { throw 'unexpected remaining args' }"
```
