### PR TITLE
Add installer packaging and Winux discovery coverage

### DIFF
--- a/.github/workflows/build-winuxcmd.yml
+++ b/.github/workflows/build-winuxcmd.yml
@@ -120,6 +120,35 @@ jobs:
           retention-days: 1
           if-no-files-found: error
 
+      - name: Install Inno Setup
+        if: github.ref_type == 'tag'
+        shell: pwsh
+        run: |
+          choco install innosetup -y --no-progress
+
+      - name: Build Installer
+        if: github.ref_type == 'tag'
+        shell: pwsh
+        run: |
+          ./scripts/build-installer.ps1 `
+            -Root $env:GITHUB_WORKSPACE `
+            -BuildDir build-${{ matrix.package_arch }} `
+            -Configuration Release `
+            -Generator Ninja `
+            -Arch ${{ matrix.package_arch }} `
+            -VsEnvScript "${{ steps.locate_vcvars.outputs.vcvars_path }}" `
+            -IsccPath "C:\Program Files (x86)\Inno Setup 6\ISCC.exe"
+
+      - name: Upload Installer Artifact
+        if: github.ref_type == 'tag'
+        uses: actions/upload-artifact@v7
+        with:
+          name: WinuxCmd-${{ steps.extract_version.outputs.project_version }}-${{ matrix.package_arch }}-installer
+          path: |
+            dist/WinuxCmd-${{ steps.extract_version.outputs.project_version }}-${{ matrix.package_arch }}-setup.exe
+          retention-days: 1
+          if-no-files-found: error
+
   release:
     runs-on: ubuntu-latest
     needs: build-windows
@@ -154,6 +183,18 @@ jobs:
           name: WinuxCmd-${{ steps.final_version.outputs.version }}-arm64
           path: artifacts/arm64
 
+      - name: Download x64 Installer
+        uses: actions/download-artifact@v8
+        with:
+          name: WinuxCmd-${{ steps.final_version.outputs.version }}-x64-installer
+          path: artifacts/installers/x64
+
+      - name: Download ARM64 Installer
+        uses: actions/download-artifact@v8
+        with:
+          name: WinuxCmd-${{ steps.final_version.outputs.version }}-arm64-installer
+          path: artifacts/installers/arm64
+
       - name: Package WinuxCmd Skill
         shell: pwsh
         run: |
@@ -162,7 +203,7 @@ jobs:
       - name: Verify Packages
         run: |
           echo "=== Valid Packages ==="
-          find artifacts -type f \( -name "*.7z" -o -name "*.zip" -o -name "*.tar.gz" \) | sort || exit 1
+          find artifacts -type f \( -name "*.7z" -o -name "*.zip" -o -name "*.tar.gz" -o -name "*.exe" \) | sort || exit 1
           echo "======================"
 
       - name: Create GitHub Release
@@ -175,6 +216,8 @@ jobs:
             artifacts/arm64/*.7z
             artifacts/arm64/*.zip
             artifacts/arm64/*.tar.gz
+            artifacts/installers/x64/*.exe
+            artifacts/installers/arm64/*.exe
             artifacts/skill/*.zip
           tag_name: ${{ github.ref_name }}
           name: Release ${{ github.ref_name }}
@@ -189,9 +232,11 @@ jobs:
             - WinuxCmd-${{ steps.final_version.outputs.version }}-win-x64.7z
             - WinuxCmd-${{ steps.final_version.outputs.version }}-win-x64.zip
             - WinuxCmd-${{ steps.final_version.outputs.version }}-win-x64.tar.gz
+            - WinuxCmd-${{ steps.final_version.outputs.version }}-x64-setup.exe
             - WinuxCmd-${{ steps.final_version.outputs.version }}-win-arm64.7z
             - WinuxCmd-${{ steps.final_version.outputs.version }}-win-arm64.zip
             - WinuxCmd-${{ steps.final_version.outputs.version }}-win-arm64.tar.gz
+            - WinuxCmd-${{ steps.final_version.outputs.version }}-arm64-setup.exe
             - WinuxCmd-skill-v${{ steps.final_version.outputs.version }}.zip
             
             ### Package Contents:
@@ -207,6 +252,7 @@ jobs:
             - **7Z**: Best compression (requires 7-Zip)
             - **ZIP**: Native Windows support (right-click to extract)
             - **TGZ**: tar.gz format (use `tar -xzf filename.tar.gz`)
+            - **EXE**: standalone installer with PATH and PowerShell integration tasks
             
             ### Usage:
             1. Download the appropriate package for your architecture

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -778,6 +778,11 @@ install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/scripts/winux.ps1"
         COMPONENT Runtime
 )
 
+install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/scripts/winux.cmd"
+        DESTINATION "${CMAKE_INSTALL_BINDIR}"
+        COMPONENT Runtime
+)
+
 install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/scripts/winux-activate.ps1"
         DESTINATION "${CMAKE_INSTALL_BINDIR}"
         COMPONENT Runtime

--- a/packaging/winuxcmd.iss
+++ b/packaging/winuxcmd.iss
@@ -1,0 +1,230 @@
+#ifndef AppVersion
+  #define AppVersion "0.0.0"
+#endif
+
+#ifndef ArchSlug
+  #define ArchSlug "x64"
+#endif
+
+#if ArchSlug == "x64"
+  #define InnoArchitecture "x64compatible"
+#elif ArchSlug == "arm64"
+  #define InnoArchitecture "arm64"
+#else
+  #define InnoArchitecture ArchSlug
+#endif
+
+#ifndef StageDir
+  #error StageDir must point at a staged WinuxCmd install tree.
+#endif
+
+#ifndef OutputDir
+  #define OutputDir "."
+#endif
+
+[Setup]
+AppId={{A39D4B7F-01E6-4E40-8183-FD317A1C4C12}
+AppName=WinuxCmd
+AppVersion={#AppVersion}
+AppPublisher=WinuxCmd Project
+AppPublisherURL=https://github.com/caomengxuan666/WinuxCmd
+AppSupportURL=https://github.com/caomengxuan666/WinuxCmd
+AppUpdatesURL=https://github.com/caomengxuan666/WinuxCmd/releases
+DefaultDirName={localappdata}\Programs\WinuxCmd
+DefaultGroupName=WinuxCmd
+DisableProgramGroupPage=yes
+UninstallDisplayIcon={app}\winuxcmd.exe
+PrivilegesRequired=lowest
+ChangesEnvironment=yes
+SolidCompression=yes
+WizardStyle=modern
+OutputDir={#OutputDir}
+OutputBaseFilename=WinuxCmd-{#AppVersion}-{#ArchSlug}-setup
+ArchitecturesAllowed={#InnoArchitecture}
+ArchitecturesInstallIn64BitMode={#InnoArchitecture}
+
+[Languages]
+Name: "english"; MessagesFile: "compiler:Default.isl"
+
+[Tasks]
+Name: "addtopath"; Description: "Add WinuxCmd command executables to your user PATH"
+Name: "pwshprofile"; Description: "Install the Winux PowerShell wrapper for PowerShell 5.1 and 7"
+
+[Files]
+Source: "{#StageDir}\*"; DestDir: "{app}"; Flags: ignoreversion recursesubdirs createallsubdirs
+
+[InstallDelete]
+Type: filesandordirs; Name: "{app}\*"
+
+[UninstallDelete]
+Type: filesandordirs; Name: "{app}"
+
+[Code]
+procedure RunPowerShell(const ScriptPath: String; const Params: String; const WorkingDir: String; const ErrorPrefix: String);
+var
+    ResultCode: Integer;
+    CommandLine: String;
+begin
+    CommandLine :=
+        '-NoProfile -ExecutionPolicy Bypass -File "' + ScriptPath + '" ' + Params;
+
+    if not Exec(
+        ExpandConstant('{sys}\WindowsPowerShell\v1.0\powershell.exe'),
+        CommandLine,
+        WorkingDir,
+        SW_HIDE,
+        ewWaitUntilTerminated,
+        ResultCode) then
+    begin
+        RaiseException(ErrorPrefix + ': failed to launch PowerShell');
+    end;
+
+    if ResultCode <> 0 then
+        RaiseException(ErrorPrefix + ': exit code ' + IntToStr(ResultCode));
+end;
+
+procedure RunTemporaryPowerShellScript(const ScriptBody: String; const WorkingDir: String; const ErrorPrefix: String);
+var
+    ScriptPath: String;
+begin
+    ScriptPath := ExpandConstant('{tmp}\winuxcmd-installer-helper.ps1');
+    if not SaveStringToFile(ScriptPath, ScriptBody, False) then
+        RaiseException(ErrorPrefix + ': failed to write helper script');
+
+    RunPowerShell(ScriptPath, '', WorkingDir, ErrorPrefix);
+end;
+
+procedure CreateCommandLinks;
+begin
+    RunPowerShell(
+        ExpandConstant('{app}\create_links.ps1'),
+        '-Force',
+        ExpandConstant('{app}'),
+        'Failed to create WinuxCmd command links');
+end;
+
+procedure ConfigurePowerShellProfiles(Install: Boolean);
+var
+    Params: String;
+begin
+    if Install then
+        Params := '-Install -ProfilesOnly -Quiet'
+    else
+        Params := '-Uninstall -ProfilesOnly -Quiet';
+
+    RunPowerShell(
+        ExpandConstant('{app}\winux-activate.ps1'),
+        Params,
+        ExpandConstant('{app}'),
+        'Failed to update PowerShell profiles');
+end;
+
+procedure ModifyUserPath(Install: Boolean);
+var
+    PathValue: String;
+    Parts, Updated: TArrayOfString;
+    I, Count: Integer;
+    AppPath: String;
+begin
+    AppPath := ExpandConstant('{app}');
+    if not RegQueryStringValue(HKCU, 'Environment', 'Path', PathValue) then
+        PathValue := '';
+
+    Parts := StringSplit(PathValue, [';'], stExcludeEmpty);
+    SetArrayLength(Updated, GetArrayLength(Parts) + 1);
+    Count := 0;
+    for I := 0 to GetArrayLength(Parts) - 1 do
+    begin
+        if CompareText(Parts[I], AppPath) <> 0 then
+        begin
+            Updated[Count] := Parts[I];
+            Count := Count + 1;
+        end;
+    end;
+
+    if Install then
+    begin
+        for I := Count downto 1 do
+            Updated[I] := Updated[I - 1];
+        Updated[0] := AppPath;
+        Count := Count + 1;
+    end;
+
+    SetArrayLength(Updated, Count);
+    if not RegWriteExpandStringValue(HKCU, 'Environment', 'Path', StringJoin(';', Updated)) then
+        RaiseException('Failed to update user PATH');
+end;
+
+procedure RemovePowerShellProfiles;
+var
+    ScriptBody: String;
+begin
+    ScriptBody :=
+        '$ErrorActionPreference = ''Stop''' + #13#10 +
+        'function Get-ProfileInstallPaths {' + #13#10 +
+        '    $docs = [Environment]::GetFolderPath(''MyDocuments'')' + #13#10 +
+        '    return @(' + #13#10 +
+        '        (Join-Path $docs ''WindowsPowerShell\profile.ps1''),' + #13#10 +
+        '        (Join-Path $docs ''WindowsPowerShell\Microsoft.PowerShell_profile.ps1''),' + #13#10 +
+        '        (Join-Path $docs ''PowerShell\profile.ps1''),' + #13#10 +
+        '        (Join-Path $docs ''PowerShell\Microsoft.PowerShell_profile.ps1'')' + #13#10 +
+        '    ) | Sort-Object -Unique' + #13#10 +
+        '}' + #13#10 +
+        'function Remove-LegacyProfileBlocks {' + #13#10 +
+        '    param([string]$Content)' + #13#10 +
+        '    $options = [System.Text.RegularExpressions.RegexOptions]::Singleline -bor [System.Text.RegularExpressions.RegexOptions]::Multiline' + #13#10 +
+        '    $patterns = @(' + #13#10 +
+        '        ''^# >>> WinuxCmd integration >>>\r?\n.*?^# <<< WinuxCmd integration <<<\r?\n?'',' + #13#10 +
+        '        ''^# Enumerate supported install roots\. WINUXCMD_INSTALL_ROOTS is mainly for\r?\n.*?^Register-EngineEvent -SourceIdentifier PowerShell\.Exiting -Action \{.*?\} \| Out-Null\r?\n?'',' + #13#10 +
+        '        ''^# Enumerate supported install roots\. WINUXCMD_INSTALL_ROOTS is mainly for\r?\n.*?^# Find winuxcmd\.exe and set alias for it\.\r?\n?'',' + #13#10 +
+        '        ''^# Find winuxcmd\.exe and set alias for it\.\r?\n?'',' + #13#10 +
+        '        ''# WinuxCmd wrapper.*?(?=^# Find winuxcmd\.exe|\Z)'',' + #13#10 +
+        '        ''^# set alias\s*\r?\nUpdate-WinuxCmdAlias\s*\r?\n\r?\n'',' + #13#10 +
+        '        ''^function Update-WinuxCmdAlias\s*\{.*?^\}'',' + #13#10 +
+        '        ''^function global:winux\s*\{.*?^\}'',' + #13#10 +
+        '        ''^Set-Alias -Name winuxcmd -Value [^\r\n]+\r?\n?'',' + #13#10 +
+        '        ''^# =+[\r\n]+# WinuxCmd Integration.*?# =+[\r\n]+# End WinuxCmd Integration[\r\n]*'',' + #13#10 +
+        '        ''^Register-EngineEvent -SourceIdentifier PowerShell\.Exiting -Action \{.*?\} \| Out-Null\r?\n?''' + #13#10 +
+        '    )' + #13#10 +
+        '    foreach ($pattern in $patterns) {' + #13#10 +
+        '        $Content = [regex]::Replace($Content, $pattern, '''', $options)' + #13#10 +
+        '    }' + #13#10 +
+        '    return $Content' + #13#10 +
+        '}' + #13#10 +
+        'foreach ($profilePath in Get-ProfileInstallPaths) {' + #13#10 +
+        '    if (-not (Test-Path $profilePath)) { continue }' + #13#10 +
+        '    $content = Get-Content $profilePath -Raw' + #13#10 +
+        '    $content = Remove-LegacyProfileBlocks -Content $content' + #13#10 +
+        '    $lines = $content -split "`r?`n" | Where-Object { $_ -notmatch ''# WinuxCmd Tab Completion'' -and $_ -notmatch ''winuxcmd-completions\.ps1'' }' + #13#10 +
+        '    $newContent = ($lines -join "`r`n").Trim()' + #13#10 +
+        '    Set-Content -LiteralPath $profilePath -Value $newContent -Encoding UTF8' + #13#10 +
+        '}';
+
+    RunTemporaryPowerShellScript(
+        ScriptBody,
+        ExpandConstant('{tmp}'),
+        'Failed to remove PowerShell profile integration');
+end;
+
+procedure CurStepChanged(CurStep: TSetupStep);
+begin
+    if CurStep = ssPostInstall then
+    begin
+        CreateCommandLinks;
+
+        if WizardIsTaskSelected('addtopath') then
+            ModifyUserPath(True);
+
+        if WizardIsTaskSelected('pwshprofile') then
+            ConfigurePowerShellProfiles(True);
+    end;
+end;
+
+procedure CurUninstallStepChanged(CurUninstallStep: TUninstallStep);
+begin
+    if CurUninstallStep = usUninstall then
+    begin
+        RemovePowerShellProfiles;
+        ModifyUserPath(False);
+    end;
+end;

--- a/scripts/build-installer.ps1
+++ b/scripts/build-installer.ps1
@@ -1,0 +1,151 @@
+<#
+.SYNOPSIS
+Build a staged WinuxCmd install tree and compile the Inno Setup installer.
+#>
+
+[CmdletBinding()]
+param(
+    [string]$Root,
+    [string]$BuildDir = "build-vs-installer",
+    [string]$Configuration = "Release",
+    [string]$Generator = "Ninja",
+    [string]$Arch = "x64",
+    [string]$VsEnvScript = "C:\Program Files\Microsoft Visual Studio\18\Community\VC\Auxiliary\Build\vcvars64.bat",
+    [string[]]$VsEnvArgs,
+    [string]$StageDir,
+    [string]$OutputDir,
+    [string]$IsccPath
+)
+
+$ErrorActionPreference = "Stop"
+
+function Resolve-Root {
+    param([string]$Value)
+
+    if ([string]::IsNullOrWhiteSpace($Value)) {
+        return (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+    }
+
+    return (Resolve-Path $Value).Path
+}
+
+function Get-ProjectVersion {
+    param([string]$ProjectRoot)
+
+    return (Get-Content (Join-Path $ProjectRoot "PROJECT_VERSION") -Raw).Trim()
+}
+
+function Resolve-IsccPath {
+    param([string]$Candidate)
+
+    if ($Candidate) {
+        if (-not (Test-Path -LiteralPath $Candidate)) {
+            throw "ISCC.exe not found: $Candidate"
+        }
+        return (Resolve-Path $Candidate).Path
+    }
+
+    $fromPath = Get-Command iscc.exe -ErrorAction SilentlyContinue
+    if ($fromPath) {
+        return $fromPath.Source
+    }
+
+    foreach ($path in @(
+        "C:\Program Files (x86)\Inno Setup 6\ISCC.exe",
+        "C:\Program Files\Inno Setup 6\ISCC.exe"
+    )) {
+        if (Test-Path -LiteralPath $path) {
+            return $path
+        }
+    }
+
+    throw "ISCC.exe not found. Install Inno Setup 6 or pass -IsccPath."
+}
+
+$rootPath = Resolve-Root -Value $Root
+$buildPath = Join-Path $rootPath $BuildDir
+$stagePath = if ($StageDir) { $StageDir } else { Join-Path $buildPath "stage" }
+$outputPath = if ($OutputDir) { $OutputDir } else { Join-Path $rootPath "dist" }
+$resolvedStagePath = [System.IO.Path]::GetFullPath($stagePath)
+$resolvedOutputDir = [System.IO.Path]::GetFullPath($outputPath)
+$projectVersion = Get-ProjectVersion -ProjectRoot $rootPath
+$issPath = Join-Path $rootPath "packaging\winuxcmd.iss"
+$buildScript = Join-Path $rootPath "scripts\build-with-vs.ps1"
+
+if (-not (Test-Path -LiteralPath $VsEnvScript)) {
+    throw "Visual Studio environment script not found: $VsEnvScript"
+}
+
+if (-not (Test-Path -LiteralPath $issPath)) {
+    throw "Installer script not found: $issPath"
+}
+
+if (-not (Test-Path -LiteralPath $buildScript)) {
+    throw "Build helper not found: $buildScript"
+}
+
+if ($null -eq $VsEnvArgs) {
+    $scriptName = Split-Path -Leaf $VsEnvScript
+    if ($scriptName -ieq "VsDevCmd.bat") {
+        $VsEnvArgs = @("-arch=$Arch")
+    } elseif ($scriptName -ieq "vcvarsall.bat") {
+        $VsEnvArgs = @($Arch)
+    } else {
+        $VsEnvArgs = @()
+    }
+}
+
+New-Item -ItemType Directory -Path $resolvedOutputDir -Force | Out-Null
+if (Test-Path -LiteralPath $resolvedStagePath) {
+    Remove-Item -LiteralPath $resolvedStagePath -Recurse -Force
+}
+New-Item -ItemType Directory -Path $resolvedStagePath -Force | Out-Null
+
+Write-Host "Root: $rootPath"
+Write-Host "BuildDir: $buildPath"
+Write-Host "StageDir: $resolvedStagePath"
+Write-Host "OutputDir: $resolvedOutputDir"
+Write-Host "Version: $projectVersion"
+Write-Host "Arch: $Arch"
+Write-Host ""
+
+$buildScriptArgs = @(
+    "-NoProfile",
+    "-ExecutionPolicy", "Bypass",
+    "-File", $buildScript,
+    "-Root", $rootPath,
+    "-BuildDir", $BuildDir,
+    "-Target", "winuxcmd",
+    "-Configuration", $Configuration,
+    "-VsEnvScript", $VsEnvScript,
+    "-Arch", $Arch,
+    "-Generator", $Generator
+)
+
+if ($VsEnvArgs.Count -gt 0) {
+    $buildScriptArgs += @("-VsEnvArgs")
+    $buildScriptArgs += $VsEnvArgs
+}
+
+& powershell @buildScriptArgs
+if ($LASTEXITCODE -ne 0) {
+    exit $LASTEXITCODE
+}
+
+& cmake --install $buildPath --prefix $resolvedStagePath
+if ($LASTEXITCODE -ne 0) {
+    exit $LASTEXITCODE
+}
+
+$resolvedIsccPath = Resolve-IsccPath -Candidate $IsccPath
+$isccArgs = @(
+    "/DAppVersion=$projectVersion",
+    "/DArchSlug=$Arch",
+    "/DStageDir=$resolvedStagePath",
+    "/DOutputDir=$resolvedOutputDir",
+    $issPath
+)
+
+Write-Host "ISCC: $resolvedIsccPath"
+& $resolvedIsccPath @isccArgs
+exit $LASTEXITCODE

--- a/scripts/winux-activate.ps1
+++ b/scripts/winux-activate.ps1
@@ -8,14 +8,19 @@ Run this ONCE after installing WinuxCmd.
 
 param(
     [switch]$Install,
-    [switch]$Uninstall
+    [switch]$Uninstall,
+    [switch]$ProfilesOnly,
+    [switch]$SkipProfileUpdate,
+    [switch]$Quiet
 )
 
 $ErrorActionPreference = "Stop"
 
 function Write-Color {
     param($Color, $Text)
-    # Simple text-based markers for older terminals
+    if ($Quiet) {
+        return
+    }
     $Markers = @{
         Green  = "[OK]"
         Yellow = "[INFO]"
@@ -34,12 +39,107 @@ function Get-ProfileInstallPath {
     return $PROFILE.CurrentUserAllHosts
 }
 
+function Get-ProfileInstallPaths {
+    if (-not [string]::IsNullOrWhiteSpace($env:WINUXCMD_PROFILE_PATH)) {
+        return @($env:WINUXCMD_PROFILE_PATH)
+    }
+
+    $docs = [Environment]::GetFolderPath("MyDocuments")
+    return @(
+        (Join-Path $docs "WindowsPowerShell\profile.ps1"),
+        (Join-Path $docs "WindowsPowerShell\Microsoft.PowerShell_profile.ps1"),
+        (Join-Path $docs "PowerShell\profile.ps1"),
+        (Join-Path $docs "PowerShell\Microsoft.PowerShell_profile.ps1")
+    ) | Sort-Object -Unique
+}
+
+function Get-WinuxInstallRoots {
+    $roots = New-Object System.Collections.Generic.List[string]
+
+    if (-not [string]::IsNullOrWhiteSpace($env:WINUXCMD_INSTALL_ROOTS)) {
+        foreach ($root in ($env:WINUXCMD_INSTALL_ROOTS -split ';')) {
+            if (-not [string]::IsNullOrWhiteSpace($root) -and (Test-Path $root)) {
+                $roots.Add((Resolve-Path $root).Path)
+            }
+        }
+    }
+
+    $classicRoot = Join-Path $env:LOCALAPPDATA "WinuxCmd"
+    if (Test-Path $classicRoot) {
+        $roots.Add((Resolve-Path $classicRoot).Path)
+    }
+
+    foreach ($root in @(
+        (Join-Path $env:LOCALAPPDATA "Programs\WinuxCmd"),
+        (Join-Path $env:ProgramFiles "WinuxCmd"),
+        (Join-Path ${env:ProgramFiles(x86)} "WinuxCmd")
+    )) {
+        if (-not [string]::IsNullOrWhiteSpace($root) -and (Test-Path $root)) {
+            $roots.Add((Resolve-Path $root).Path)
+        }
+    }
+
+    $wingetPackagesRoot = Join-Path $env:LOCALAPPDATA "Microsoft\WinGet\Packages"
+    if (Test-Path $wingetPackagesRoot) {
+        foreach ($pkgRoot in Get-ChildItem -Path $wingetPackagesRoot -Directory -Filter "*WinuxCmd*" -ErrorAction SilentlyContinue) {
+            $roots.Add($pkgRoot.FullName)
+        }
+    }
+
+    return $roots | Select-Object -Unique
+}
+
+function Get-WinuxVersionDirectories {
+    $versionDirs = New-Object System.Collections.Generic.List[object]
+
+    foreach ($root in Get-WinuxInstallRoots) {
+        $rootName = Split-Path $root -Leaf
+        if ((Test-Path (Join-Path $root "winuxcmd.exe")) -or (Test-Path (Join-Path $root "bin\winuxcmd.exe"))) {
+            $item = Get-Item $root
+            $item | Add-Member -NotePropertyName WinuxPriority -NotePropertyValue 3 -Force
+            $versionDirs.Add($item)
+            continue
+        }
+
+        if ($rootName -like "WinuxCmd-*") {
+            $item = Get-Item $root
+            $item | Add-Member -NotePropertyName WinuxPriority -NotePropertyValue 2 -Force
+            $versionDirs.Add($item)
+            continue
+        }
+
+        foreach ($dir in Get-ChildItem -Path $root -Directory -Filter "WinuxCmd-*" -ErrorAction SilentlyContinue) {
+            $dir | Add-Member -NotePropertyName WinuxPriority -NotePropertyValue 1 -Force
+            $versionDirs.Add($dir)
+        }
+    }
+
+    return $versionDirs |
+        Sort-Object -Property @{
+            Expression = { $_.WinuxPriority }
+            Descending = $true
+        }, @{
+            Expression = {
+                if ($_.Name -match 'WinuxCmd-(\d+\.\d+\.\d+)') {
+                    [Version]$Matches[1]
+                } else {
+                    [Version]"0.0.0"
+                }
+            }
+            Descending = $true
+        }
+}
+
 function Remove-LegacyProfileBlocks {
     param([string]$Content)
 
     $options = [System.Text.RegularExpressions.RegexOptions]::Singleline -bor
                [System.Text.RegularExpressions.RegexOptions]::Multiline
     $patterns = @(
+        '^# >>> WinuxCmd integration >>>\r?\n.*?^# <<< WinuxCmd integration <<<\r?\n?',
+        '^# Enumerate supported install roots\. WINUXCMD_INSTALL_ROOTS is mainly for\r?\n.*?^Register-EngineEvent -SourceIdentifier PowerShell\.Exiting -Action \{.*?\} \| Out-Null\r?\n?',
+        '^# Enumerate supported install roots\. WINUXCMD_INSTALL_ROOTS is mainly for\r?\n.*?^# Find winuxcmd\.exe and set alias for it\.\r?\n?',
+        '^# Find winuxcmd\.exe and set alias for it\.\r?\n?',
         '# WinuxCmd wrapper.*?(?=^# Find winuxcmd\.exe|\Z)',
         '^# set alias\s*\r?\nUpdate-WinuxCmdAlias\s*\r?\n\r?\n',
         '^function Update-WinuxCmdAlias\s*\{.*?^\}',
@@ -56,40 +156,24 @@ function Remove-LegacyProfileBlocks {
     return $Content
 }
 
-# ========== Find WinuxCmd installation ==========
 function Get-WinuxBinDir {
-    # Priority 1: Check current directory (Scoop installation scenario)
     if (Test-Path ".\winuxcmd.exe") {
         return (Get-Location).Path
     }
-    
-    # Priority 2: Check script directory
+
     if ($PSScriptRoot -and (Test-Path (Join-Path $PSScriptRoot "winuxcmd.exe"))) {
         return $PSScriptRoot
     }
-    
-    # Priority 3: Check environment variable
+
     if ($env:WINUXCMD_HOME -and (Test-Path $env:WINUXCMD_HOME)) {
         $winuxExe = Join-Path $env:WINUXCMD_HOME "winuxcmd.exe"
         if (Test-Path $winuxExe) {
             return $env:WINUXCMD_HOME
         }
     }
-    
-    # Priority 4: Check $env:LOCALAPPDATA\WinuxCmd (traditional installation)
-    $baseDir = "$env:LOCALAPPDATA\WinuxCmd"
-    if (Test-Path $baseDir) {
-        $versionDirs = Get-ChildItem -Path $baseDir -Directory -Filter "WinuxCmd-*" |
-                       Sort-Object -Property @{
-                           Expression = {
-                               if ($_.Name -match 'WinuxCmd-(\d+\.\d+\.\d+)') {
-                                   [Version]$Matches[1]
-                               } else {
-                                   [Version]"0.0.0"
-                               }
-                           }
-                           Descending = $true
-                       }
+
+    $versionDirs = Get-WinuxVersionDirectories
+    if ($versionDirs.Count -gt 0) {
         foreach ($versionDir in $versionDirs) {
             $binDir = Join-Path $versionDir.FullName "bin"
             if (-not (Test-Path $binDir)) {
@@ -104,49 +188,119 @@ function Get-WinuxBinDir {
             }
         }
     }
-    
-    # Priority 5: Check PATH for winuxcmd.exe
+
     $winuxPath = Get-Command winuxcmd.exe -ErrorAction SilentlyContinue
     if ($winuxPath) {
         return Split-Path $winuxPath.Source
     }
-    
+
     Write-Color "Red" "WinuxCmd not found. Please install WinuxCmd first."
     return $null
 }
 
-# ========== Install to Profile ==========
 function Install-WinuxToProfile {
     param([string]$BinDir)
 
     $winuxPs1Path = Join-Path $BinDir "winux.ps1"
     $winuxCmdPath = Join-Path $BinDir "winuxcmd.exe"
 
-    # Verify winuxcmd.exe exists
     if (-not (Test-Path $winuxCmdPath)) {
         Write-Color "Red" "Error: winuxcmd.exe not found at: $winuxCmdPath"
         return $false
     }
 
-    # Dynamically find the latest winux version
     $winuxFunction = @'
-# Find winuxcmd.exe and set alias for it.
-function Update-WinuxCmdAlias {
-    $baseDir = "$env:LOCALAPPDATA\WinuxCmd"
-    if (-not (Test-Path $baseDir)) {
-        return
+# >>> WinuxCmd integration >>>
+# Enumerate supported install roots. WINUXCMD_INSTALL_ROOTS is mainly for
+# tests and explicit overrides, then we probe classic and WinGet roots.
+function Get-WinuxInstallRoots {
+    $roots = New-Object System.Collections.Generic.List[string]
+
+    if (-not [string]::IsNullOrWhiteSpace($env:WINUXCMD_INSTALL_ROOTS)) {
+        foreach ($root in ($env:WINUXCMD_INSTALL_ROOTS -split ';')) {
+            if (-not [string]::IsNullOrWhiteSpace($root) -and (Test-Path $root)) {
+                $roots.Add((Resolve-Path $root).Path)
+            }
+        }
     }
 
-    $dirs = Get-ChildItem -Path $baseDir -Directory -Filter "WinuxCmd-*" -ErrorAction SilentlyContinue
+    $classicRoot = Join-Path $env:LOCALAPPDATA 'WinuxCmd'
+    if (Test-Path $classicRoot) {
+        $roots.Add((Resolve-Path $classicRoot).Path)
+    }
+
+    foreach ($root in @(
+        (Join-Path $env:LOCALAPPDATA 'Programs\WinuxCmd'),
+        (Join-Path $env:ProgramFiles 'WinuxCmd'),
+        (Join-Path ${env:ProgramFiles(x86)} 'WinuxCmd')
+    )) {
+        if (-not [string]::IsNullOrWhiteSpace($root) -and (Test-Path $root)) {
+            $roots.Add((Resolve-Path $root).Path)
+        }
+    }
+
+    $wingetPackagesRoot = Join-Path $env:LOCALAPPDATA 'Microsoft\WinGet\Packages'
+    if (Test-Path $wingetPackagesRoot) {
+        foreach ($pkgRoot in Get-ChildItem -Path $wingetPackagesRoot -Directory -Filter '*WinuxCmd*' -ErrorAction SilentlyContinue) {
+            $roots.Add($pkgRoot.FullName)
+        }
+    }
+
+    return $roots | Select-Object -Unique
+}
+
+function Get-WinuxVersionDirectories {
+    $versionDirs = New-Object System.Collections.Generic.List[object]
+
+    foreach ($root in Get-WinuxInstallRoots) {
+        $rootName = Split-Path $root -Leaf
+        if ((Test-Path (Join-Path $root 'winuxcmd.exe')) -or (Test-Path (Join-Path $root 'bin\winuxcmd.exe'))) {
+            $item = Get-Item $root
+            $item | Add-Member -NotePropertyName WinuxPriority -NotePropertyValue 3 -Force
+            $versionDirs.Add($item)
+            continue
+        }
+
+        if ($rootName -like 'WinuxCmd-*') {
+            $item = Get-Item $root
+            $item | Add-Member -NotePropertyName WinuxPriority -NotePropertyValue 2 -Force
+            $versionDirs.Add($item)
+            continue
+        }
+
+        foreach ($dir in Get-ChildItem -Path $root -Directory -Filter 'WinuxCmd-*' -ErrorAction SilentlyContinue) {
+            $dir | Add-Member -NotePropertyName WinuxPriority -NotePropertyValue 1 -Force
+            $versionDirs.Add($dir)
+        }
+    }
+
+    return $versionDirs | Sort-Object -Property @{
+        Expression = { $_.WinuxPriority }
+        Descending = $true
+    }, @{
+        Expression = {
+            if ($_.Name -match 'WinuxCmd-(\d+\.\d+\.\d+)') {
+                [Version]$Matches[1]
+            } else {
+                [Version]'0.0.0'
+            }
+        }
+        Descending = $true
+    }
+}
+
+# Find winuxcmd.exe and set alias for it.
+function Update-WinuxCmdAlias {
     $latestExe = $null
 
-    foreach ($dir in $dirs) {
-        if ($dir.Name -match 'WinuxCmd-(\d+\.\d+\.\d+)-win-(x64|arm64)') {
-            $exePath = Join-Path $dir.FullName "bin\winuxcmd.exe"
-            if (Test-Path $exePath) {
-                $latestExe = $exePath
-                # continue search for potential latest version.
-            }
+    foreach ($dir in Get-WinuxVersionDirectories) {
+        $exePath = Join-Path $dir.FullName 'bin\winuxcmd.exe'
+        if (-not (Test-Path $exePath)) {
+            $exePath = Join-Path $dir.FullName 'winuxcmd.exe'
+        }
+
+        if (Test-Path $exePath) {
+            $latestExe = $exePath
         }
     }
 
@@ -163,30 +317,26 @@ function global:winux {
     )
 
     function Find-LatestWinuxCmd {
-        $baseDir = "$env:LOCALAPPDATA\WinuxCmd"
-        if (-not (Test-Path $baseDir)) {
-            return $null
-        }
-
-        # Fetch all version then sort.
         $allVersions = @()
-        $dirs = Get-ChildItem -Path $baseDir -Directory -Filter "WinuxCmd-*" -ErrorAction SilentlyContinue
-
-        foreach ($dir in $dirs) {
-            if ($dir.Name -match 'WinuxCmd-(\d+\.\d+\.\d+)-win-(x64|arm64)') {
+        foreach ($dir in Get-WinuxVersionDirectories) {
+            $versionString = 'installed'
+            $version = [Version]'0.0.0'
+            if ($dir.Name -match 'WinuxCmd-(\d+\.\d+\.\d+)') {
                 try {
                     $version = [Version]$Matches[1]
-                    $allVersions += [PSCustomObject]@{
-                        Directory = $dir
-                        Version = $version
-                        FullName = $dir.FullName
-                        VersionString = $Matches[1]
-                    }
+                    $versionString = $Matches[1]
+                } catch {
+                    $version = [Version]'0.0.0'
+                    $versionString = 'installed'
                 }
-                catch {
-                    # skip parser error
-                    continue
-                }
+            }
+
+            $allVersions += [PSCustomObject]@{
+                Directory = $dir
+                Version = $version
+                FullName = $dir.FullName
+                VersionString = $versionString
+                WinuxPriority = $dir.WinuxPriority
             }
         }
 
@@ -194,11 +344,15 @@ function global:winux {
             return $null
         }
 
-        # sort from by version
-        $sorted = $allVersions | Sort-Object Version -Descending
+        $sorted = $allVersions | Sort-Object -Property @{
+            Expression = { $_.WinuxPriority }
+            Descending = $true
+        }, @{
+            Expression = { $_.Version }
+            Descending = $true
+        }
         $latestDir = $sorted[0].FullName
 
-        # find new and exe.
         $binDir = Join-Path $latestDir "bin"
         $winuxCmdPath = Join-Path $binDir "winuxcmd.exe"
         $winuxPs1Path = Join-Path $binDir "winux.ps1"
@@ -223,11 +377,14 @@ function global:winux {
         }
     }
 
-    # Get WinuxCmd Path
     $winuxPaths = Find-LatestWinuxCmd
     if (-not $winuxPaths) {
         Write-Host "WinuxCmd not found. Please install WinuxCmd first."
-        Write-Host "Expected location: $env:LOCALAPPDATA\WinuxCmd"
+        Write-Host "Expected locations:"
+        Write-Host "  $env:LOCALAPPDATA\WinuxCmd"
+        Write-Host "  $env:LOCALAPPDATA\Programs\WinuxCmd"
+        Write-Host "  $env:ProgramFiles\WinuxCmd"
+        Write-Host "  $env:LOCALAPPDATA\Microsoft\WinGet\Packages\*\WinuxCmd-*"
         return
     }
 
@@ -235,7 +392,6 @@ function global:winux {
     $winuxCmdPath = $winuxPaths.WinuxCmdExe
     $winuxVersion = $winuxPaths.Version
 
-    # Handle empty arguments (just 'winux' command)
     if ($Arguments.Count -eq 0) {
         Write-Host "WinuxCmd v$winuxVersion - GNU Coreutils for Windows"
         Write-Host "==================================================="
@@ -264,14 +420,10 @@ function global:winux {
         return
     }
 
-    # Get the first argument as the command
     $Command = $Arguments[0]
     $RemainingArgs = if ($Arguments.Count -gt 1) { $Arguments[1..($Arguments.Count - 1)] } else { @() }
-
-    # Management commands that go to winux.ps1
     $managementCommands = @("activate", "deactivate", "status", "list", "help", "version")
 
-    # Check if this is a management command
     if ($Command -in $managementCommands) {
         switch ($Command) {
             "activate" {
@@ -341,7 +493,6 @@ function global:winux {
         return
     }
 
-    # Special case: --help and --version flags (when used as first argument)
     if ($Command -eq "--help" -or $Command -eq "-h") {
         if (Test-Path $winuxCmdPath) {
             & $winuxCmdPath --help
@@ -356,9 +507,7 @@ function global:winux {
         return
     }
 
-    # All other commands: pass through to winuxcmd.exe
     if (Test-Path $winuxCmdPath) {
-        # Build argument list properly - include the command and all remaining args
         & $winuxCmdPath @Arguments
     } else {
         Write-Host "winuxcmd.exe not found at: $winuxCmdPath"
@@ -378,45 +527,90 @@ Register-EngineEvent -SourceIdentifier PowerShell.Exiting -Action {
         }
     }
 } | Out-Null
+# <<< WinuxCmd integration <<<
 '@
 
-    $profilePath = Get-ProfileInstallPath
+    foreach ($profilePath in Get-ProfileInstallPaths) {
+        $profileDir = Split-Path $profilePath -Parent
+        if (-not (Test-Path $profileDir)) {
+            New-Item -ItemType Directory -Path $profileDir -Force | Out-Null
+        }
 
-    # Ensure profile directory exists
-    $profileDir = Split-Path $profilePath -Parent
-    if (-not (Test-Path $profileDir)) {
-        New-Item -ItemType Directory -Path $profileDir -Force | Out-Null
-    }
+        $currentContent = ""
+        if (Test-Path $profilePath) {
+            $currentContent = Get-Content $profilePath -Raw
+            $currentContent = $currentContent.Trim()
+        }
 
-    # read current profile
-    $currentContent = ""
-    if (Test-Path $profilePath) {
-        $currentContent = Get-Content $profilePath -Raw
+        $currentContent = Remove-LegacyProfileBlocks -Content $currentContent
+        $currentContent = $currentContent -replace '\n\n\n+', "`n`n"
         $currentContent = $currentContent.Trim()
+
+        $newContent = if ([string]::IsNullOrWhiteSpace($currentContent)) {
+            $winuxFunction.Trim()
+        } else {
+            $currentContent + "`n`n" + $winuxFunction.Trim()
+        }
+        Set-Content -Path $profilePath -Value $newContent -Encoding UTF8 -Force
     }
-
-    $currentContent = Remove-LegacyProfileBlocks -Content $currentContent
-
-    # remove extra space
-    $currentContent = $currentContent -replace '\n\n\n+', "`n`n"
-    $currentContent = $currentContent.Trim()
-
-    # add new dynamical function
-    $newContent = $currentContent + "`n`n" + $winuxFunction
-    Set-Content -Path $profilePath -Value $newContent -Encoding UTF8 -Force
 
     return $true
 }
 
-# ========== Main Script ==========
+function Update-UserPathEntry {
+    param(
+        [string]$BinDir,
+        [bool]$Present
+    )
+
+    $userPath = [System.Environment]::GetEnvironmentVariable("PATH", "User")
+    $parts = @()
+    if (-not [string]::IsNullOrWhiteSpace($userPath)) {
+        $parts = $userPath -split ";" | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+    }
+
+    $filtered = foreach ($part in $parts) {
+        if ($part -ne $BinDir) {
+            $part
+        }
+    }
+
+    $updated = if ($Present) { @($BinDir) + @($filtered) } else { @($filtered) }
+    [System.Environment]::SetEnvironmentVariable("PATH", ($updated -join ";"), "User")
+}
+
+function Remove-WinuxFromProfiles {
+    foreach ($profilePath in Get-ProfileInstallPaths) {
+        if (-not (Test-Path $profilePath)) {
+            continue
+        }
+
+        $content = Get-Content $profilePath -Raw
+        $content = Remove-LegacyProfileBlocks -Content $content
+        $lines = $content -split "`r?`n" | Where-Object {
+            $_ -notmatch '# WinuxCmd Tab Completion' -and
+            $_ -notmatch 'winuxcmd-completions\.ps1'
+        }
+        $newContent = ($lines -join "`r`n").Trim()
+        Set-Content -LiteralPath $profilePath -Value $newContent -Encoding UTF8
+        Write-Color "Green" "Cleaned profile: $profilePath"
+    }
+}
+
 Write-Color "Cyan" "WinuxCmd Profile Initializer"
 Write-Color "Cyan" "==========================="
-Write-Host ""
-
-# ── New: --install flag for one-shot permanent setup ──────────────────────────
-if ($Install) {
-    Write-Color "Yellow" "Permanent installation: PATH..."
+if (-not $Quiet) {
     Write-Host ""
+}
+
+if ($Install) {
+    $updateProfiles = -not $SkipProfileUpdate
+    $updatePath = -not $ProfilesOnly
+
+    Write-Color "Yellow" "Permanent installation: configuring WinuxCmd integration..."
+    if (-not $Quiet) {
+        Write-Host ""
+    }
 
     $binDir = Get-WinuxBinDir
     if (-not $binDir) {
@@ -425,54 +619,66 @@ if ($Install) {
     }
     Write-Color "Cyan" "Found WinuxCmd at: $binDir"
 
-    # 1. Add bin dir to HKCU\Environment\PATH (no admin required)
-    $userPath = [System.Environment]::GetEnvironmentVariable("PATH", "User")
-    if ($userPath -notlike "*$binDir*") {
-        $newPath = if ($userPath) { "$binDir;$userPath" } else { $binDir }
-        [System.Environment]::SetEnvironmentVariable("PATH", $newPath, "User")
+    if ($updatePath) {
+        Update-UserPathEntry -BinDir $binDir -Present $true
         Write-Color "Green" "Added '$binDir' to user PATH registry."
-        Write-Host "       (Effective in new sessions / after re-login)"
-    } else {
-        Write-Color "Green" "Already in user PATH."
-    }
-    # Also add to current session
-    $env:PATH = "$binDir;$env:PATH"
+        if (-not $Quiet) {
+            Write-Host "       (Effective in new sessions / after re-login)"
+        }
 
-    Write-Host ""
+        if ($env:PATH -notlike "*$binDir*") {
+            $env:PATH = "$binDir;$env:PATH"
+        }
+    }
+
+    if ($updateProfiles) {
+        if (Install-WinuxToProfile -BinDir $binDir) {
+            foreach ($profilePath in Get-ProfileInstallPaths) {
+                Write-Color "Green" "Installed Winux PowerShell wrapper in: $profilePath"
+            }
+        } else {
+            Write-Color "Red" "Failed to install Winux PowerShell wrapper."
+            exit 1
+        }
+    }
+
+    if (-not $Quiet) {
+        Write-Host ""
+    }
     Write-Color "Green" "Installation complete!"
-    Write-Host "  - Open a new PowerShell window: ls, grep, tree etc. are on PATH"
-    Write-Host "  - No need to run this script again"
+    if (-not $Quiet) {
+        if ($updateProfiles) {
+            Write-Host "  - Open a new PowerShell window and run: winux activate"
+        }
+        if ($updatePath) {
+            Write-Host "  - GNU command executables are also available from PATH"
+        }
+    }
     exit 0
 }
 
 if ($Uninstall) {
+    $removeProfiles = -not $SkipProfileUpdate
+    $removePath = -not $ProfilesOnly
+
     Write-Color "Yellow" "Removing permanent installation..."
     $binDir = Get-WinuxBinDir
-    if ($binDir) {
-        $userPath = [System.Environment]::GetEnvironmentVariable("PATH", "User")
-        if ($userPath -like "*$binDir*") {
-            $newPath = ($userPath -split ";" | Where-Object { $_ -ne $binDir }) -join ";"
-            [System.Environment]::SetEnvironmentVariable("PATH", $newPath, "User")
-            Write-Color "Green" "Removed from user PATH registry."
+    if ($removePath -and $binDir) {
+        Update-UserPathEntry -BinDir $binDir -Present $false
+        if ($env:PATH -like "*$binDir*") {
+            $env:PATH = (($env:PATH -split ';' | Where-Object { $_ -ne $binDir }) -join ';')
         }
+        Write-Color "Green" "Removed from user PATH registry."
     }
-    # Remove legacy completion lines from profile if an older install added them.
-    foreach ($prof in @($PROFILE.CurrentUserCurrentHost, $PROFILE.CurrentUserAllHosts)) {
-        if (-not $prof -or -not (Test-Path $prof)) { continue }
-        $lines = Get-Content $prof | Where-Object {
-            $_ -notmatch '# WinuxCmd Tab Completion' -and
-            $_ -notmatch "winuxcmd-completions\.ps1"
-        }
-        Set-Content $prof $lines -Encoding UTF8
-        Write-Color "Green" "Cleaned profile: $prof"
+
+    if ($removeProfiles) {
+        Remove-WinuxFromProfiles
     }
+
     Write-Color "Green" "Uninstall complete. Open a new shell to take effect."
     exit 0
 }
 
-# ── Legacy flow (no flags) ────────────────────────────────────────────────────
-
-# Find WinuxCmd (For Verify Installation)
 $binDir = Get-WinuxBinDir
 if (-not $binDir) {
     Write-Color "Red" "Failed to find WinuxCmd installation"
@@ -482,13 +688,12 @@ if (-not $binDir) {
 
 Write-Color "Cyan" "Found WinuxCmd at: $binDir"
 
-# Get profile path for display
-$profilePath = Get-ProfileInstallPath
-
-# Ask for confirmation
 Write-Host ""
 Write-Host "This will add the 'winux' command to your PowerShell profile."
-Write-Host "Profile location: $profilePath"
+Write-Host "Profile locations:"
+foreach ($profilePath in Get-ProfileInstallPaths) {
+    Write-Host "  $profilePath"
+}
 Write-Host ""
 
 $confirm = Read-Host "Continue? (Y/N)"
@@ -497,7 +702,6 @@ if ($confirm -notmatch '^[Yy]') {
     exit 0
 }
 
-# Install to profile.
 if (Install-WinuxToProfile -BinDir $binDir) {
     Write-Color "Green" "WinuxCmd added to PowerShell profile"
     Write-Host ""

--- a/scripts/winux.cmd
+++ b/scripts/winux.cmd
@@ -1,0 +1,14 @@
+@echo off
+setlocal
+
+set "SCRIPT_DIR=%~dp0"
+if "%SCRIPT_DIR:~-1%"=="\" set "SCRIPT_DIR=%SCRIPT_DIR:~0,-1%"
+set "WINUX_PS1=%SCRIPT_DIR%\winux.ps1"
+
+if not exist "%WINUX_PS1%" (
+    echo winux.ps1 not found
+    exit /b 1
+)
+
+powershell -NoProfile -ExecutionPolicy Bypass -File "%WINUX_PS1%" -Action %*
+exit /b %ERRORLEVEL%

--- a/scripts/winux.ps1
+++ b/scripts/winux.ps1
@@ -26,7 +26,7 @@ $AllScopeAliases = @("echo", "cp", "where")
 
 function Get-AvailableCommands {
     $commands = [ordered]@{}
-    $ignoredNames = @("winuxcmd")
+    $ignoredNames = @("winuxcmd", "unins000")
 
     foreach ($exe in Get-ChildItem -LiteralPath $ScriptDir -Filter "*.exe" -File -ErrorAction SilentlyContinue) {
         $commandName = $exe.BaseName

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -157,6 +157,20 @@ add_test(
 )
 set_tests_properties(winux_command_discovery PROPERTIES LABELS "WinuxCmd;PowerShell")
 
+add_test(
+    NAME winux_winget_discovery
+    COMMAND ${POWERSHELL_EXE} -NoProfile -ExecutionPolicy Bypass -File
+            "${CMAKE_CURRENT_SOURCE_DIR}/scripts/winux_winget_discovery_test.ps1"
+)
+set_tests_properties(winux_winget_discovery PROPERTIES LABELS "WinuxCmd;PowerShell")
+
+add_test(
+    NAME winux_installer_root_discovery
+    COMMAND ${POWERSHELL_EXE} -NoProfile -ExecutionPolicy Bypass -File
+            "${CMAKE_CURRENT_SOURCE_DIR}/scripts/winux_installer_root_discovery_test.ps1"
+)
+set_tests_properties(winux_installer_root_discovery PROPERTIES LABELS "WinuxCmd;PowerShell")
+
 # Also add dependency to test-all target
 if(TARGET test-all)
     add_dependencies(test-all create-test-links)

--- a/tests/scripts/winux_installer_root_discovery_test.ps1
+++ b/tests/scripts/winux_installer_root_discovery_test.ps1
@@ -1,0 +1,77 @@
+$ErrorActionPreference = "Stop"
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..\..")).Path
+$activateScript = Join-Path $repoRoot "scripts\winux-activate.ps1"
+$winuxScript = Join-Path $repoRoot "scripts\winux.ps1"
+
+$tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("winux-installer-discovery-" + [guid]::NewGuid().ToString("N"))
+$localAppDataRoot = Join-Path $tempRoot "LocalAppData"
+$installRoot = Join-Path $localAppDataRoot "Programs\WinuxCmd"
+$wingetPackageRoot = Join-Path $localAppDataRoot "Microsoft\WinGet\Packages\caomengxuan666.WinuxCmd_Microsoft.Winget.Source_8wekyb3d8bbwe"
+$wingetInstallRoot = Join-Path $wingetPackageRoot "WinuxCmd-9.99.9-win-x64"
+$profilePath = Join-Path $tempRoot "profile.ps1"
+
+$null = New-Item -ItemType Directory -Path $installRoot -Force
+$null = New-Item -ItemType Directory -Path $wingetInstallRoot -Force
+
+try {
+    Copy-Item -LiteralPath $activateScript -Destination (Join-Path $installRoot "winux-activate.ps1")
+    Copy-Item -LiteralPath $winuxScript -Destination (Join-Path $installRoot "winux.ps1")
+    foreach ($name in @("winuxcmd.exe", "ls.exe", "cat.exe", "man.exe")) {
+        Copy-Item -LiteralPath $env:ComSpec -Destination (Join-Path $installRoot $name)
+    }
+
+    Copy-Item -LiteralPath $winuxScript -Destination (Join-Path $wingetInstallRoot "winux.ps1")
+    foreach ($name in @("winuxcmd.exe", "ls.exe", "cat.exe", "man.exe")) {
+        Copy-Item -LiteralPath $env:ComSpec -Destination (Join-Path $wingetInstallRoot $name)
+    }
+
+    $env:WINUXCMD_PROFILE_PATH = $profilePath
+
+    $installCommand = @"
+`$env:LOCALAPPDATA = '$localAppDataRoot'
+Set-Location '$installRoot'
+& '$installRoot\winux-activate.ps1' -Install -ProfilesOnly -Quiet
+"@
+    powershell -NoProfile -ExecutionPolicy Bypass -Command $installCommand | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        throw "winux-activate.ps1 installer-root install exited with $LASTEXITCODE"
+    }
+
+    $verifyCommand = @"
+`$env:LOCALAPPDATA = '$localAppDataRoot'
+. '$profilePath'
+winux list 6>&1 | Out-String
+"@
+    $listOutput = powershell -NoProfile -ExecutionPolicy Bypass -Command $verifyCommand
+    if ($LASTEXITCODE -ne 0) {
+        throw "generated Winux wrapper failed from installer-style root"
+    }
+
+    $listText = ($listOutput | Out-String)
+    if ($listText -notmatch 'Available WinuxCmd Commands:') {
+        throw "expected winux list output via installer-style root"
+    }
+    if ($listText -notmatch 'man\s*\r?\n\s*-> man\.exe') {
+        throw "expected installer-style root discovery to find man.exe"
+    }
+
+    $activateCommand = @"
+`$env:LOCALAPPDATA = '$localAppDataRoot'
+. '$profilePath'
+winux activate | Out-String
+"@
+    $activateOutput = powershell -NoProfile -ExecutionPolicy Bypass -Command $activateCommand
+    if ($LASTEXITCODE -ne 0) {
+        throw "generated Winux wrapper failed to activate from installer-style root"
+    }
+
+    $activateText = ($activateOutput | Out-String)
+    if ($activateText -notmatch [regex]::Escape($installRoot)) {
+        throw "expected installer-style root to outrank newer WinGet versioned roots"
+    }
+}
+finally {
+    Remove-Item -LiteralPath Env:WINUXCMD_PROFILE_PATH -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/tests/scripts/winux_winget_discovery_test.ps1
+++ b/tests/scripts/winux_winget_discovery_test.ps1
@@ -1,0 +1,55 @@
+$ErrorActionPreference = "Stop"
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot "..\..")).Path
+$activateScript = Join-Path $repoRoot "scripts\winux-activate.ps1"
+$winuxScript = Join-Path $repoRoot "scripts\winux.ps1"
+
+$tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("winux-winget-discovery-" + [guid]::NewGuid().ToString("N"))
+$packageRoot = Join-Path $tempRoot "caomengxuan666.WinuxCmd_Microsoft.Winget.Source_8wekyb3d8bbwe"
+$installRoot = Join-Path $packageRoot "WinuxCmd-0.12.0-win-x64"
+$profilePath = Join-Path $tempRoot "profile.ps1"
+
+$null = New-Item -ItemType Directory -Path $installRoot -Force
+
+try {
+    Copy-Item -LiteralPath $activateScript -Destination (Join-Path $installRoot "winux-activate.ps1")
+    Copy-Item -LiteralPath $winuxScript -Destination (Join-Path $installRoot "winux.ps1")
+    foreach ($name in @("winuxcmd.exe", "ls.exe", "cat.exe", "man.exe")) {
+        Copy-Item -LiteralPath $env:ComSpec -Destination (Join-Path $installRoot $name)
+    }
+
+    $env:WINUXCMD_INSTALL_ROOTS = $packageRoot
+    $env:WINUXCMD_PROFILE_PATH = $profilePath
+
+    $installCommand = @"
+Set-Location '$installRoot'
+& '$installRoot\winux-activate.ps1' -Install -ProfilesOnly -Quiet
+"@
+    powershell -NoProfile -ExecutionPolicy Bypass -Command $installCommand | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+        throw "winux-activate.ps1 install exited with $LASTEXITCODE"
+    }
+
+    $verifyCommand = @"
+`$env:WINUXCMD_INSTALL_ROOTS = '$packageRoot'
+. '$profilePath'
+winux list 6>&1 | Out-String
+"@
+    $listOutput = powershell -NoProfile -ExecutionPolicy Bypass -Command $verifyCommand
+    if ($LASTEXITCODE -ne 0) {
+        throw "generated Winux wrapper failed to run from WinGet-style install root"
+    }
+
+    $listText = ($listOutput | Out-String)
+    if ($listText -notmatch 'Available WinuxCmd Commands:') {
+        throw "expected winux list output via generated wrapper"
+    }
+    if ($listText -notmatch 'ls\s*\r?\n\s*-> ls\.exe') {
+        throw "expected WinGet-style install root discovery to find ls.exe"
+    }
+}
+finally {
+    Remove-Item -LiteralPath Env:WINUXCMD_INSTALL_ROOTS -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath Env:WINUXCMD_PROFILE_PATH -ErrorAction SilentlyContinue
+    Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+}


### PR DESCRIPTION
## Summary
- add Inno Setup based installer packaging and release upload flow
- restore Winux installer and WinGet discovery in the PowerShell wrapper
- add PowerShell tests for installer root and WinGet package discovery

## Verification
- powershell -NoProfile -ExecutionPolicy Bypass -File tests/scripts/winux_activate_profile_cleanup_test.ps1
- powershell -NoProfile -ExecutionPolicy Bypass -File tests/scripts/winux_command_discovery_test.ps1
- powershell -NoProfile -ExecutionPolicy Bypass -File tests/scripts/winux_winget_discovery_test.ps1
- powershell -NoProfile -ExecutionPolicy Bypass -File tests/scripts/winux_installer_root_discovery_test.ps1
- powershell -NoProfile -ExecutionPolicy Bypass -File scripts/build-installer.ps1 -Root C:\\Users\\cmx\\repo\\WinuxCmd -Arch x64 -IsccPath 'C:\\Users\\cmx\\tools\\Inno Setup 6\\ISCC.exe'