### PR TITLE
Add mailmap entry for Uarz contributions

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -1,0 +1,1 @@
+Uarz <149165079+Uarz@users.noreply.github.com> Codex <codex@openai.com>


### PR DESCRIPTION
Add mailmap entry for Uarz contributions

Adds a `.mailmap` entry to map earlier commits authored as `Codex <codex@openai.com>` to the intended GitHub identity:

```text
Uarz <149165079+Uarz@users.noreply.github.com>
```

This corrects author attribution for previous merged contributions without rewriting repository history.

Verification:

```powershell
git check-mailmap "Codex <codex@openai.com>"
git shortlog -sne --all | Select-String -Pattern 'Uarz|Codex'
```

Observed:

```text
Uarz <149165079+Uarz@users.noreply.github.com>
4 Uarz <149165079+Uarz@users.noreply.github.com>
```
