### PR TITLE
Pick latest WinuxCmd install during activation

### DIFF
--- a/scripts/winux-activate.ps1
+++ b/scripts/winux-activate.ps1
@@ -50,6 +50,16 @@ function Get-WinuxBinDir {
     $baseDir = "$env:LOCALAPPDATA\WinuxCmd"
     if (Test-Path $baseDir) {
         $versionDir = Get-ChildItem -Path $baseDir -Directory -Filter "WinuxCmd-*" |
+                      Sort-Object -Property @{
+                          Expression = {
+                              if ($_.Name -match 'WinuxCmd-(\d+\.\d+\.\d+)') {
+                                  [Version]$Matches[1]
+                              } else {
+                                  [Version]"0.0.0"
+                              }
+                          }
+                          Descending = $true
+                      } |
                       Select-Object -First 1
         if ($versionDir) {
             $binDir = Join-Path $versionDir.FullName "bin"

--- a/scripts/winux-activate.ps1
+++ b/scripts/winux-activate.ps1
@@ -49,19 +49,18 @@ function Get-WinuxBinDir {
     # Priority 4: Check $env:LOCALAPPDATA\WinuxCmd (traditional installation)
     $baseDir = "$env:LOCALAPPDATA\WinuxCmd"
     if (Test-Path $baseDir) {
-        $versionDir = Get-ChildItem -Path $baseDir -Directory -Filter "WinuxCmd-*" |
-                      Sort-Object -Property @{
-                          Expression = {
-                              if ($_.Name -match 'WinuxCmd-(\d+\.\d+\.\d+)') {
-                                  [Version]$Matches[1]
-                              } else {
-                                  [Version]"0.0.0"
-                              }
-                          }
-                          Descending = $true
-                      } |
-                      Select-Object -First 1
-        if ($versionDir) {
+        $versionDirs = Get-ChildItem -Path $baseDir -Directory -Filter "WinuxCmd-*" |
+                       Sort-Object -Property @{
+                           Expression = {
+                               if ($_.Name -match 'WinuxCmd-(\d+\.\d+\.\d+)') {
+                                   [Version]$Matches[1]
+                               } else {
+                                   [Version]"0.0.0"
+                               }
+                           }
+                           Descending = $true
+                       }
+        foreach ($versionDir in $versionDirs) {
             $binDir = Join-Path $versionDir.FullName "bin"
             if (-not (Test-Path $binDir)) {
                 $exeFile = Get-ChildItem -Path $versionDir.FullName -Filter "winuxcmd.exe" -Recurse -File |


### PR DESCRIPTION
Pick latest WinuxCmd install during activation

Fixes #79.

Updates `Get-WinuxBinDir` so traditional `%LOCALAPPDATA%\WinuxCmd` installs are sorted by version before selecting a directory.

Previously the function used the first `WinuxCmd-*` directory returned by `Get-ChildItem`, which is not guaranteed to be the newest installed version.

Verification:

```powershell
powershell -NoProfile -Command "`$null = [scriptblock]::Create((Get-Content -Raw 'scripts\winux-activate.ps1')); 'parse ok'"
powershell -NoProfile -Command "`$items = 'WinuxCmd-0.9.0-win-x64','WinuxCmd-0.11.3-win-x64','WinuxCmd-0.10.0-win-x64' | ForEach-Object { [pscustomobject]@{ Name = `$_ } }; `$picked = `$items | Sort-Object -Property @{ Expression = { if (`$_.Name -match 'WinuxCmd-(\d+\.\d+\.\d+)') { [Version]`$Matches[1] } else { [Version]'0.0.0' } }; Descending = `$true } | Select-Object -First 1; if (`$picked.Name -eq 'WinuxCmd-0.11.3-win-x64') { 'version sort ok' } else { throw `$picked.Name }"
```
