### PR TITLE
Automate WPM source index updates

### DIFF
--- a/.github/scripts/update-wpm-source-index.ps1
+++ b/.github/scripts/update-wpm-source-index.ps1
@@ -1,0 +1,100 @@
+<#
+.SYNOPSIS
+    Update the official WPM source index for a WinuxCmd release.
+#>
+
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$IndexPath,
+
+    [Parameter(Mandatory = $true)]
+    [string]$Version,
+
+    [Parameter(Mandatory = $true)]
+    [string]$X64ZipPath,
+
+    [Parameter(Mandatory = $true)]
+    [string]$Arm64ZipPath,
+
+    [Parameter(Mandatory = $false)]
+    [string]$Repository = "unixwin/WinuxCmd",
+
+    [Parameter(Mandatory = $false)]
+    [string]$ReleaseTag = "v$Version",
+
+    [Parameter(Mandatory = $false)]
+    [string]$UpdatedDate = (Get-Date -Format "yyyy-MM-dd")
+)
+
+$ErrorActionPreference = "Stop"
+
+if ($Version -notmatch '^\d+\.\d+\.\d+$') {
+    throw "Invalid version '$Version'. Expected semantic version like 0.14.3."
+}
+
+if ($UpdatedDate -notmatch '^\d{4}-\d{2}-\d{2}$') {
+    throw "Invalid updated date '$UpdatedDate'. Expected yyyy-MM-dd."
+}
+
+$resolvedIndex = Resolve-Path -LiteralPath $IndexPath -ErrorAction Stop
+$resolvedX64 = Resolve-Path -LiteralPath $X64ZipPath -ErrorAction Stop
+$resolvedArm64 = Resolve-Path -LiteralPath $Arm64ZipPath -ErrorAction Stop
+
+$index = Get-Content -LiteralPath $resolvedIndex -Raw | ConvertFrom-Json
+$package = $index.packages | Where-Object { $_.name -eq "winuxcmd" } | Select-Object -First 1
+if ($null -eq $package) {
+    throw "Package 'winuxcmd' was not found in $resolvedIndex."
+}
+
+function Update-Artifact {
+    param(
+        [Parameter(Mandatory = $true)]
+        [pscustomobject]$Artifacts,
+
+        [Parameter(Mandatory = $true)]
+        [string]$Arch,
+
+        [Parameter(Mandatory = $true)]
+        [string]$ArchivePath,
+
+        [Parameter(Mandatory = $true)]
+        [string]$AssetName
+    )
+
+    $property = $Artifacts.PSObject.Properties[$Arch]
+    if ($null -eq $property) {
+        throw "Artifact '$Arch' was not found for package 'winuxcmd'."
+    }
+
+    $artifact = $property.Value
+    $artifact.type = "zip"
+    $artifact.sha256 = (Get-FileHash -Algorithm SHA256 -LiteralPath $ArchivePath).Hash.ToLowerInvariant()
+    $artifact.urls = @("https://github.com/$Repository/releases/download/$ReleaseTag/$AssetName")
+    $artifact.files = @(
+        [pscustomobject]@{
+            from = "winuxcmd.exe"
+            to = "winuxcmd.exe"
+        }
+    )
+}
+
+$index.version = "official-" + $UpdatedDate.Replace("-", ".")
+$index.updated = $UpdatedDate
+$package.version = $Version
+
+Update-Artifact `
+    -Artifacts $package.artifacts `
+    -Arch "windows-x64" `
+    -ArchivePath $resolvedX64 `
+    -AssetName "WinuxCmd-$Version-win-x64.zip"
+
+Update-Artifact `
+    -Artifacts $package.artifacts `
+    -Arch "windows-arm64" `
+    -ArchivePath $resolvedArm64 `
+    -AssetName "WinuxCmd-$Version-win-arm64.zip"
+
+$json = $index | ConvertTo-Json -Depth 100
+Set-Content -LiteralPath $resolvedIndex -Value $json -Encoding utf8NoBOM
+
+Write-Host "Updated winuxcmd WPM index metadata to $Version."

