### PR TITLE
Make activation override aliases on PowerShell 5

### DIFF
--- a/scripts/winux.ps1
+++ b/scripts/winux.ps1
@@ -208,9 +208,21 @@ function Save-ConflictedAliases {
     }
 }
 
-function Remove-ConflictedAliases {
+function Set-WinuxAliases {
     foreach ($aliasName in $ConflictedAliases) {
-        Remove-Item -Path "Alias:\$aliasName" -Force -ErrorAction SilentlyContinue
+        if (-not $CommandMap.ContainsKey($aliasName)) { continue }
+
+        $commandPath = Join-Path $ScriptDir $CommandMap[$aliasName]
+        if (-not (Test-Path $commandPath)) { continue }
+
+        $alias = Get-Alias -Name $aliasName -ErrorAction SilentlyContinue
+        $options = if ($alias) {
+            [System.Management.Automation.ScopedItemOptions]$alias.Options
+        } else {
+            [System.Management.Automation.ScopedItemOptions]::None
+        }
+
+        Set-Alias -Name $aliasName -Value $commandPath -Scope Global -Option $options -Force
     }
 }
 
@@ -221,7 +233,8 @@ function Restore-ConflictedAliases {
         $saved = $global:Winux_SavedAliases[$aliasName]
         
         try {
-            Set-Alias -Name $aliasName -Value $saved.Definition -Scope Global -Force
+            $options = [System.Management.Automation.ScopedItemOptions]$saved.Options
+            Set-Alias -Name $aliasName -Value $saved.Definition -Scope Global -Option $options -Force
         }
         catch {
             # If restore fails, ignore it
@@ -233,7 +246,8 @@ function Restore-ConflictedAliases {
 
 foreach ($aliasName in $global:Winux_SavedAliases.Keys) {
     $saved = $global:Winux_SavedAliases[$aliasName]
-    Set-Alias -Name $aliasName -Value $saved.Definition -Scope Global -Force
+    $options = [System.Management.Automation.ScopedItemOptions]$saved.Options
+    Set-Alias -Name $aliasName -Value $saved.Definition -Scope Global -Option $options -Force
 }
 
 Remove-Variable Winux_SavedAliases -Scope Global -ErrorAction SilentlyContinue
@@ -278,7 +292,7 @@ function Invoke-Activate {
     Write-Host "Activating WinuxCmd..." -ForegroundColor Green
 
     Save-ConflictedAliases
-    Remove-ConflictedAliases
+    Set-WinuxAliases
 
     # Add WinuxCmd bin directory to PATH
     if ($env:PATH -notlike "$ScriptDir*") {


### PR DESCRIPTION
Make activation override aliases on PowerShell 5

Fixes #81.

Fixes the activation behavior for Windows PowerShell 5.1, where `winux activate` currently succeeds but bare commands such as `ls -la` still hit the built-in `ls -> Get-ChildItem` alias.

In PowerShell 5.1, removing an `AllScope` alias inside a function only removes the function-scope copy. The caller session still keeps the original alias after `winux activate` returns.

Activation now sets conflicted aliases to the matching WinuxCmd executables in the global scope while preserving the original alias options. Deactivation restores both the original alias definition and its options.

This avoids relying on scope-sensitive alias removal and uses one consistent path for conflicted aliases.

Verification on Windows PowerShell 5.1:

```powershell
powershell -NoProfile -Command "`$null = [scriptblock]::Create((Get-Content -Raw 'scripts\winux.ps1')); 'parse ok'"
```

Runtime check with a temporary `winux.ps1`/`ls.exe` directory:

```powershell
$p = '...\winux.ps1'
& $p -Action activate
Get-Alias ls
ls -la
& $p -Action deactivate
Get-Alias ls
```

Observed:

- after activate: `ls` points to `...\ls.exe` with `Options: AllScope`
- `ls -la` succeeds
- after deactivate: `ls` restores to `Get-ChildItem` with `Options: AllScope`

Batch check against the script's conflicted alias list on Windows PowerShell 5.1:

- overridden successfully: `cat`, `clear`, `diff`, `kill`, `ls`, `mv`, `ps`, `pwd`, `rm`, `rmdir`, `sleep`, `sort`, `tee`, `man`
- unchanged because there is no corresponding `CommandMap` entry: `group`, `type`
