### PR TITLE
Reuse valid WPM artifact cache

### DIFF
--- a/src/commands/wpm.cpp
+++ b/src/commands/wpm.cpp
@@ -1061,6 +1061,16 @@ auto verify_sha256(const fs::path& file, std::string expected) -> bool {
   return true;
 }
 
+auto cached_artifact_is_valid(const fs::path& file, std::string expected)
+    -> bool {
+  if (expected.empty()) return false;
+  std::error_code ec;
+  if (!fs::is_regular_file(file, ec)) return false;
+  expected = lower_ascii(expected);
+  auto actual = sha256_file(file);
+  return actual && *actual == expected;
+}
+
 auto run_process(const std::wstring& command, const fs::path& cwd = {}) -> int {
   std::wstring mutable_cmd = command;
   STARTUPINFOW si{};
@@ -1214,6 +1224,15 @@ auto download_artifact(const fs::path& root, const std::string& package,
 
   std::string type = artifact.value("type", "exe");
   fs::path out = cache_dir(root) / (package + "." + type);
+  std::string expected_sha = artifact.value("sha256", "");
+  if (cached_artifact_is_valid(out, expected_sha)) {
+    if (verbose) safePrintLn("wpm: using cached " + out.string());
+    return out;
+  }
+  if (fs::exists(out)) {
+    std::error_code ec;
+    fs::remove(out, ec);
+  }
   for (const auto& url : urls) {
     if (verbose) safePrintLn("wpm: downloading " + url);
     auto result = http_get(url, "wpm: downloading " + package);
@@ -1226,7 +1245,7 @@ auto download_artifact(const fs::path& root, const std::string& package,
       safeErrorPrintLn("wpm: failed to write cache file " + out.string());
       continue;
     }
-    if (!verify_sha256(out, artifact.value("sha256", ""))) {
+    if (!verify_sha256(out, expected_sha)) {
       std::error_code ec;
       fs::remove(out, ec);
       continue;

--- a/tests/unit/wpm/wpm_unit_test.cpp
+++ b/tests/unit/wpm/wpm_unit_test.cpp
@@ -611,6 +611,28 @@ TEST(wpm, wpm_install_existing_package_skips_download) {
   EXPECT_EQ(tmp.read("jq.exe"), "already here\n");
 }
 
+TEST(wpm, wpm_install_uses_valid_cached_artifact_before_downloading) {
+  TempDir tmp;
+  const auto missing_artifact_path = tmp.path / L"source" / L"jq.exe";
+  tmp.write(".wpm/indexes/official.json",
+            install_fixture_index_json(missing_artifact_path));
+  tmp.write(".wpm/cache/jq.exe", "external exe\n");
+
+  Pipeline install;
+  install.add(L"winuxcmd.exe",
+              {L"wpm", L"install", L"jq", L"--root", tmp.wpath()});
+  auto install_result = install.run();
+
+  EXPECT_EQ(install_result.exit_code, 0);
+  EXPECT_TRUE(install_result.stdout_text.find("installed jq") !=
+              std::string::npos);
+  EXPECT_TRUE(install_result.stdout_text.find("downloading jq") ==
+              std::string::npos);
+  EXPECT_TRUE(install_result.stderr_text.find("download failed") ==
+              std::string::npos);
+  EXPECT_EQ(tmp.read("jq.exe"), "external exe\n");
+}
+
 TEST(wpm, wpm_install_dry_run_does_not_claim_install_success) {
   TempDir tmp;
   const auto artifact_path = tmp.path / L"source" / L"jq.exe";


### PR DESCRIPTION
## Summary
- reuse an existing WPM artifact cache file when its SHA256 matches the package index
- remove stale cache files before retrying downloads
- add a regression test covering cache reuse before network download

## Validation
- git diff --check
- isolated fd install reproduced a single download

Note: full winuxcmd-tests could not run locally because CMake benchmark FetchContent needs GitHub access and the available toolchains are missing either compatible C++23 module support or Windows SDK rc/mt tools.