--- a/.github/workflows/build-winuxcmd.yml
+++ b/.github/workflows/build-winuxcmd.yml
@@ -279,9 +279,95 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+  update-wpm-source-index:
+    runs-on: ubuntu-latest
+    needs: release
+    if: github.ref_type == 'tag' && startsWith(github.ref_name, 'v')
+
+    steps:
+      - name: Verify wpm-source token
+        shell: bash
+        env:
+          WPM_SOURCE_TOKEN: ${{ secrets.WPM_SOURCE_TOKEN }}
+        run: |
+          if [ -z "${WPM_SOURCE_TOKEN}" ]; then
+            echo "::error::Set WPM_SOURCE_TOKEN to a token with write access to unixwin/wpm-source."
+            exit 1
+          fi
+
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 1
+
+      - name: Checkout WPM Source
+        uses: actions/checkout@v6
+        with:
+          repository: unixwin/wpm-source
+          token: ${{ secrets.WPM_SOURCE_TOKEN }}
+          path: wpm-source
+          fetch-depth: 1
+
+      - name: Download x64 Packages
+        uses: actions/download-artifact@v8
+        with:
+          name: WinuxCmd-${{ needs.release.outputs.version }}-x64
+          path: artifacts/x64
+
+      - name: Download ARM64 Packages
+        uses: actions/download-artifact@v8
+        with:
+          name: WinuxCmd-${{ needs.release.outputs.version }}-arm64
+          path: artifacts/arm64
+
+      - name: Update WPM source index
+        shell: pwsh
+        run: |
+          ./.github/scripts/update-wpm-source-index.ps1 `
+            -IndexPath "wpm-source/index.json" `
+            -Version "${{ needs.release.outputs.version }}" `
+            -X64ZipPath "artifacts/x64/WinuxCmd-${{ needs.release.outputs.version }}-win-x64.zip" `
+            -Arm64ZipPath "artifacts/arm64/WinuxCmd-${{ needs.release.outputs.version }}-win-arm64.zip" `
+            -ReleaseTag "${{ github.ref_name }}"
+
+      - name: Create and merge wpm-source PR
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.WPM_SOURCE_TOKEN }}
+          VERSION: ${{ needs.release.outputs.version }}
+        run: |
+          set -euo pipefail
+
+          cd wpm-source
+          if git diff --quiet -- index.json; then
+            echo "wpm-source index already matches WinuxCmd ${VERSION}."
+            exit 0
+          fi
+
+          branch="automation/winuxcmd-${VERSION}-index"
+          title="Update WinuxCmd package index to ${VERSION}"
+          body="Automated update from unixwin/WinuxCmd release v${VERSION}."
+
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -B "${branch}"
+          git add index.json
+          git commit -m "${title}"
+          git push --force-with-lease origin "${branch}"
+
+          pr_url="$(gh pr list --repo unixwin/wpm-source --head "${branch}" --state open --json url --jq '.[0].url')"
+          if [ -z "${pr_url}" ]; then
+            pr_url="$(gh pr create --repo unixwin/wpm-source --base main --head "${branch}" --title "${title}" --body "${body}")"
+          fi
+
+          gh pr merge "${pr_url}" --repo unixwin/wpm-source --squash --delete-branch ||
+            gh pr merge "${pr_url}" --repo unixwin/wpm-source --squash --delete-branch --auto
+
   cache-and-notify:
     runs-on: windows-2025
-    needs: release  # Depends on release job
+    needs:
+      - release
+      - update-wpm-source-index
     if: github.ref_type == 'tag' && startsWith(github.ref_name, 'v')  # Only run on tag releases
 
     steps:


### PR DESCRIPTION
## Summary
- add a release helper script that updates wpm-source index metadata from release zip artifacts
- add a tag-release CI job that downloads x64/arm64 packages, updates unixwin/wpm-source, opens a PR, and merges it when possible
- make cache refresh wait until the WPM source index update finishes

## Setup needed
- add a WinuxCmd repository secret named WPM_SOURCE_TOKEN with write access to unixwin/wpm-source

## Tests
- local PowerShell parser check for update-wpm-source-index.ps1
- local dry-run against a temp copy of wpm-source/index.json
- git diff --check