### PR TITLE
Enhance WPM artifact installation

### DIFF
--- a/src/commands/wpm.cpp
+++ b/src/commands/wpm.cpp
@@ -1071,6 +1071,43 @@ auto cached_artifact_is_valid(const fs::path& file, std::string expected)
   return actual && *actual == expected;
 }
 
+auto supported_artifact_type(std::string_view type) -> bool {
+  return type == "exe" || type == "zip" || type == "tar.gz" || type == "tgz" ||
+         type == "tar.xz";
+}
+
+auto archive_artifact_type(std::string_view type) -> bool {
+  return type == "zip" || type == "tar.gz" || type == "tgz" || type == "tar.xz";
+}
+
+auto artifact_cache_extension(std::string_view type) -> std::string {
+  if (type == "tgz") return "tar.gz";
+  return std::string(type);
+}
+
+auto artifact_size_bytes(const nlohmann::json& artifact)
+    -> std::optional<unsigned long long> {
+  for (const auto* key : {"size", "size_bytes"}) {
+    if (!artifact.contains(key)) continue;
+    const auto& value = artifact[key];
+    if (value.is_number_unsigned()) {
+      return value.get<unsigned long long>();
+    }
+    if (value.is_number_integer()) {
+      auto signed_value = value.get<long long>();
+      if (signed_value >= 0)
+        return static_cast<unsigned long long>(signed_value);
+    }
+    if (value.is_string()) {
+      try {
+        return std::stoull(value.get<std::string>());
+      } catch (...) {
+      }
+    }
+  }
+  return std::nullopt;
+}
+
 auto run_process(const std::wstring& command, const fs::path& cwd = {}) -> int {
   std::wstring mutable_cmd = command;
   STARTUPINFOW si{};
@@ -1099,17 +1136,45 @@ auto quote(const fs::path& p) -> std::wstring {
   return out;
 }
 
-auto extract_zip(const fs::path& zip, const fs::path& dest) -> bool {
+auto extract_archive(const fs::path& archive, const fs::path& dest,
+                     std::string_view type) -> bool {
   std::error_code ec;
   fs::create_directories(dest, ec);
-  std::wstring command = L"tar.exe -xf " + quote(zip) + L" -C " + quote(dest);
+  std::wstring command =
+      L"tar.exe -xf " + quote(archive) + L" -C " + quote(dest);
   int code = run_process(command);
   if (code != 0) {
-    safeErrorPrintLn("wpm: zip extraction failed; Windows tar.exe returned " +
+    safeErrorPrintLn("wpm: " + std::string(type) +
+                     " extraction failed; Windows tar.exe returned " +
                      std::to_string(code));
     return false;
   }
   return true;
+}
+
+auto trim_trailing_separators(std::string value) -> std::string {
+  while (!value.empty() && (value.back() == '/' || value.back() == '\\')) {
+    value.pop_back();
+  }
+  return value;
+}
+
+auto mapping_is_directory(const nlohmann::json& mapping) -> bool {
+  std::string kind = lower_ascii(mapping.value("kind", ""));
+  if (kind == "dir" || kind == "directory") return true;
+  std::string from = mapping.value("from", "");
+  if (!from.empty() && (from.back() == '/' || from.back() == '\\')) return true;
+  if (mapping.contains("to") && mapping["to"].is_string()) {
+    std::string to = mapping["to"].get<std::string>();
+    if (!to.empty() && (to.back() == '/' || to.back() == '\\')) return true;
+  }
+  return false;
+}
+
+auto mapping_default_to(const std::string& from, bool directory)
+    -> std::string {
+  std::string clean = directory ? trim_trailing_separators(from) : from;
+  return fs::path(clean).filename().string();
 }
 
 auto find_file_recursive(const fs::path& root, std::string_view filename)
@@ -1127,13 +1192,103 @@ auto find_file_recursive(const fs::path& root, std::string_view filename)
   return std::nullopt;
 }
 
-auto find_artifact_file(const fs::path& root, std::string_view from)
+auto find_directory_recursive(const fs::path& root, std::string_view dirname)
     -> std::optional<fs::path> {
-  fs::path requested = fs::path(std::string(from));
+  std::error_code ec;
+  if (!fs::exists(root, ec)) return std::nullopt;
+  for (const auto& entry : fs::recursive_directory_iterator(root, ec)) {
+    if (ec) break;
+    if (!entry.is_directory(ec)) continue;
+    if (lower_ascii(entry.path().filename().string()) ==
+        lower_ascii(std::string(dirname))) {
+      return entry.path();
+    }
+  }
+  return std::nullopt;
+}
+
+auto find_single_regular_file(const fs::path& root) -> std::optional<fs::path> {
+  std::error_code ec;
+  std::optional<fs::path> only;
+  if (!fs::exists(root, ec)) return std::nullopt;
+  for (const auto& entry : fs::recursive_directory_iterator(root, ec)) {
+    if (ec) break;
+    if (!entry.is_regular_file(ec)) continue;
+    if (only) return std::nullopt;
+    only = entry.path();
+  }
+  return only;
+}
+
+auto find_artifact_path(const fs::path& root, std::string_view from,
+                        bool directory, bool allow_single_file_fallback)
+    -> std::optional<fs::path> {
+  std::string clean = directory ? trim_trailing_separators(std::string(from))
+                                : std::string(from);
+  fs::path requested = fs::path(clean);
   std::error_code ec;
   auto direct = root / requested;
+  if (directory) {
+    if (fs::is_directory(direct, ec)) return direct;
+    return find_directory_recursive(root, requested.filename().string());
+  }
   if (fs::is_regular_file(direct, ec)) return direct;
-  return find_file_recursive(root, requested.filename().string());
+  if (auto found = find_file_recursive(root, requested.filename().string()))
+    return found;
+  if (allow_single_file_fallback) return find_single_regular_file(root);
+  return std::nullopt;
+}
+
+auto copy_directory_contents(const fs::path& src, const fs::path& dest,
+                             bool force) -> bool {
+  std::error_code ec;
+  if (fs::exists(dest, ec) && !fs::is_directory(dest, ec)) {
+    safeErrorPrintLn("wpm: destination exists and is not a directory: " +
+                     dest.string());
+    return false;
+  }
+  fs::create_directories(dest, ec);
+  if (ec) {
+    safeErrorPrintLn("wpm: failed to create directory '" + dest.string() +
+                     "': " + ec.message());
+    return false;
+  }
+
+  for (const auto& entry : fs::recursive_directory_iterator(src, ec)) {
+    if (ec) {
+      safeErrorPrintLn("wpm: failed to read directory '" + src.string() +
+                       "': " + ec.message());
+      return false;
+    }
+    auto relative = fs::relative(entry.path(), src, ec);
+    if (ec) {
+      safeErrorPrintLn("wpm: failed to map directory entry '" +
+                       entry.path().string() + "': " + ec.message());
+      return false;
+    }
+    auto target = dest / relative;
+    if (entry.is_directory(ec)) {
+      fs::create_directories(target, ec);
+      if (ec) {
+        safeErrorPrintLn("wpm: failed to create directory '" + target.string() +
+                         "': " + ec.message());
+        return false;
+      }
+      continue;
+    }
+    if (!entry.is_regular_file(ec)) continue;
+    fs::create_directories(target.parent_path(), ec);
+    fs::copy_file(
+        entry.path(), target,
+        force ? fs::copy_options::overwrite_existing : fs::copy_options::none,
+        ec);
+    if (ec) {
+      safeErrorPrintLn("wpm: failed to copy '" + entry.path().string() +
+                       "' to '" + target.string() + "': " + ec.message());
+      return false;
+    }
+  }
+  return true;
 }
 
 auto artifact_for_current_arch(const nlohmann::json& pkg)
@@ -1181,6 +1336,8 @@ auto join_json_string_array(const nlohmann::json& object, std::string_view key)
 auto artifact_install_state(const nlohmann::json& pkg) -> std::string {
   auto artifact = artifact_for_current_arch(pkg);
   if (!artifact) return "metadata-only (no current-arch artifact)";
+  if (!supported_artifact_type(artifact->value("type", "exe")))
+    return "metadata-only (unsupported artifact type)";
   if (artifact_urls(*artifact).empty())
     return "metadata-only (no download URLs)";
   if (artifact->value("sha256", "").empty())
@@ -1223,7 +1380,8 @@ auto download_artifact(const fs::path& root, const std::string& package,
   }
 
   std::string type = artifact.value("type", "exe");
-  fs::path out = cache_dir(root) / (package + "." + type);
+  fs::path out =
+      cache_dir(root) / (package + "." + artifact_cache_extension(type));
   std::string expected_sha = artifact.value("sha256", "");
   if (cached_artifact_is_valid(out, expected_sha)) {
     if (verbose) safePrintLn("wpm: using cached " + out.string());
@@ -1266,17 +1424,20 @@ auto copy_artifact_files(const fs::path& extracted, const fs::path& root,
 
   for (const auto& mapping : artifact["files"]) {
     std::string from = mapping.value("from", "");
+    bool directory = mapping_is_directory(mapping);
     std::string to = mapping.contains("to") && mapping["to"].is_string()
                          ? mapping["to"].get<std::string>()
-                         : fs::path(from).filename().string();
+                         : mapping_default_to(from, directory);
     if (from.empty() || to.empty()) {
       safeErrorPrintLn("wpm: invalid file mapping in artifact");
       return false;
     }
 
-    auto src = find_artifact_file(extracted, from);
+    bool single_file_fallback = artifact.value("type", "exe") == "exe";
+    auto src =
+        find_artifact_path(extracted, from, directory, single_file_fallback);
     if (!src) {
-      safeErrorPrintLn("wpm: extracted file not found: " + from);
+      safeErrorPrintLn("wpm: extracted path not found: " + from);
       return false;
     }
 
@@ -1287,7 +1448,17 @@ auto copy_artifact_files(const fs::path& extracted, const fs::path& root,
                               same_file(root / "winuxcmd.exe", dest) &&
                               !same_path_name(root / "winuxcmd.exe", dest);
     bool dest_is_legacy_link = is_legacy_link_name(dest.filename().string());
-    if (dest_exists && !dest_is_winux_link && !force &&
+    if (directory && dest_exists && !fs::is_directory(dest, ec)) {
+      safeErrorPrintLn("wpm: destination exists and is not a directory: " +
+                       dest.string());
+      return false;
+    }
+    if (directory && dest_exists && !force) {
+      safeErrorPrintLn("wpm: destination exists; use --force: " +
+                       dest.string());
+      return false;
+    }
+    if (dest_exists && !dest_is_winux_link && !force && !directory &&
         !same_file(*src, dest)) {
       safeErrorPrintLn("wpm: destination exists; use --force: " +
                        dest.string());
@@ -1300,10 +1471,16 @@ auto copy_artifact_files(const fs::path& extracted, const fs::path& root,
       return false;
     }
     if (dry_run) {
-      safePrintLn("would copy " + src->string() + " -> " + dest.string());
+      safePrintLn(
+          std::string(directory ? "would copy directory " : "would copy ") +
+          src->string() + " -> " + dest.string());
       continue;
     }
     fs::create_directories(dest.parent_path(), ec);
+    if (directory) {
+      if (!copy_directory_contents(*src, dest, force)) return false;
+      continue;
+    }
     if (dest_is_winux_link) {
       if (!DeleteFileW(dest.wstring().c_str())) {
         safeErrorPrintLn("wpm: failed to break WinuxCmd hardlink '" +
@@ -1333,9 +1510,10 @@ auto artifact_destination_paths(const fs::path& root,
   std::vector<fs::path> destinations;
   for (const auto& mapping : artifact["files"]) {
     std::string from = mapping.value("from", "");
+    bool directory = mapping_is_directory(mapping);
     std::string to = mapping.contains("to") && mapping["to"].is_string()
                          ? mapping["to"].get<std::string>()
-                         : fs::path(from).filename().string();
+                         : mapping_default_to(from, directory);
     if (from.empty() || to.empty()) {
       safeErrorPrintLn("wpm: invalid file mapping in artifact");
       return std::nullopt;
@@ -1460,8 +1638,8 @@ auto install_package(const Options& opts, std::string_view package_name)
   fs::create_directories(extracted, ec);
 
   std::string type = artifact->value("type", "exe");
-  if (type == "zip") {
-    if (!extract_zip(*downloaded, extracted)) return 1;
+  if (archive_artifact_type(type)) {
+    if (!extract_archive(*downloaded, extracted, type)) return 1;
   } else if (type == "exe") {
     fs::copy_file(*downloaded, extracted / downloaded->filename(),
                   fs::copy_options::overwrite_existing, ec);
@@ -1540,15 +1718,19 @@ auto update_winuxcmd(const Options& opts) -> int {
   fs::remove_all(extracted, ec);
   fs::create_directories(extracted, ec);
 
-  if (artifact->value("type", "zip") == "zip") {
-    if (!extract_zip(*downloaded, extracted)) return 1;
-  } else {
+  std::string type = artifact->value("type", "zip");
+  if (archive_artifact_type(type)) {
+    if (!extract_archive(*downloaded, extracted, type)) return 1;
+  } else if (type == "exe") {
     fs::copy_file(*downloaded, extracted / "winuxcmd.exe",
                   fs::copy_options::overwrite_existing, ec);
     if (ec) {
       safeErrorPrintLn("wpm: failed to stage winuxcmd.exe: " + ec.message());
       return 1;
     }
+  } else {
+    safeErrorPrintLn("wpm: unsupported artifact type: " + type);
+    return 1;
   }
 
   auto staged_exe = find_file_recursive(extracted, "winuxcmd.exe");
@@ -1817,6 +1999,9 @@ auto show_info(const Options& opts, std::string_view name) -> int {
   if (artifact) {
     safePrintLn("Type: " + artifact->value("type", ""));
     safePrintLn("URLs: " + std::to_string(artifact_urls(*artifact).size()));
+    if (auto size = artifact_size_bytes(*artifact)) {
+      safePrintLn("Size: " + human_size(*size));
+    }
     std::string sha256 = artifact->value("sha256", "");
     safePrintLn("SHA256: " +
                 std::string(sha256.empty() ? "missing" : "present"));
@@ -1861,7 +2046,7 @@ auto print_usage() -> int {
   safePrintLn(
       "  -n, --dry-run                 show planned changes without writing");
   safePrintLn("  -v, --verbose                 print detailed progress");
-  safePrintLn("  -h, --help                    display this help and exit");
+  safePrintLn("      --help                    display this help and exit");
   safePrintLn(
       "  -V, --version                 output version information and exit");
   return 0;

--- a/src/commands/wpm.cpp
+++ b/src/commands/wpm.cpp
@@ -893,6 +893,12 @@ auto apply_user_proxy(HINTERNET session, HINTERNET request,
   free_ie_proxy_config(ie_config);
 }
 
+auto loopback_proxy_candidates() -> std::vector<std::wstring> {
+  return {L"127.0.0.1:7897", L"127.0.0.1:7890",  L"127.0.0.1:7891",
+          L"127.0.0.1:7892", L"127.0.0.1:7893",  L"127.0.0.1:10808",
+          L"127.0.0.1:10809"};
+}
+
 auto response_header(HINTERNET request, DWORD query)
     -> std::optional<std::wstring> {
   DWORD size = 0;
@@ -937,7 +943,9 @@ auto redirect_url(std::wstring_view location, bool https,
 }
 
 auto http_get(std::string_view url, std::string_view progress_label = {},
-              int redirects_remaining = 5) -> HttpResult {
+              int redirects_remaining = 5,
+              std::optional<std::wstring> forced_proxy = std::nullopt,
+              bool allow_loopback_proxy_fallback = true) -> HttpResult {
   HttpResult result;
 
   if (starts_with_ci(url, "file://")) {
@@ -981,19 +989,40 @@ auto http_get(std::string_view url, std::string_view progress_label = {},
   if (path_part.empty()) path_part = L"/";
 
   bool https = parts.nScheme == INTERNET_SCHEME_HTTPS;
+  auto finish_failed = [&](HttpResult failed) -> HttpResult {
+    if (!forced_proxy) {
+      failed = with_urlmon_fallback(std::move(failed), wurl, progress_label);
+    }
+    if (failed.ok || forced_proxy || !allow_loopback_proxy_fallback) {
+      return failed;
+    }
+
+    auto original_error = failed.error;
+    for (const auto& proxy : loopback_proxy_candidates()) {
+      auto proxied = http_get(url, progress_label, redirects_remaining, proxy,
+                              false);
+      if (proxied.ok) return proxied;
+      if (!proxied.error.empty()) {
+        failed.error = original_error + "; loopback proxy " +
+                       wstring_to_utf8(proxy) + " failed: " + proxied.error;
+      }
+    }
+    return failed;
+  };
+
   HINTERNET session =
       WinHttpOpen(L"WinuxCmd-WPM/0.2", WINHTTP_ACCESS_TYPE_DEFAULT_PROXY,
                   WINHTTP_NO_PROXY_NAME, WINHTTP_NO_PROXY_BYPASS, 0);
   if (!session) {
     result.error = "failed to open WinHTTP session";
-    return with_urlmon_fallback(std::move(result), wurl, progress_label);
+    return finish_failed(std::move(result));
   }
 
   HINTERNET connect = WinHttpConnect(session, host.c_str(), parts.nPort, 0);
   if (!connect) {
     result.error = "failed to connect";
     WinHttpCloseHandle(session);
-    return with_urlmon_fallback(std::move(result), wurl, progress_label);
+    return finish_failed(std::move(result));
   }
 
   DWORD flags = https ? WINHTTP_FLAG_SECURE : 0;
@@ -1004,10 +1033,14 @@ auto http_get(std::string_view url, std::string_view progress_label = {},
     result.error = "failed to create request";
     WinHttpCloseHandle(connect);
     WinHttpCloseHandle(session);
-    return with_urlmon_fallback(std::move(result), wurl, progress_label);
+    return finish_failed(std::move(result));
   }
 
-  apply_user_proxy(session, request, wurl, https);
+  if (forced_proxy) {
+    set_request_proxy(request, *forced_proxy);
+  } else {
+    apply_user_proxy(session, request, wurl, https);
+  }
 
   DWORD timeout_ms = 12000;
   WinHttpSetOption(request, WINHTTP_OPTION_CONNECT_TIMEOUT, &timeout_ms,
@@ -1027,7 +1060,7 @@ auto http_get(std::string_view url, std::string_view progress_label = {},
     WinHttpCloseHandle(request);
     WinHttpCloseHandle(connect);
     WinHttpCloseHandle(session);
-    return with_urlmon_fallback(std::move(result), wurl, progress_label);
+    return finish_failed(std::move(result));
   }
 
   DWORD status = 0;
@@ -1044,7 +1077,8 @@ auto http_get(std::string_view url, std::string_view progress_label = {},
     WinHttpCloseHandle(session);
     if (location && !location->empty()) {
       return http_get(redirect_url(*location, https, host, parts.nPort),
-                      progress_label, redirects_remaining - 1);
+                      progress_label, redirects_remaining - 1, forced_proxy,
+                      allow_loopback_proxy_fallback);
     }
     result.error = "HTTP redirect without Location header";
     return result;
@@ -1054,7 +1088,7 @@ auto http_get(std::string_view url, std::string_view progress_label = {},
     WinHttpCloseHandle(request);
     WinHttpCloseHandle(connect);
     WinHttpCloseHandle(session);
-    return with_urlmon_fallback(std::move(result), wurl, progress_label);
+    return finish_failed(std::move(result));
   }
 
   std::optional<unsigned long long> expected_bytes;
@@ -1134,7 +1168,7 @@ auto http_get(std::string_view url, std::string_view progress_label = {},
   WinHttpCloseHandle(connect);
   WinHttpCloseHandle(session);
   if (!result.ok) {
-    return with_urlmon_fallback(std::move(result), wurl, progress_label);
+    return finish_failed(std::move(result));
   }
   return result;
 }

--- a/src/commands/wpm.cpp
+++ b/src/commands/wpm.cpp
@@ -722,6 +722,15 @@ auto http_get_urlmon(std::wstring_view url,
   return result;
 }
 
+auto with_urlmon_fallback(HttpResult result, std::wstring_view url,
+                          std::string_view progress_label = {}) -> HttpResult {
+  auto fallback = http_get_urlmon(url, progress_label);
+  if (fallback.ok) return fallback;
+  if (result.error.empty()) return fallback;
+  if (!fallback.error.empty()) result.error += "; " + fallback.error;
+  return result;
+}
+
 auto human_size(unsigned long long bytes) -> std::string {
   constexpr std::array<std::string_view, 5> units = {"B", "KiB", "MiB", "GiB",
                                                      "TiB"};
@@ -737,6 +746,151 @@ auto human_size(unsigned long long bytes) -> std::string {
 
 auto env_var_present(const char* name) -> bool {
   return GetEnvironmentVariableA(name, nullptr, 0) > 0;
+}
+
+auto env_var_value(const char* name) -> std::optional<std::string> {
+  DWORD size = GetEnvironmentVariableA(name, nullptr, 0);
+  if (size == 0) return std::nullopt;
+  std::string value(size, '\0');
+  DWORD written = GetEnvironmentVariableA(name, value.data(), size);
+  if (written == 0 || written >= size) return std::nullopt;
+  value.resize(written);
+  return value;
+}
+
+auto trim_ascii(std::string value) -> std::string {
+  auto is_space = [](unsigned char c) { return std::isspace(c) != 0; };
+  while (!value.empty() && is_space(static_cast<unsigned char>(value.front()))) {
+    value.erase(value.begin());
+  }
+  while (!value.empty() && is_space(static_cast<unsigned char>(value.back()))) {
+    value.pop_back();
+  }
+  if (value.size() >= 2 &&
+      ((value.front() == '"' && value.back() == '"') ||
+       (value.front() == '\'' && value.back() == '\''))) {
+    value = value.substr(1, value.size() - 2);
+  }
+  return value;
+}
+
+auto normalize_proxy_server(std::string value) -> std::optional<std::wstring> {
+  value = trim_ascii(std::move(value));
+  if (value.empty()) return std::nullopt;
+
+  auto lower = lower_ascii(value);
+  if (lower.find("http=") != std::string::npos ||
+      lower.find("https=") != std::string::npos) {
+    return utf8_to_wstring(value);
+  }
+
+  auto scheme = lower.find("://");
+  if (scheme != std::string::npos) {
+    auto scheme_name = lower.substr(0, scheme);
+    if (scheme_name != "http" && scheme_name != "https")
+      return std::nullopt;
+    value.erase(0, scheme + 3);
+  }
+
+  if (auto at = value.find('@'); at != std::string::npos) {
+    value.erase(0, at + 1);
+  }
+  if (auto slash = value.find_first_of("/?#"); slash != std::string::npos) {
+    value.resize(slash);
+  }
+
+  value = trim_ascii(std::move(value));
+  if (value.empty()) return std::nullopt;
+  return utf8_to_wstring(value);
+}
+
+auto proxy_from_environment(bool https) -> std::optional<std::wstring> {
+  std::array<std::string_view, 8> names =
+      https ? std::array<std::string_view, 8>{
+                  "WPM_HTTPS_PROXY", "WPM_HTTP_PROXY", "HTTPS_PROXY",
+                  "https_proxy", "ALL_PROXY", "all_proxy", "HTTP_PROXY",
+                  "http_proxy"}
+            : std::array<std::string_view, 8>{
+                  "WPM_HTTP_PROXY", "WPM_HTTPS_PROXY", "HTTP_PROXY",
+                  "http_proxy", "ALL_PROXY", "all_proxy", "HTTPS_PROXY",
+                  "https_proxy"};
+  for (auto name : names) {
+    std::string key(name);
+    if (auto value = env_var_value(key.c_str())) {
+      if (auto proxy = normalize_proxy_server(*value)) return proxy;
+    }
+  }
+  return std::nullopt;
+}
+
+void free_proxy_info(WINHTTP_PROXY_INFO& info) {
+  if (info.lpszProxy) GlobalFree(info.lpszProxy);
+  if (info.lpszProxyBypass) GlobalFree(info.lpszProxyBypass);
+  info.lpszProxy = nullptr;
+  info.lpszProxyBypass = nullptr;
+}
+
+void free_ie_proxy_config(WINHTTP_CURRENT_USER_IE_PROXY_CONFIG& config) {
+  if (config.lpszAutoConfigUrl) GlobalFree(config.lpszAutoConfigUrl);
+  if (config.lpszProxy) GlobalFree(config.lpszProxy);
+  if (config.lpszProxyBypass) GlobalFree(config.lpszProxyBypass);
+  config.lpszAutoConfigUrl = nullptr;
+  config.lpszProxy = nullptr;
+  config.lpszProxyBypass = nullptr;
+}
+
+auto set_request_proxy(HINTERNET request, const std::wstring& proxy,
+                       LPCWSTR bypass = WINHTTP_NO_PROXY_BYPASS) -> bool {
+  WINHTTP_PROXY_INFO info{};
+  info.dwAccessType = WINHTTP_ACCESS_TYPE_NAMED_PROXY;
+  info.lpszProxy = const_cast<LPWSTR>(proxy.c_str());
+  info.lpszProxyBypass = const_cast<LPWSTR>(bypass);
+  return WinHttpSetOption(request, WINHTTP_OPTION_PROXY, &info,
+                          sizeof(info)) != 0;
+}
+
+auto apply_user_proxy(HINTERNET session, HINTERNET request,
+                      std::wstring_view url, bool https) -> void {
+  if (auto proxy = proxy_from_environment(https)) {
+    set_request_proxy(request, *proxy);
+    return;
+  }
+
+  WINHTTP_CURRENT_USER_IE_PROXY_CONFIG ie_config{};
+  if (!WinHttpGetIEProxyConfigForCurrentUser(&ie_config)) return;
+
+  if (ie_config.lpszProxy && *ie_config.lpszProxy) {
+    std::wstring proxy(ie_config.lpszProxy);
+    LPCWSTR bypass = ie_config.lpszProxyBypass ? ie_config.lpszProxyBypass
+                                               : WINHTTP_NO_PROXY_BYPASS;
+    set_request_proxy(request, proxy, bypass);
+    free_ie_proxy_config(ie_config);
+    return;
+  }
+
+  if (ie_config.fAutoDetect || ie_config.lpszAutoConfigUrl) {
+    WINHTTP_AUTOPROXY_OPTIONS options{};
+    if (ie_config.lpszAutoConfigUrl && *ie_config.lpszAutoConfigUrl) {
+      options.dwFlags = WINHTTP_AUTOPROXY_CONFIG_URL;
+      options.lpszAutoConfigUrl = ie_config.lpszAutoConfigUrl;
+    } else {
+      options.dwFlags = WINHTTP_AUTOPROXY_AUTO_DETECT;
+      options.dwAutoDetectFlags =
+          WINHTTP_AUTO_DETECT_TYPE_DHCP | WINHTTP_AUTO_DETECT_TYPE_DNS_A;
+    }
+    options.fAutoLogonIfChallenged = TRUE;
+
+    WINHTTP_PROXY_INFO auto_proxy{};
+    std::wstring url_copy(url);
+    if (WinHttpGetProxyForUrl(session, url_copy.c_str(), &options,
+                              &auto_proxy)) {
+      WinHttpSetOption(request, WINHTTP_OPTION_PROXY, &auto_proxy,
+                       sizeof(auto_proxy));
+    }
+    free_proxy_info(auto_proxy);
+  }
+
+  free_ie_proxy_config(ie_config);
 }
 
 auto response_header(HINTERNET request, DWORD query)
@@ -832,16 +986,14 @@ auto http_get(std::string_view url, std::string_view progress_label = {},
                   WINHTTP_NO_PROXY_NAME, WINHTTP_NO_PROXY_BYPASS, 0);
   if (!session) {
     result.error = "failed to open WinHTTP session";
-    auto fallback = http_get_urlmon(wurl, progress_label);
-    return fallback.ok ? fallback : result;
+    return with_urlmon_fallback(std::move(result), wurl, progress_label);
   }
 
   HINTERNET connect = WinHttpConnect(session, host.c_str(), parts.nPort, 0);
   if (!connect) {
     result.error = "failed to connect";
     WinHttpCloseHandle(session);
-    auto fallback = http_get_urlmon(wurl, progress_label);
-    return fallback.ok ? fallback : result;
+    return with_urlmon_fallback(std::move(result), wurl, progress_label);
   }
 
   DWORD flags = https ? WINHTTP_FLAG_SECURE : 0;
@@ -852,9 +1004,10 @@ auto http_get(std::string_view url, std::string_view progress_label = {},
     result.error = "failed to create request";
     WinHttpCloseHandle(connect);
     WinHttpCloseHandle(session);
-    auto fallback = http_get_urlmon(wurl, progress_label);
-    return fallback.ok ? fallback : result;
+    return with_urlmon_fallback(std::move(result), wurl, progress_label);
   }
+
+  apply_user_proxy(session, request, wurl, https);
 
   DWORD timeout_ms = 12000;
   WinHttpSetOption(request, WINHTTP_OPTION_CONNECT_TIMEOUT, &timeout_ms,
@@ -874,8 +1027,7 @@ auto http_get(std::string_view url, std::string_view progress_label = {},
     WinHttpCloseHandle(request);
     WinHttpCloseHandle(connect);
     WinHttpCloseHandle(session);
-    auto fallback = http_get_urlmon(wurl, progress_label);
-    return fallback.ok ? fallback : result;
+    return with_urlmon_fallback(std::move(result), wurl, progress_label);
   }
 
   DWORD status = 0;
@@ -902,8 +1054,7 @@ auto http_get(std::string_view url, std::string_view progress_label = {},
     WinHttpCloseHandle(request);
     WinHttpCloseHandle(connect);
     WinHttpCloseHandle(session);
-    auto fallback = http_get_urlmon(wurl, progress_label);
-    return fallback.ok ? fallback : result;
+    return with_urlmon_fallback(std::move(result), wurl, progress_label);
   }
 
   std::optional<unsigned long long> expected_bytes;
@@ -983,8 +1134,7 @@ auto http_get(std::string_view url, std::string_view progress_label = {},
   WinHttpCloseHandle(connect);
   WinHttpCloseHandle(session);
   if (!result.ok) {
-    auto fallback = http_get_urlmon(wurl, progress_label);
-    return fallback.ok ? fallback : result;
+    return with_urlmon_fallback(std::move(result), wurl, progress_label);
   }
   return result;
 }

--- a/tests/unit/wpm/wpm_unit_test.cpp
+++ b/tests/unit/wpm/wpm_unit_test.cpp
@@ -38,6 +38,13 @@ auto file_url(std::filesystem::path path) -> std::string {
   return "file://" + text;
 }
 
+auto sha256_file_hex(const std::filesystem::path& path) -> std::string {
+  auto result = run_command(build_winuxcmd_path().wstring(),
+                            {L"sha256sum", path.wstring()});
+  if (result.exit_code != 0 || result.stdout_text.size() < 64) return "";
+  return result.stdout_text.substr(0, 64);
+}
+
 auto install_fixture_index_json(const std::filesystem::path& artifact_path)
     -> std::string {
   return "{\n"
@@ -631,6 +638,100 @@ TEST(wpm, wpm_install_uses_valid_cached_artifact_before_downloading) {
   EXPECT_TRUE(install_result.stderr_text.find("download failed") ==
               std::string::npos);
   EXPECT_EQ(tmp.read("jq.exe"), "external exe\n");
+}
+
+TEST(wpm, wpm_install_single_exe_can_rename_command) {
+  TempDir tmp;
+  const auto artifact_path = tmp.path / L"source" / L"tealdeer-upstream.exe";
+  tmp.write("source/tealdeer-upstream.exe", "external exe\n");
+  tmp.write(".wpm/indexes/official.json",
+            "{\n"
+            "  \"schema\": 1,\n"
+            "  \"name\": \"fixture\",\n"
+            "  \"version\": \"fixture-single-exe-rename\",\n"
+            "  \"packages\": [\n"
+            "    {\"name\":\"tealdeer\",\"version\":\"1.0.0\","
+            "\"description\":\"single exe rename fixture\","
+            "\"kind\":\"external\",\"commands\":[\"tldr\"],"
+            "\"artifacts\":{\"" +
+                current_arch_key() +
+                "\":{\"type\":\"exe\","
+                "\"sha256\":"
+                "\"5140f4f6bf8b5691b7bccc1c4f00a2027dae00b2110d38a1e090af291226"
+                "f322\","
+                "\"urls\":[\"" +
+                file_url(artifact_path) +
+                "\"],\"files\":[{\"from\":\"tldr.exe\","
+                "\"to\":\"tldr.exe\"}]}}}\n"
+                "  ]\n"
+                "}\n");
+
+  Pipeline install;
+  install.add(L"winuxcmd.exe",
+              {L"wpm", L"install", L"tealdeer", L"--root", tmp.wpath()});
+  auto install_result = install.run();
+
+  EXPECT_EQ(install_result.exit_code, 0);
+  EXPECT_TRUE(install_result.stdout_text.find("installed tealdeer") !=
+              std::string::npos);
+  EXPECT_EQ(tmp.read("tldr.exe"), "external exe\n");
+}
+
+TEST(wpm, wpm_install_tar_gz_with_directory_mapping) {
+  TempDir tmp;
+  const auto payload_dir = tmp.path / L"payload";
+  const auto archive_path = tmp.path / L"tool.tar.gz";
+  tmp.write("payload/bin/tool.exe", "external exe\n");
+  tmp.write("payload/runtime/lang.txt", "runtime file\n");
+
+  auto tar_result = run_command(
+      L"tar.exe",
+      {L"-czf", archive_path.wstring(), L"-C", payload_dir.wstring(), L"."});
+  EXPECT_EQ(tar_result.exit_code, 0);
+  if (tar_result.exit_code != 0) return;
+
+  auto sha256 = sha256_file_hex(archive_path);
+  EXPECT_EQ(sha256.size(), 64u);
+  if (sha256.size() != 64) return;
+  auto size = std::filesystem::file_size(archive_path);
+  tmp.write(".wpm/indexes/official.json",
+            "{\n"
+            "  \"schema\": 1,\n"
+            "  \"name\": \"fixture\",\n"
+            "  \"version\": \"fixture-tar-gz-dir\",\n"
+            "  \"packages\": [\n"
+            "    {\"name\":\"tool\",\"version\":\"1.0.0\","
+            "\"description\":\"tar directory fixture\","
+            "\"kind\":\"external\",\"commands\":[\"tool\"],"
+            "\"artifacts\":{\"" +
+                current_arch_key() + "\":{\"type\":\"tar.gz\",\"size\":" +
+                std::to_string(size) + ",\"sha256\":\"" + sha256 +
+                "\",\"urls\":[\"" + file_url(archive_path) +
+                "\"],\"files\":["
+                "{\"from\":\"bin/tool.exe\",\"to\":\"tool.exe\"},"
+                "{\"from\":\"runtime\",\"to\":\"runtime\","
+                "\"kind\":\"dir\"}]}}}\n"
+                "  ]\n"
+                "}\n");
+
+  Pipeline info;
+  info.add(L"winuxcmd.exe", {L"wpm", L"info", L"tool", L"--root", tmp.wpath()});
+  auto info_result = info.run();
+  EXPECT_EQ(info_result.exit_code, 0);
+  EXPECT_TRUE(info_result.stdout_text.find("Type: tar.gz") !=
+              std::string::npos);
+  EXPECT_TRUE(info_result.stdout_text.find("Size: ") != std::string::npos);
+
+  Pipeline install;
+  install.add(L"winuxcmd.exe",
+              {L"wpm", L"install", L"tool", L"--root", tmp.wpath()});
+  auto install_result = install.run();
+
+  EXPECT_EQ(install_result.exit_code, 0);
+  EXPECT_TRUE(install_result.stdout_text.find("installed tool") !=
+              std::string::npos);
+  EXPECT_EQ(tmp.read("tool.exe"), "external exe\n");
+  EXPECT_EQ(tmp.read("runtime/lang.txt"), "runtime file\n");
 }
 
 TEST(wpm, wpm_install_dry_run_does_not_claim_install_success) {


### PR DESCRIPTION
## Summary
- support tar.gz/tgz/tar.xz artifacts through tar.exe extraction
- support directory mappings for packages like Helix runtime files
- show optional artifact size metadata in wpm info
- add tests for single-exe rename and tar.gz directory mapping

## Validation
- pwsh -NoProfile -Command "& 'C:/Users/Administrator/unixwin-winuxcmd/scripts/build-with-vs.ps1' -Root 'C:/Users/Administrator/unixwin-winuxcmd' -BuildDir 'build-wpm-dir-archive-nobench' -Target 'winuxcmd-tests' -Configuration 'Debug' -CMakeExtraArgs @('-DENABLE_TESTS=ON','-DENABLE_BENCHMARKS=OFF')"
- C:/Users/Administrator/unixwin-winuxcmd/build-wpm-dir-archive-nobench/tests/winuxcmd-tests.exe --gtest_filter=wpm.*