### PR TITLE
docs: update command counts

### DIFF
--- a/DOCS/generated/command_compatibility_matrix.json
+++ b/DOCS/generated/command_compatibility_matrix.json
@@ -30,7 +30,7 @@
   {
     "command": "b2sum",
     "source_file": "src/commands/b2sum.cpp",
-    "source_line_count": 365,
+    "source_line_count": 366,
     "upstream_source_line_count": 2346,
     "family": "gnu-coreutils",
     "reference_url": "https://www.gnu.org/software/coreutils/manual/",
@@ -128,7 +128,7 @@
   {
     "command": "base32",
     "source_file": "src/commands/base32.cpp",
-    "source_line_count": 218,
+    "source_line_count": 190,
     "upstream_source_line_count": 1556,
     "family": "gnu-coreutils",
     "reference_url": "https://www.gnu.org/software/coreutils/manual/",
@@ -170,7 +170,7 @@
   {
     "command": "base64",
     "source_file": "src/commands/base64.cpp",
-    "source_line_count": 220,
+    "source_line_count": 192,
     "upstream_source_line_count": 1556,
     "family": "gnu-coreutils",
     "reference_url": "https://www.gnu.org/software/coreutils/manual/",
@@ -178,7 +178,7 @@
     "option_count": 3,
     "placeholder_count": 0,
     "unsupported_count": 0,
-    "test_count": 11,
+    "test_count": 12,
     "perf_probe_count": 2,
     "perf_failure_count": 0,
     "perf_worst_ratio": 1.324,
@@ -275,7 +275,7 @@
   {
     "command": "basenc",
     "source_file": "src/commands/basenc.cpp",
-    "source_line_count": 479,
+    "source_line_count": 594,
     "upstream_source_line_count": 1556,
     "family": "gnu-coreutils",
     "reference_url": "https://www.gnu.org/software/coreutils/manual/",
@@ -283,7 +283,7 @@
     "option_count": 13,
     "placeholder_count": 0,
     "unsupported_count": 0,
-    "test_count": 16,
+    "test_count": 19,
     "perf_probe_count": 2,
     "perf_failure_count": 0,
     "perf_worst_ratio": 1.071,
@@ -387,7 +387,7 @@
   {
     "command": "cal",
     "source_file": "src/commands/cal.cpp",
-    "source_line_count": 171,
+    "source_line_count": 167,
     "upstream_source_line_count": 1212,
     "family": "util-linux",
     "reference_url": "https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/",
@@ -415,7 +415,7 @@
   {
     "command": "cat",
     "source_file": "src/commands/cat.cpp",
-    "source_line_count": 333,
+    "source_line_count": 331,
     "upstream_source_line_count": 834,
     "family": "gnu-coreutils",
     "reference_url": "https://www.gnu.org/software/coreutils/manual/",
@@ -423,7 +423,7 @@
     "option_count": 10,
     "placeholder_count": 1,
     "unsupported_count": 0,
-    "test_count": 16,
+    "test_count": 19,
     "perf_probe_count": 3,
     "perf_failure_count": 0,
     "perf_worst_ratio": 1.121,
@@ -503,6 +503,39 @@
       "Has compatibility placeholder/no-op option(s).",
       "Performance probes: 3."
     ]
+  },
+  {
+    "command": "chattr",
+    "source_file": "src/commands/chattr.cpp",
+    "source_line_count": 185,
+    "upstream_source_line_count": 0,
+    "family": "local",
+    "reference_url": "",
+    "priority": "P2",
+    "option_count": 2,
+    "placeholder_count": 0,
+    "unsupported_count": 0,
+    "test_count": 4,
+    "perf_probe_count": 0,
+    "perf_failure_count": 0,
+    "perf_worst_ratio": null,
+    "options": [
+      {
+        "short": "-R",
+        "long": "--recursive",
+        "description": "recursively change attributes of directories",
+        "value_type": "flag",
+        "status": "declared"
+      },
+      {
+        "short": "-V",
+        "long": "--verbose",
+        "description": "print changed files",
+        "value_type": "flag",
+        "status": "declared"
+      }
+    ],
+    "notes": []
   },
   {
     "command": "chcon",
@@ -969,7 +1002,7 @@
   {
     "command": "chroot",
     "source_file": "src/commands/chroot.cpp",
-    "source_line_count": 76,
+    "source_line_count": 75,
     "upstream_source_line_count": 372,
     "family": "gnu-coreutils",
     "reference_url": "https://www.gnu.org/software/coreutils/manual/",
@@ -1011,7 +1044,7 @@
   {
     "command": "cksum",
     "source_file": "src/commands/cksum.cpp",
-    "source_line_count": 660,
+    "source_line_count": 667,
     "upstream_source_line_count": 2023,
     "family": "gnu-coreutils",
     "reference_url": "https://www.gnu.org/software/coreutils/manual/",
@@ -1214,7 +1247,7 @@
   {
     "command": "col",
     "source_file": "src/commands/col.cpp",
-    "source_line_count": 181,
+    "source_line_count": 182,
     "upstream_source_line_count": 641,
     "family": "util-linux",
     "reference_url": "https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/",
@@ -1270,12 +1303,12 @@
   {
     "command": "column",
     "source_file": "src/commands/column.cpp",
-    "source_line_count": 433,
+    "source_line_count": 432,
     "upstream_source_line_count": 1158,
     "family": "util-linux",
     "reference_url": "https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/",
     "priority": "P1",
-    "option_count": 28,
+    "option_count": 27,
     "placeholder_count": 0,
     "unsupported_count": 0,
     "test_count": 14,
@@ -1468,13 +1501,6 @@
       {
         "short": "",
         "long": "--help",
-        "description": "display this help and exit",
-        "value_type": "BOOL_TYPE",
-        "status": "declared"
-      },
-      {
-        "short": "-h",
-        "long": "help",
         "description": "display this help and exit",
         "value_type": "BOOL_TYPE",
         "status": "declared"
@@ -1893,7 +1919,7 @@
   {
     "command": "csplit",
     "source_file": "src/commands/csplit.cpp",
-    "source_line_count": 515,
+    "source_line_count": 512,
     "upstream_source_line_count": 1210,
     "family": "gnu-coreutils",
     "reference_url": "https://www.gnu.org/software/coreutils/manual/",
@@ -2069,7 +2095,7 @@
   {
     "command": "cygpath",
     "source_file": "src/commands/cygpath.cpp",
-    "source_line_count": 340,
+    "source_line_count": 501,
     "upstream_source_line_count": 1001,
     "family": "cygpath",
     "reference_url": "https://cygwin.com/cygwin-ug-net/cygpath.html",
@@ -2077,7 +2103,7 @@
     "option_count": 23,
     "placeholder_count": 0,
     "unsupported_count": 0,
-    "test_count": 8,
+    "test_count": 12,
     "perf_probe_count": 3,
     "perf_failure_count": 0,
     "perf_worst_ratio": 1.367,
@@ -2120,7 +2146,7 @@
       {
         "short": "-d",
         "long": "--dos",
-        "description": "print DOS short form of NAMEs [accepted, not implemented]",
+        "description": "print DOS short form of NAMEs",
         "value_type": "flag",
         "status": "declared"
       },
@@ -2141,7 +2167,7 @@
       {
         "short": "-f",
         "long": "--file",
-        "description": "read input paths from FILE [not implemented]",
+        "description": "read input paths from FILE",
         "value_type": "STRING_TYPE",
         "status": "declared"
       },
@@ -2155,84 +2181,84 @@
       {
         "short": "-l",
         "long": "--long-name",
-        "description": "print Windows long form [accepted, not implemented]",
+        "description": "print Windows long form",
         "value_type": "flag",
         "status": "declared"
       },
       {
         "short": "-s",
         "long": "--short-name",
-        "description": "print DOS short form [accepted, not implemented]",
+        "description": "print DOS short form",
         "value_type": "flag",
         "status": "declared"
       },
       {
         "short": "-U",
         "long": "--proc-cygdrive",
-        "description": "emit /proc/cygdrive paths [accepted, not implemented]",
+        "description": "emit /proc/cygdrive paths",
         "value_type": "flag",
         "status": "declared"
       },
       {
         "short": "-C",
         "long": "--codepage",
-        "description": "print Windows path in codepage CP [accepted, not implemented]",
+        "description": "print Windows path in codepage CP",
         "value_type": "STRING_TYPE",
         "status": "declared"
       },
       {
         "short": "-M",
         "long": "--mode",
-        "description": "report file text/binary mode [not implemented]",
+        "description": "report file text/binary mode",
         "value_type": "flag",
         "status": "declared"
       },
       {
         "short": "-A",
         "long": "--allusers",
-        "description": "use All Users for special folders [not implemented]",
+        "description": "use All Users for special folders",
         "value_type": "flag",
         "status": "declared"
       },
       {
         "short": "-D",
         "long": "--desktop",
-        "description": "output Desktop directory [not implemented]",
+        "description": "output Desktop directory",
         "value_type": "flag",
         "status": "declared"
       },
       {
         "short": "-H",
         "long": "--homeroot",
-        "description": "output Profiles directory [not implemented]",
+        "description": "output Profiles directory",
         "value_type": "flag",
         "status": "declared"
       },
       {
         "short": "-O",
         "long": "--mydocs",
-        "description": "output My Documents directory [not implemented]",
+        "description": "output My Documents directory",
         "value_type": "flag",
         "status": "declared"
       },
       {
         "short": "-P",
         "long": "--smprograms",
-        "description": "output Start Menu Programs directory [not implemented]",
+        "description": "output Start Menu Programs directory",
         "value_type": "flag",
         "status": "declared"
       },
       {
         "short": "-S",
         "long": "--sysdir",
-        "description": "output system directory [not implemented]",
+        "description": "output system directory",
         "value_type": "flag",
         "status": "declared"
       },
       {
         "short": "-W",
         "long": "--windir",
-        "description": "output Windows directory [not implemented]",
+        "description": "output Windows directory",
         "value_type": "flag",
         "status": "declared"
       },
@@ -2454,7 +2480,7 @@
   {
     "command": "df",
     "source_file": "src/commands/df.cpp",
-    "source_line_count": 906,
+    "source_line_count": 903,
     "upstream_source_line_count": 1600,
     "family": "gnu-coreutils",
     "reference_url": "https://www.gnu.org/software/coreutils/manual/",
@@ -3322,7 +3348,7 @@
   {
     "command": "env",
     "source_file": "src/commands/env.cpp",
-    "source_line_count": 839,
+    "source_line_count": 861,
     "upstream_source_line_count": 800,
     "family": "gnu-coreutils",
     "reference_url": "https://www.gnu.org/software/coreutils/manual/",
@@ -3330,7 +3356,7 @@
     "option_count": 12,
     "placeholder_count": 0,
     "unsupported_count": 0,
-    "test_count": 36,
+    "test_count": 38,
     "perf_probe_count": 2,
     "perf_failure_count": 0,
     "perf_worst_ratio": 1.023,
@@ -3425,6 +3451,32 @@
     ]
   },
   {
+    "command": "envsubst",
+    "source_file": "src/commands/envsubst.cpp",
+    "source_line_count": 167,
+    "upstream_source_line_count": 0,
+    "family": "local",
+    "reference_url": "",
+    "priority": "P2",
+    "option_count": 1,
+    "placeholder_count": 0,
+    "unsupported_count": 0,
+    "test_count": 3,
+    "perf_probe_count": 0,
+    "perf_failure_count": 0,
+    "perf_worst_ratio": null,
+    "options": [
+      {
+        "short": "-v",
+        "long": "--variables",
+        "description": "output variables occurring in SHELL-FORMAT",
+        "value_type": "flag",
+        "status": "declared"
+      }
+    ],
+    "notes": []
+  },
+  {
     "command": "expand",
     "source_file": "src/commands/expand.cpp",
     "source_line_count": 301,
@@ -3490,7 +3542,7 @@
   {
     "command": "factor",
     "source_file": "src/commands/factor.cpp",
-    "source_line_count": 131,
+    "source_line_count": 140,
     "upstream_source_line_count": 1756,
     "family": "gnu-coreutils",
     "reference_url": "https://www.gnu.org/software/coreutils/manual/",
@@ -3595,7 +3647,7 @@
   {
     "command": "find",
     "source_file": "src/commands/find.cpp",
-    "source_line_count": 2915,
+    "source_line_count": 3009,
     "upstream_source_line_count": 4965,
     "family": "gnu-findutils",
     "reference_url": "https://www.gnu.org/software/findutils/manual/",
@@ -3603,7 +3655,7 @@
     "option_count": 79,
     "placeholder_count": 1,
     "unsupported_count": 0,
-    "test_count": 104,
+    "test_count": 105,
     "perf_probe_count": 6,
     "perf_failure_count": 0,
     "perf_worst_ratio": 2.802,
@@ -4449,9 +4501,91 @@
     ]
   },
   {
+    "command": "getfacl",
+    "source_file": "src/commands/getfacl.cpp",
+    "source_line_count": 154,
+    "upstream_source_line_count": 0,
+    "family": "local",
+    "reference_url": "",
+    "priority": "P2",
+    "option_count": 2,
+    "placeholder_count": 0,
+    "unsupported_count": 0,
+    "test_count": 3,
+    "perf_probe_count": 0,
+    "perf_failure_count": 0,
+    "perf_worst_ratio": null,
+    "options": [
+      {
+        "short": "-p",
+        "long": "--absolute-names",
+        "description": "do not strip leading path separators",
+        "value_type": "flag",
+        "status": "declared"
+      },
+      {
+        "short": "-n",
+        "long": "--numeric",
+        "description": "print numeric IDs instead of account names",
+        "value_type": "flag",
+        "status": "declared"
+      }
+    ],
+    "notes": []
+  },
+  {
+    "command": "getopt",
+    "source_file": "src/commands/getopt.cpp",
+    "source_line_count": 167,
+    "upstream_source_line_count": 0,
+    "family": "util-linux",
+    "reference_url": "https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/",
+    "priority": "P2",
+    "option_count": 4,
+    "placeholder_count": 0,
+    "unsupported_count": 0,
+    "test_count": 4,
+    "perf_probe_count": 0,
+    "perf_failure_count": 0,
+    "perf_worst_ratio": null,
+    "options": [
+      {
+        "short": "-o",
+        "long": "--options",
+        "description": "short option specification",
+        "value_type": "STRING_TYPE",
+        "status": "declared"
+      },
+      {
+        "short": "-n",
+        "long": "--name",
+        "description": "name used in diagnostics",
+        "value_type": "STRING_TYPE",
+        "status": "declared"
+      },
+      {
+        "short": "-q",
+        "long": "--quiet",
+        "description": "disable error reporting by getopt",
+        "value_type": "flag",
+        "status": "declared"
+      },
+      {
+        "short": "-u",
+        "long": "--unquoted",
+        "description": "do not quote the output",
+        "value_type": "flag",
+        "status": "declared"
+      }
+    ],
+    "notes": [
+      "No local upstream source file mapped yet."
+    ]
+  },
+  {
     "command": "grep",
     "source_file": "src/commands/grep.cpp",
-    "source_line_count": 2312,
+    "source_line_count": 2310,
     "upstream_source_line_count": 2686,
     "family": "gnu-grep",
     "reference_url": "https://www.gnu.org/software/grep/manual/",
@@ -4459,7 +4593,7 @@
     "option_count": 49,
     "placeholder_count": 0,
     "unsupported_count": 0,
-    "test_count": 82,
+    "test_count": 86,
     "perf_probe_count": 6,
     "perf_failure_count": 0,
     "perf_worst_ratio": 1.469,
@@ -4817,7 +4951,7 @@
   {
     "command": "egrep",
     "source_file": "src/commands/grep.cpp",
-    "source_line_count": 2312,
+    "source_line_count": 2310,
     "upstream_source_line_count": 2686,
     "family": "gnu-grep",
     "reference_url": "https://www.gnu.org/software/grep/manual/",
@@ -5183,7 +5317,7 @@
   {
     "command": "fgrep",
     "source_file": "src/commands/grep.cpp",
-    "source_line_count": 2312,
+    "source_line_count": 2310,
     "upstream_source_line_count": 2686,
     "family": "gnu-grep",
     "reference_url": "https://www.gnu.org/software/grep/manual/",
@@ -5886,7 +6020,7 @@
   {
     "command": "id",
     "source_file": "src/commands/id.cpp",
-    "source_line_count": 308,
+    "source_line_count": 234,
     "upstream_source_line_count": 411,
     "family": "gnu-coreutils",
     "reference_url": "https://www.gnu.org/software/coreutils/manual/",
@@ -6146,7 +6280,7 @@
   {
     "command": "join",
     "source_file": "src/commands/join.cpp",
-    "source_line_count": 605,
+    "source_line_count": 602,
     "upstream_source_line_count": 1052,
     "family": "gnu-coreutils",
     "reference_url": "https://www.gnu.org/software/coreutils/manual/",
@@ -6258,7 +6392,7 @@
   {
     "command": "kill",
     "source_file": "src/commands/kill.cpp",
-    "source_line_count": 655,
+    "source_line_count": 654,
     "upstream_source_line_count": 1858,
     "family": "gnu-coreutils",
     "reference_url": "https://www.gnu.org/software/coreutils/manual/",
@@ -6881,17 +7015,132 @@
     ]
   },
   {
+    "command": "killall",
+    "source_file": "src/commands/killall.cpp",
+    "source_line_count": 127,
+    "upstream_source_line_count": 0,
+    "family": "local",
+    "reference_url": "",
+    "priority": "P2",
+    "option_count": 10,
+    "placeholder_count": 0,
+    "unsupported_count": 0,
+    "test_count": 3,
+    "perf_probe_count": 0,
+    "perf_failure_count": 0,
+    "perf_worst_ratio": null,
+    "options": [
+      {
+        "short": "-e",
+        "long": "--exact",
+        "description": "require an exact process-name match",
+        "value_type": "flag",
+        "status": "declared"
+      },
+      {
+        "short": "-I",
+        "long": "--ignore-case",
+        "description": "match case insensitively",
+        "value_type": "flag",
+        "status": "declared"
+      },
+      {
+        "short": "-q",
+        "long": "--quiet",
+        "description": "do not complain if no processes were killed",
+        "value_type": "flag",
+        "status": "declared"
+      },
+      {
+        "short": "-v",
+        "long": "--verbose",
+        "description": "report successful signals",
+        "value_type": "flag",
+        "status": "declared"
+      },
+      {
+        "short": "-0",
+        "long": "",
+        "description": "only check for matching processes",
+        "value_type": "flag",
+        "status": "declared"
+      },
+      {
+        "short": "-9",
+        "long": "",
+        "description": "send SIGKILL; mapped to Win32 termination",
+        "value_type": "flag",
+        "status": "declared"
+      },
+      {
+        "short": "-TERM",
+        "long": "",
+        "description": "send SIGTERM; mapped to Win32 termination",
+        "value_type": "flag",
+        "status": "declared"
+      },
+      {
+        "short": "-SIGTERM",
+        "long": "",
+        "description": "send SIGTERM; mapped to Win32 termination",
+        "value_type": "flag",
+        "status": "declared"
+      },
+      {
+        "short": "-KILL",
+        "long": "",
+        "description": "send SIGKILL; mapped to Win32 termination",
+        "value_type": "flag",
+        "status": "declared"
+      },
+      {
+        "short": "-SIGKILL",
+        "long": "",
+        "description": "send SIGKILL; mapped to Win32 termination",
+        "value_type": "flag",
+        "status": "declared"
+      }
+    ],
+    "notes": []
+  },
+  {
+    "command": "ldd",
+    "source_file": "src/commands/ldd.cpp",
+    "source_line_count": 213,
+    "upstream_source_line_count": 0,
+    "family": "local",
+    "reference_url": "",
+    "priority": "P2",
+    "option_count": 1,
+    "placeholder_count": 0,
+    "unsupported_count": 0,
+    "test_count": 3,
+    "perf_probe_count": 0,
+    "perf_failure_count": 0,
+    "perf_worst_ratio": null,
+    "options": [
+      {
+        "short": "-n",
+        "long": "--name",
+        "description": "print only imported DLL names",
+        "value_type": "flag",
+        "status": "declared"
+      }
+    ],
+    "notes": []
+  },
+  {
     "command": "less",
     "source_file": "src/commands/less.cpp",
-    "source_line_count": 512,
+    "source_line_count": 839,
     "upstream_source_line_count": 5961,
     "family": "less",
     "reference_url": "https://www.greenwoodsoftware.com/less/",
     "priority": "P0",
-    "option_count": 14,
-    "placeholder_count": 4,
+    "option_count": 16,
+    "placeholder_count": 5,
     "unsupported_count": 0,
-    "test_count": 4,
+    "test_count": 6,
     "perf_probe_count": 1,
     "perf_failure_count": 0,
     "perf_worst_ratio": 0.906,
@@ -6928,6 +7177,13 @@
         "short": "-I",
         "long": "--IGNORE-CASE",
         "description": "ignore case in all searches",
+        "value_type": "BOOL_TYPE",
+        "status": "declared"
+      },
+      {
+        "short": "-K",
+        "long": "--quit-on-intr",
+        "description": "exit less in response to Ctrl+C",
         "value_type": "BOOL_TYPE",
         "status": "declared"
       },
@@ -6976,7 +7232,14 @@
       {
         "short": "-R",
         "long": "--RAW-CONTROL-CHARS",
-        "description": "accepted placeholder; ANSI color parsing is not implemented",
+        "description": "accepted placeholder; ANSI SGR color sequences are passed through",
+        "value_type": "BOOL_TYPE",
+        "status": "placeholder"
+      },
+      {
+        "short": "",
+        "long": "--no-init",
+        "description": "accepted placeholder; terminal init/deinit sequences are not used",
         "value_type": "BOOL_TYPE",
         "status": "placeholder"
       },
@@ -7198,6 +7461,53 @@
     ]
   },
   {
+    "command": "logger",
+    "source_file": "src/commands/logger.cpp",
+    "source_line_count": 106,
+    "upstream_source_line_count": 0,
+    "family": "local",
+    "reference_url": "",
+    "priority": "P2",
+    "option_count": 4,
+    "placeholder_count": 0,
+    "unsupported_count": 0,
+    "test_count": 2,
+    "perf_probe_count": 0,
+    "perf_failure_count": 0,
+    "perf_worst_ratio": null,
+    "options": [
+      {
+        "short": "-p",
+        "long": "--priority",
+        "description": "message priority",
+        "value_type": "STRING_TYPE",
+        "status": "declared"
+      },
+      {
+        "short": "-t",
+        "long": "--tag",
+        "description": "mark every line with this tag",
+        "value_type": "STRING_TYPE",
+        "status": "declared"
+      },
+      {
+        "short": "-s",
+        "long": "--stderr",
+        "description": "also write the message to standard error",
+        "value_type": "flag",
+        "status": "declared"
+      },
+      {
+        "short": "",
+        "long": "--id",
+        "description": "accepted for compatibility",
+        "value_type": "STRING_TYPE",
+        "status": "declared"
+      }
+    ],
+    "notes": []
+  },
+  {
     "command": "logname",
     "source_file": "src/commands/logname.cpp",
     "source_line_count": 69,
@@ -7228,7 +7538,7 @@
   {
     "command": "ls",
     "source_file": "src/commands/ls.cpp",
-    "source_line_count": 3014,
+    "source_line_count": 2999,
     "upstream_source_line_count": 4888,
     "family": "gnu-coreutils",
     "reference_url": "https://www.gnu.org/software/coreutils/manual/",
@@ -7236,7 +7546,7 @@
     "option_count": 60,
     "placeholder_count": 0,
     "unsupported_count": 0,
-    "test_count": 132,
+    "test_count": 133,
     "perf_probe_count": 5,
     "perf_failure_count": 0,
     "perf_worst_ratio": 1.125,
@@ -7667,9 +7977,42 @@
     ]
   },
   {
+    "command": "lsattr",
+    "source_file": "src/commands/lsattr.cpp",
+    "source_line_count": 150,
+    "upstream_source_line_count": 0,
+    "family": "local",
+    "reference_url": "",
+    "priority": "P2",
+    "option_count": 2,
+    "placeholder_count": 0,
+    "unsupported_count": 0,
+    "test_count": 2,
+    "perf_probe_count": 0,
+    "perf_failure_count": 0,
+    "perf_worst_ratio": null,
+    "options": [
+      {
+        "short": "-R",
+        "long": "--recursive",
+        "description": "recursively list attributes of directories",
+        "value_type": "flag",
+        "status": "declared"
+      },
+      {
+        "short": "-d",
+        "long": "--directory",
+        "description": "list directories themselves, not contents",
+        "value_type": "flag",
+        "status": "declared"
+      }
+    ],
+    "notes": []
+  },
+  {
     "command": "lsof",
     "source_file": "src/commands/lsof.cpp",
-    "source_line_count": 818,
+    "source_line_count": 821,
     "upstream_source_line_count": 5202,
     "family": "lsof",
     "reference_url": "https://github.com/lsof-org/lsof",
@@ -7739,7 +8082,7 @@
   {
     "command": "man",
     "source_file": "src/commands/man.cpp",
-    "source_line_count": 82,
+    "source_line_count": 85,
     "upstream_source_line_count": 3953,
     "family": "man-db",
     "reference_url": "https://www.nongnu.org/man-db/",
@@ -7866,7 +8209,7 @@
     "option_count": 4,
     "placeholder_count": 0,
     "unsupported_count": 0,
-    "test_count": 8,
+    "test_count": 9,
     "perf_probe_count": 2,
     "perf_failure_count": 0,
     "perf_worst_ratio": 1.301,
@@ -7947,6 +8290,39 @@
     ]
   },
   {
+    "command": "mkgroup",
+    "source_file": "src/commands/mkgroup.cpp",
+    "source_line_count": 110,
+    "upstream_source_line_count": 0,
+    "family": "local",
+    "reference_url": "",
+    "priority": "P2",
+    "option_count": 2,
+    "placeholder_count": 0,
+    "unsupported_count": 0,
+    "test_count": 3,
+    "perf_probe_count": 0,
+    "perf_failure_count": 0,
+    "perf_worst_ratio": null,
+    "options": [
+      {
+        "short": "-c",
+        "long": "--current",
+        "description": "print groups from the current process token",
+        "value_type": "flag",
+        "status": "declared"
+      },
+      {
+        "short": "-l",
+        "long": "--local",
+        "description": "enumerate local machine groups (default)",
+        "value_type": "flag",
+        "status": "declared"
+      }
+    ],
+    "notes": []
+  },
+  {
     "command": "mknod",
     "source_file": "src/commands/mknod.cpp",
     "source_line_count": 160,
@@ -7989,9 +8365,56 @@
     ]
   },
   {
+    "command": "mkpasswd",
+    "source_file": "src/commands/mkpasswd.cpp",
+    "source_line_count": 123,
+    "upstream_source_line_count": 0,
+    "family": "local",
+    "reference_url": "",
+    "priority": "P2",
+    "option_count": 4,
+    "placeholder_count": 0,
+    "unsupported_count": 0,
+    "test_count": 3,
+    "perf_probe_count": 0,
+    "perf_failure_count": 0,
+    "perf_worst_ratio": null,
+    "options": [
+      {
+        "short": "-c",
+        "long": "--current",
+        "description": "print only the current process user",
+        "value_type": "flag",
+        "status": "declared"
+      },
+      {
+        "short": "-l",
+        "long": "--local",
+        "description": "enumerate local machine users (default)",
+        "value_type": "flag",
+        "status": "declared"
+      },
+      {
+        "short": "-p",
+        "long": "--path-prefix",
+        "description": "home directory prefix",
+        "value_type": "STRING_TYPE",
+        "status": "declared"
+      },
+      {
+        "short": "-s",
+        "long": "--shell",
+        "description": "login shell path",
+        "value_type": "STRING_TYPE",
+        "status": "declared"
+      }
+    ],
+    "notes": []
+  },
+  {
     "command": "mktemp",
     "source_file": "src/commands/mktemp.cpp",
-    "source_line_count": 348,
+    "source_line_count": 405,
     "upstream_source_line_count": 321,
     "family": "gnu-coreutils",
     "reference_url": "https://www.gnu.org/software/coreutils/manual/",
@@ -8054,7 +8477,7 @@
   {
     "command": "more",
     "source_file": "src/commands/more.cpp",
-    "source_line_count": 365,
+    "source_line_count": 612,
     "upstream_source_line_count": 2071,
     "family": "util-linux",
     "reference_url": "https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/",
@@ -8147,7 +8570,7 @@
   {
     "command": "mpicalc",
     "source_file": "src/commands/mpicalc.cpp",
-    "source_line_count": 532,
+    "source_line_count": 534,
     "upstream_source_line_count": 575,
     "family": "libgcrypt",
     "reference_url": "https://gnupg.org/software/libgcrypt/",
@@ -8364,7 +8787,7 @@
   {
     "command": "nice",
     "source_file": "src/commands/nice.cpp",
-    "source_line_count": 169,
+    "source_line_count": 148,
     "upstream_source_line_count": 219,
     "family": "gnu-coreutils",
     "reference_url": "https://www.gnu.org/software/coreutils/manual/",
@@ -8392,7 +8815,7 @@
   {
     "command": "nl",
     "source_file": "src/commands/nl.cpp",
-    "source_line_count": 413,
+    "source_line_count": 410,
     "upstream_source_line_count": 554,
     "family": "gnu-coreutils",
     "reference_url": "https://www.gnu.org/software/coreutils/manual/",
@@ -8561,7 +8984,7 @@
   {
     "command": "numfmt",
     "source_file": "src/commands/numfmt.cpp",
-    "source_line_count": 284,
+    "source_line_count": 280,
     "upstream_source_line_count": 1471,
     "family": "gnu-coreutils",
     "reference_url": "https://www.gnu.org/software/coreutils/manual/",
@@ -8895,6 +9318,93 @@
     ]
   },
   {
+    "command": "pgrep",
+    "source_file": "src/commands/pgrep.cpp",
+    "source_line_count": 117,
+    "upstream_source_line_count": 0,
+    "family": "local",
+    "reference_url": "",
+    "priority": "P2",
+    "option_count": 6,
+    "placeholder_count": 0,
+    "unsupported_count": 0,
+    "test_count": 3,
+    "perf_probe_count": 0,
+    "perf_failure_count": 0,
+    "perf_worst_ratio": null,
+    "options": [
+      {
+        "short": "-f",
+        "long": "--full",
+        "description": "match against full command line",
+        "value_type": "flag",
+        "status": "declared"
+      },
+      {
+        "short": "-i",
+        "long": "--ignore-case",
+        "description": "match case insensitively",
+        "value_type": "flag",
+        "status": "declared"
+      },
+      {
+        "short": "-l",
+        "long": "--list-name",
+        "description": "list PID and process name",
+        "value_type": "flag",
+        "status": "declared"
+      },
+      {
+        "short": "-a",
+        "long": "--list-full",
+        "description": "list PID and full command line",
+        "value_type": "flag",
+        "status": "declared"
+      },
+      {
+        "short": "-x",
+        "long": "--exact",
+        "description": "match the whole name or command line",
+        "value_type": "flag",
+        "status": "declared"
+      },
+      {
+        "short": "-c",
+        "long": "--count",
+        "description": "print only a count of matching processes",
+        "value_type": "flag",
+        "status": "declared"
+      }
+    ],
+    "notes": []
+  },
+  {
+    "command": "pidof",
+    "source_file": "src/commands/pidof.cpp",
+    "source_line_count": 81,
+    "upstream_source_line_count": 0,
+    "family": "local",
+    "reference_url": "",
+    "priority": "P2",
+    "option_count": 1,
+    "placeholder_count": 0,
+    "unsupported_count": 0,
+    "test_count": 3,
+    "perf_probe_count": 0,
+    "perf_failure_count": 0,
+    "perf_worst_ratio": null,
+    "options": [
+      {
+        "short": "-x",
+        "long": "--scripts",
+        "description": "also match command-line basename",
+        "value_type": "flag",
+        "status": "declared"
+      }
+    ],
+    "notes": []
+  },
+  {
     "command": "pinky",
     "source_file": "src/commands/pinky.cpp",
     "source_line_count": 127,
@@ -8984,6 +9494,121 @@
     "notes": [
       "Performance probes: 3."
     ]
+  },
+  {
+    "command": "pkill",
+    "source_file": "src/commands/pkill.cpp",
+    "source_line_count": 115,
+    "upstream_source_line_count": 0,
+    "family": "local",
+    "reference_url": "",
+    "priority": "P2",
+    "option_count": 10,
+    "placeholder_count": 0,
+    "unsupported_count": 0,
+    "test_count": 3,
+    "perf_probe_count": 0,
+    "perf_failure_count": 0,
+    "perf_worst_ratio": null,
+    "options": [
+      {
+        "short": "-f",
+        "long": "--full",
+        "description": "match against full command line",
+        "value_type": "flag",
+        "status": "declared"
+      },
+      {
+        "short": "-i",
+        "long": "--ignore-case",
+        "description": "match case insensitively",
+        "value_type": "flag",
+        "status": "declared"
+      },
+      {
+        "short": "-x",
+        "long": "--exact",
+        "description": "match the whole name or command line",
+        "value_type": "flag",
+        "status": "declared"
+      },
+      {
+        "short": "-e",
+        "long": "--echo",
+        "description": "display what is killed",
+        "value_type": "flag",
+        "status": "declared"
+      },
+      {
+        "short": "-0",
+        "long": "",
+        "description": "only check for matching processes",
+        "value_type": "flag",
+        "status": "declared"
+      },
+      {
+        "short": "-9",
+        "long": "",
+        "description": "send SIGKILL; mapped to Win32 termination",
+        "value_type": "flag",
+        "status": "declared"
+      },
+      {
+        "short": "-TERM",
+        "long": "",
+        "description": "send SIGTERM; mapped to Win32 termination",
+        "value_type": "flag",
+        "status": "declared"
+      },
+      {
+        "short": "-SIGTERM",
+        "long": "",
+        "description": "send SIGTERM; mapped to Win32 termination",
+        "value_type": "flag",
+        "status": "declared"
+      },
+      {
+        "short": "-KILL",
+        "long": "",
+        "description": "send SIGKILL; mapped to Win32 termination",
+        "value_type": "flag",
+        "status": "declared"
+      },
+      {
+        "short": "-SIGKILL",
+        "long": "",
+        "description": "send SIGKILL; mapped to Win32 termination",
+        "value_type": "flag",
+        "status": "declared"
+      }
+    ],
+    "notes": []
+  },
+  {
+    "command": "pldd",
+    "source_file": "src/commands/pldd.cpp",
+    "source_line_count": 67,
+    "upstream_source_line_count": 0,
+    "family": "local",
+    "reference_url": "",
+    "priority": "P2",
+    "option_count": 1,
+    "placeholder_count": 0,
+    "unsupported_count": 0,
+    "test_count": 3,
+    "perf_probe_count": 0,
+    "perf_failure_count": 0,
+    "perf_worst_ratio": null,
+    "options": [
+      {
+        "short": "-n",
+        "long": "--name",
+        "description": "print module basenames instead of paths",
+        "value_type": "flag",
+        "status": "declared"
+      }
+    ],
+    "notes": []
   },
   {
     "command": "pr",
@@ -9345,7 +9970,7 @@
   {
     "command": "ptx",
     "source_file": "src/commands/ptx.cpp",
-    "source_line_count": 432,
+    "source_line_count": 428,
     "upstream_source_line_count": 1647,
     "family": "gnu-coreutils",
     "reference_url": "https://www.gnu.org/software/coreutils/manual/",
@@ -9527,7 +10152,7 @@
   {
     "command": "readlink",
     "source_file": "src/commands/readlink.cpp",
-    "source_line_count": 455,
+    "source_line_count": 429,
     "upstream_source_line_count": 181,
     "family": "gnu-coreutils",
     "reference_url": "https://www.gnu.org/software/coreutils/manual/",
@@ -9700,6 +10325,65 @@
     ]
   },
   {
+    "command": "regtool",
+    "source_file": "src/commands/regtool.cpp",
+    "source_line_count": 301,
+    "upstream_source_line_count": 0,
+    "family": "local",
+    "reference_url": "",
+    "priority": "P2",
+    "option_count": 1,
+    "placeholder_count": 0,
+    "unsupported_count": 0,
+    "test_count": 5,
+    "perf_probe_count": 0,
+    "perf_failure_count": 0,
+    "perf_worst_ratio": null,
+    "options": [
+      {
+        "short": "",
+        "long": "",
+        "description": "operate on the Windows registry",
+        "value_type": "STRING_TYPE",
+        "status": "declared"
+      }
+    ],
+    "notes": []
+  },
+  {
+    "command": "renice",
+    "source_file": "src/commands/renice.cpp",
+    "source_line_count": 112,
+    "upstream_source_line_count": 0,
+    "family": "local",
+    "reference_url": "",
+    "priority": "P2",
+    "option_count": 2,
+    "placeholder_count": 0,
+    "unsupported_count": 0,
+    "test_count": 3,
+    "perf_probe_count": 0,
+    "perf_failure_count": 0,
+    "perf_worst_ratio": null,
+    "options": [
+      {
+        "short": "-n",
+        "long": "--priority",
+        "description": "set niceness value",
+        "value_type": "STRING_TYPE",
+        "status": "declared"
+      },
+      {
+        "short": "-p",
+        "long": "--pid",
+        "description": "interpret operands as process IDs",
+        "value_type": "flag",
+        "status": "declared"
+      }
+    ],
+    "notes": []
+  },
+  {
     "command": "reset",
     "source_file": "src/commands/reset.cpp",
     "source_line_count": 45,
@@ -9793,7 +10477,7 @@
   {
     "command": "rm",
     "source_file": "src/commands/rm.cpp",
-    "source_line_count": 589,
+    "source_line_count": 570,
     "upstream_source_line_count": 350,
     "family": "gnu-coreutils",
     "reference_url": "https://www.gnu.org/software/coreutils/manual/",
@@ -9801,7 +10485,7 @@
     "option_count": 11,
     "placeholder_count": 0,
     "unsupported_count": 0,
-    "test_count": 21,
+    "test_count": 24,
     "perf_probe_count": 4,
     "perf_failure_count": 0,
     "perf_worst_ratio": 1.445,
@@ -9891,7 +10575,7 @@
   {
     "command": "rmdir",
     "source_file": "src/commands/rmdir.cpp",
-    "source_line_count": 162,
+    "source_line_count": 149,
     "upstream_source_line_count": 258,
     "family": "gnu-coreutils",
     "reference_url": "https://www.gnu.org/software/coreutils/manual/",
@@ -9899,7 +10583,7 @@
     "option_count": 3,
     "placeholder_count": 0,
     "unsupported_count": 0,
-    "test_count": 10,
+    "test_count": 12,
     "perf_probe_count": 2,
     "perf_failure_count": 0,
     "perf_worst_ratio": 1.207,
@@ -9989,7 +10673,7 @@
   {
     "command": "sdiff",
     "source_file": "src/commands/sdiff.cpp",
-    "source_line_count": 326,
+    "source_line_count": 324,
     "upstream_source_line_count": 997,
     "family": "gnu-diffutils",
     "reference_url": "https://www.gnu.org/software/diffutils/manual/",
@@ -10074,7 +10758,7 @@
     "option_count": 13,
     "placeholder_count": 0,
     "unsupported_count": 0,
-    "test_count": 86,
+    "test_count": 87,
     "perf_probe_count": 4,
     "perf_failure_count": 0,
     "perf_worst_ratio": 1.348,
@@ -10179,7 +10863,7 @@
   {
     "command": "seq",
     "source_file": "src/commands/seq.cpp",
-    "source_line_count": 413,
+    "source_line_count": 408,
     "upstream_source_line_count": 605,
     "family": "gnu-coreutils",
     "reference_url": "https://www.gnu.org/software/coreutils/manual/",
@@ -10879,7 +11563,7 @@
   {
     "command": "shred",
     "source_file": "src/commands/shred.cpp",
-    "source_line_count": 166,
+    "source_line_count": 178,
     "upstream_source_line_count": 1181,
     "family": "gnu-coreutils",
     "reference_url": "https://www.gnu.org/software/coreutils/manual/",
@@ -11292,7 +11976,7 @@
   {
     "command": "split",
     "source_file": "src/commands/split.cpp",
-    "source_line_count": 691,
+    "source_line_count": 709,
     "upstream_source_line_count": 1546,
     "family": "gnu-coreutils",
     "reference_url": "https://www.gnu.org/software/coreutils/manual/",
@@ -11510,7 +12194,7 @@
   {
     "command": "strings",
     "source_file": "src/commands/strings.cpp",
-    "source_line_count": 385,
+    "source_line_count": 386,
     "upstream_source_line_count": 1147,
     "family": "gnu-binutils",
     "reference_url": "https://www.gnu.org/software/binutils/",
@@ -11616,12 +12300,12 @@
   {
     "command": "stty",
     "source_file": "src/commands/stty.cpp",
-    "source_line_count": 471,
+    "source_line_count": 475,
     "upstream_source_line_count": 2152,
     "family": "gnu-coreutils",
     "reference_url": "https://www.gnu.org/software/coreutils/manual/",
     "priority": "P2",
-    "option_count": 3,
+    "option_count": 4,
     "placeholder_count": 0,
     "unsupported_count": 0,
     "test_count": 9,
@@ -11648,6 +12332,13 @@
         "long": "--file",
         "description": "open and use the specified device instead of stdin",
         "value_type": "STRING_TYPE",
+        "status": "declared"
+      },
+      {
+        "short": "-echo",
+        "long": "",
+        "description": "do not echo input characters",
+        "value_type": "flag",
         "status": "declared"
       }
     ],
@@ -11693,7 +12384,7 @@
   {
     "command": "sync",
     "source_file": "src/commands/sync.cpp",
-    "source_line_count": 155,
+    "source_line_count": 153,
     "upstream_source_line_count": 191,
     "family": "gnu-coreutils",
     "reference_url": "https://www.gnu.org/software/coreutils/manual/",
@@ -11728,7 +12419,7 @@
   {
     "command": "tac",
     "source_file": "src/commands/tac.cpp",
-    "source_line_count": 231,
+    "source_line_count": 207,
     "upstream_source_line_count": 507,
     "family": "gnu-coreutils",
     "reference_url": "https://www.gnu.org/software/coreutils/manual/",
@@ -11736,7 +12427,7 @@
     "option_count": 3,
     "placeholder_count": 0,
     "unsupported_count": 0,
-    "test_count": 11,
+    "test_count": 13,
     "perf_probe_count": 1,
     "perf_failure_count": 0,
     "perf_worst_ratio": 1.492,
@@ -11946,7 +12637,7 @@
   {
     "command": "test",
     "source_file": "src/commands/test.cpp",
-    "source_line_count": 282,
+    "source_line_count": 278,
     "upstream_source_line_count": 786,
     "family": "gnu-coreutils",
     "reference_url": "https://www.gnu.org/software/coreutils/manual/",
@@ -12240,7 +12931,7 @@
   {
     "command": "[",
     "source_file": "src/commands/test_bracket.cpp",
-    "source_line_count": 257,
+    "source_line_count": 253,
     "upstream_source_line_count": 786,
     "family": "gnu-coreutils",
     "reference_url": "https://www.gnu.org/software/coreutils/manual/",
@@ -12653,7 +13344,7 @@
   {
     "command": "toe",
     "source_file": "src/commands/toe.cpp",
-    "source_line_count": 32,
+    "source_line_count": 33,
     "upstream_source_line_count": 677,
     "family": "ncurses",
     "reference_url": "https://invisible-island.net/ncurses/",
@@ -12828,7 +13519,7 @@
         "status": "declared"
       },
       {
-        "short": "-h",
+        "short": "",
         "long": "--help",
         "description": "display this help",
         "value_type": "flag",
@@ -12842,7 +13533,7 @@
   {
     "command": "touch",
     "source_file": "src/commands/touch.cpp",
-    "source_line_count": 599,
+    "source_line_count": 616,
     "upstream_source_line_count": 390,
     "family": "gnu-coreutils",
     "reference_url": "https://www.gnu.org/software/coreutils/manual/",
@@ -12850,7 +13541,7 @@
     "option_count": 9,
     "placeholder_count": 1,
     "unsupported_count": 0,
-    "test_count": 12,
+    "test_count": 15,
     "perf_probe_count": 3,
     "perf_failure_count": 0,
     "perf_worst_ratio": 2.651,
@@ -13130,7 +13821,7 @@
   {
     "command": "truncate",
     "source_file": "src/commands/truncate.cpp",
-    "source_line_count": 443,
+    "source_line_count": 463,
     "upstream_source_line_count": 345,
     "family": "gnu-coreutils",
     "reference_url": "https://www.gnu.org/software/coreutils/manual/",
@@ -13138,7 +13829,7 @@
     "option_count": 4,
     "placeholder_count": 0,
     "unsupported_count": 0,
-    "test_count": 9,
+    "test_count": 12,
     "perf_probe_count": 1,
     "perf_failure_count": 0,
     "perf_worst_ratio": 0.405,
@@ -13242,7 +13933,7 @@
   {
     "command": "tzset",
     "source_file": "src/commands/tzset.cpp",
-    "source_line_count": 110,
+    "source_line_count": 125,
     "upstream_source_line_count": 0,
     "family": "local",
     "reference_url": "",
@@ -13256,7 +13947,7 @@
     "perf_worst_ratio": 1.237,
     "options": [
       {
-        "short": "-h",
+        "short": "",
         "long": "--help",
         "description": "output usage information and exit",
         "value_type": "BOOL_TYPE",
@@ -13438,7 +14129,7 @@
   {
     "command": "uniq",
     "source_file": "src/commands/uniq.cpp",
-    "source_line_count": 349,
+    "source_line_count": 347,
     "upstream_source_line_count": 579,
     "family": "gnu-coreutils",
     "reference_url": "https://www.gnu.org/software/coreutils/manual/",
@@ -13446,7 +14137,7 @@
     "option_count": 10,
     "placeholder_count": 0,
     "unsupported_count": 0,
-    "test_count": 15,
+    "test_count": 17,
     "perf_probe_count": 4,
     "perf_failure_count": 0,
     "perf_worst_ratio": 1.599,
@@ -13557,7 +14248,7 @@
   {
     "command": "unlink",
     "source_file": "src/commands/unlink.cpp",
-    "source_line_count": 126,
+    "source_line_count": 134,
     "upstream_source_line_count": 68,
     "family": "gnu-coreutils",
     "reference_url": "https://www.gnu.org/software/coreutils/manual/",
@@ -13565,7 +14256,7 @@
     "option_count": 1,
     "placeholder_count": 0,
     "unsupported_count": 0,
-    "test_count": 10,
+    "test_count": 11,
     "perf_probe_count": 1,
     "perf_failure_count": 0,
     "perf_worst_ratio": 0.828,
@@ -14278,7 +14969,7 @@
   {
     "command": "xargs",
     "source_file": "src/commands/xargs.cpp",
-    "source_line_count": 1311,
+    "source_line_count": 1306,
     "upstream_source_line_count": 1905,
     "family": "gnu-findutils",
     "reference_url": "https://www.gnu.org/software/findutils/manual/",
@@ -14474,7 +15165,7 @@
   {
     "command": "yes",
     "source_file": "src/commands/yes.cpp",
-    "source_line_count": 116,
+    "source_line_count": 119,
     "upstream_source_line_count": 227,
     "family": "gnu-coreutils",
     "reference_url": "https://www.gnu.org/software/coreutils/manual/",

--- a/DOCS/generated/command_compatibility_matrix.md
+++ b/DOCS/generated/command_compatibility_matrix.md
@@ -8,14 +8,14 @@ Scope excludes `wpm` by release policy.
 
 | Metric | Value |
 | --- | ---: |
-| Commands | 154 |
+| Commands | 170 |
 | P0 hot commands | 33 |
 | P1 commands | 39 |
-| P2 commands | 82 |
+| P2 commands | 98 |
 | Declared unsupported options | 4 |
-| Declared placeholder/no-op options | 16 |
+| Declared placeholder/no-op options | 17 |
 | Commands without direct unit tests | 0 |
-| P0 commands thin vs upstream | 0 |
+| P0 commands thin vs upstream | 1 |
 | Commands with mapped local upstream source | 153 |
 | Commands with performance probes | 154 |
 | Performance/parity probe failures | 0 |
@@ -30,7 +30,7 @@ Scope excludes `wpm` by release policy.
 
 ## Focus Lists
 
-- P0 commands thin vs upstream: _None._.
+- P0 commands thin vs upstream: `rmdir`.
 - Commands without direct unit tests: _None._.
 - Commands with unsupported or placeholder options: `cat`, `find`, `less`, `more`, `touch`, `install`, `kill`, `stat`, `strings`, `hostname`.
 - P0 commands without performance probes yet: _None._.
@@ -39,78 +39,78 @@ Scope excludes `wpm` by release policy.
 
 | Priority | Command | Family | Local LOC | Upstream LOC | Options | Unsupported | Placeholder | Tests | Perf probes | Worst perf | Perf fails | Source | Notes |
 | --- | --- | --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | --- | --- |
-| P0 | `[` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 257 | 786 | 39 | 0 | 0 | 2 | 1 | 0.9x | 0 | `src/commands/test_bracket.cpp` | Performance probes: 1. |
-| P0 | `cat` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 333 | 834 | 10 | 0 | 1 | 16 | 3 | 1.1x | 0 | `src/commands/cat.cpp` | Has compatibility placeholder/no-op option(s).<br>Performance probes: 3. |
+| P0 | `[` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 253 | 786 | 39 | 0 | 0 | 2 | 1 | 0.9x | 0 | `src/commands/test_bracket.cpp` | Performance probes: 1. |
+| P0 | `cat` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 331 | 834 | 10 | 0 | 1 | 19 | 3 | 1.1x | 0 | `src/commands/cat.cpp` | Has compatibility placeholder/no-op option(s).<br>Performance probes: 3. |
 | P0 | `cp` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 752 | 1173 | 35 | 0 | 0 | 20 | 5 | 1.7x | 0 | `src/commands/cp.cpp` | Performance probes: 5. |
 | P0 | `cut` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 543 | 1233 | 11 | 0 | 0 | 29 | 1 | 0.4x | 0 | `src/commands/cut.cpp` | Performance probes: 1. |
 | P0 | `date` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 613 | 732 | 8 | 0 | 0 | 9 | 1 | 0.9x | 0 | `src/commands/date.cpp` | Performance probes: 1. |
 | P0 | `dirname` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 145 | 110 | 1 | 0 | 0 | 9 | 2 | 1.2x | 0 | `src/commands/dirname.cpp` | Performance probes: 2. |
 | P0 | `du` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 879 | 1034 | 25 | 0 | 0 | 36 | 2 | 1.0x | 0 | `src/commands/du.cpp` | Performance probes: 2. |
 | P0 | `echo` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 459 | 255 | 5 | 0 | 0 | 29 | 1 | 0.7x | 0 | `src/commands/echo.cpp` | Performance probes: 1. |
-| P0 | `env` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 839 | 800 | 12 | 0 | 0 | 36 | 2 | 1.0x | 0 | `src/commands/env.cpp` | Performance probes: 2. |
+| P0 | `env` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 861 | 800 | 12 | 0 | 0 | 38 | 2 | 1.0x | 0 | `src/commands/env.cpp` | Performance probes: 2. |
 | P0 | `head` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 556 | 932 | 6 | 0 | 0 | 28 | 3 | 1.2x | 0 | `src/commands/head.cpp` | Performance probes: 3. |
 | P0 | `ln` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 373 | 647 | 15 | 0 | 0 | 13 | 3 | 1.7x | 0 | `src/commands/ln.cpp` | Performance probes: 3. |
-| P0 | `ls` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 3014 | 4888 | 60 | 0 | 0 | 132 | 5 | 1.1x | 0 | `src/commands/ls.cpp` | Performance probes: 5. |
-| P0 | `mkdir` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 334 | 278 | 4 | 0 | 0 | 8 | 2 | 1.3x | 0 | `src/commands/mkdir.cpp` | Performance probes: 2. |
+| P0 | `ls` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 2999 | 4888 | 60 | 0 | 0 | 133 | 5 | 1.1x | 0 | `src/commands/ls.cpp` | Performance probes: 5. |
+| P0 | `mkdir` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 334 | 278 | 4 | 0 | 0 | 9 | 2 | 1.3x | 0 | `src/commands/mkdir.cpp` | Performance probes: 2. |
 | P0 | `mv` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 485 | 520 | 21 | 0 | 0 | 15 | 4 | 1.0x | 0 | `src/commands/mv.cpp` | Performance probes: 4. |
 | P0 | `pwd` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 225 | 328 | 2 | 0 | 0 | 20 | 1 | 0.9x | 0 | `src/commands/pwd.cpp` | Performance probes: 1. |
-| P0 | `rm` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 589 | 350 | 11 | 0 | 0 | 21 | 4 | 1.4x | 0 | `src/commands/rm.cpp` | Performance probes: 4. |
-| P0 | `rmdir` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 162 | 258 | 3 | 0 | 0 | 10 | 2 | 1.2x | 0 | `src/commands/rmdir.cpp` | Performance probes: 2. |
+| P0 | `rm` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 570 | 350 | 11 | 0 | 0 | 24 | 4 | 1.4x | 0 | `src/commands/rm.cpp` | Performance probes: 4. |
+| P0 | `rmdir` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 149 | 258 | 3 | 0 | 0 | 12 | 2 | 1.2x | 0 | `src/commands/rmdir.cpp` | Performance probes: 2. |
 | P0 | `sort` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 1606 | 4462 | 29 | 0 | 0 | 66 | 6 | 1.9x | 0 | `src/commands/sort.cpp` | Performance probes: 6. |
 | P0 | `tail` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 990 | 2194 | 15 | 0 | 0 | 42 | 4 | 1.1x | 0 | `src/commands/tail.cpp` | Performance probes: 4. |
 | P0 | `tee` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 169 | 293 | 4 | 0 | 0 | 10 | 2 | 1.7x | 0 | `src/commands/tee.cpp` | Performance probes: 2. |
-| P0 | `test` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 282 | 786 | 39 | 0 | 0 | 2 | 2 | 1.7x | 0 | `src/commands/test.cpp` | Performance probes: 2. |
-| P0 | `touch` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 599 | 390 | 9 | 0 | 1 | 12 | 3 | 2.7x | 0 | `src/commands/touch.cpp` | Has compatibility placeholder/no-op option(s).<br>Performance probes: 3. |
+| P0 | `test` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 278 | 786 | 39 | 0 | 0 | 2 | 2 | 1.7x | 0 | `src/commands/test.cpp` | Performance probes: 2. |
+| P0 | `touch` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 616 | 390 | 9 | 0 | 1 | 15 | 3 | 2.7x | 0 | `src/commands/touch.cpp` | Has compatibility placeholder/no-op option(s).<br>Performance probes: 3. |
 | P0 | `tr` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 476 | 1679 | 5 | 0 | 0 | 16 | 5 | 1.2x | 0 | `src/commands/tr.cpp` | Performance probes: 5. |
 | P0 | `wc` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 721 | 917 | 8 | 0 | 0 | 24 | 3 | 1.8x | 0 | `src/commands/wc.cpp` | Performance probes: 3. |
 | P0 | `diff` | [gnu-diffutils](https://www.gnu.org/software/diffutils/manual/) | 626 | 1507 | 5 | 0 | 0 | 13 | 1 | 0.7x | 0 | `src/commands/diff.cpp` | Performance probes: 1. |
-| P0 | `find` | [gnu-findutils](https://www.gnu.org/software/findutils/manual/) | 2915 | 4965 | 79 | 0 | 1 | 104 | 6 | 2.8x | 0 | `src/commands/find.cpp` | Regex behavior is command-owned, not shell-owned.<br>Has compatibility placeholder/no-op option(s).<br>Performance probes: 6. |
-| P0 | `xargs` | [gnu-findutils](https://www.gnu.org/software/findutils/manual/) | 1311 | 1905 | 21 | 0 | 0 | 79 | 2 | 0.0x | 0 | `src/commands/xargs.cpp` | Performance probes: 2. |
-| P0 | `egrep` | [gnu-grep](https://www.gnu.org/software/grep/manual/) | 2312 | 2686 | 49 | 0 | 0 | 2 | 1 | 1.3x | 0 | `src/commands/grep.cpp` | Regex behavior is command-owned, not shell-owned.<br>Performance probes: 1. |
-| P0 | `fgrep` | [gnu-grep](https://www.gnu.org/software/grep/manual/) | 2312 | 2686 | 49 | 0 | 0 | 2 | 1 | 0.9x | 0 | `src/commands/grep.cpp` | Regex behavior is command-owned, not shell-owned.<br>Performance probes: 1. |
-| P0 | `grep` | [gnu-grep](https://www.gnu.org/software/grep/manual/) | 2312 | 2686 | 49 | 0 | 0 | 82 | 6 | 1.5x | 0 | `src/commands/grep.cpp` | Regex behavior is command-owned, not shell-owned.<br>Performance probes: 6. |
-| P0 | `sed` | [gnu-sed](https://www.gnu.org/software/sed/manual/) | 1960 | 2885 | 13 | 0 | 0 | 86 | 4 | 1.3x | 0 | `src/commands/sed.cpp` | Regex behavior is command-owned, not shell-owned.<br>Performance probes: 4. |
-| P0 | `less` | [less](https://www.greenwoodsoftware.com/less/) | 512 | 5961 | 14 | 0 | 4 | 4 | 1 | 0.9x | 0 | `src/commands/less.cpp` | Interactive terminal behavior needs PTY/manual coverage.<br>Has compatibility placeholder/no-op option(s).<br>Performance probes: 1. |
-| P0 | `more` | [util-linux](https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/) | 365 | 2071 | 10 | 0 | 1 | 10 | 3 | 1.1x | 0 | `src/commands/more.cpp` | Interactive terminal behavior needs PTY/manual coverage.<br>Has compatibility placeholder/no-op option(s).<br>Performance probes: 3. |
-| P1 | `cygpath` | [cygpath](https://cygwin.com/cygwin-ug-net/cygpath.html) | 340 | 1001 | 23 | 0 | 0 | 8 | 3 | 1.4x | 0 | `src/commands/cygpath.cpp` | Performance probes: 3. |
-| P1 | `strings` | [gnu-binutils](https://www.gnu.org/software/binutils/) | 385 | 1147 | 12 | 0 | 3 | 11 | 1 | 1.2x | 0 | `src/commands/strings.cpp` | Has compatibility placeholder/no-op option(s).<br>Performance probes: 1. |
-| P1 | `b2sum` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 365 | 2346 | 11 | 0 | 0 | 24 | 1 | 0.9x | 0 | `src/commands/b2sum.cpp` | Performance probes: 1. |
+| P0 | `find` | [gnu-findutils](https://www.gnu.org/software/findutils/manual/) | 3009 | 4965 | 79 | 0 | 1 | 105 | 6 | 2.8x | 0 | `src/commands/find.cpp` | Regex behavior is command-owned, not shell-owned.<br>Has compatibility placeholder/no-op option(s).<br>Performance probes: 6. |
+| P0 | `xargs` | [gnu-findutils](https://www.gnu.org/software/findutils/manual/) | 1306 | 1905 | 21 | 0 | 0 | 79 | 2 | 0.0x | 0 | `src/commands/xargs.cpp` | Performance probes: 2. |
+| P0 | `egrep` | [gnu-grep](https://www.gnu.org/software/grep/manual/) | 2310 | 2686 | 49 | 0 | 0 | 2 | 1 | 1.3x | 0 | `src/commands/grep.cpp` | Regex behavior is command-owned, not shell-owned.<br>Has explicitly unsupported declared option(s).<br>Performance probes: 1. |
+| P0 | `fgrep` | [gnu-grep](https://www.gnu.org/software/grep/manual/) | 2310 | 2686 | 49 | 0 | 0 | 2 | 1 | 0.9x | 0 | `src/commands/grep.cpp` | Regex behavior is command-owned, not shell-owned.<br>Has explicitly unsupported declared option(s).<br>Performance probes: 1. |
+| P0 | `grep` | [gnu-grep](https://www.gnu.org/software/grep/manual/) | 2310 | 2686 | 49 | 0 | 0 | 86 | 6 | 1.5x | 0 | `src/commands/grep.cpp` | Regex behavior is command-owned, not shell-owned.<br>Has explicitly unsupported declared option(s).<br>Performance probes: 6. |
+| P0 | `sed` | [gnu-sed](https://www.gnu.org/software/sed/manual/) | 1960 | 2885 | 13 | 0 | 0 | 87 | 4 | 1.3x | 0 | `src/commands/sed.cpp` | Regex behavior is command-owned, not shell-owned.<br>Performance probes: 4. |
+| P0 | `less` | [less](https://www.greenwoodsoftware.com/less/) | 839 | 5961 | 16 | 0 | 5 | 6 | 1 | 0.9x | 0 | `src/commands/less.cpp` | Interactive terminal behavior needs PTY/manual coverage.<br>Has compatibility placeholder/no-op option(s).<br>Performance probes: 1. |
+| P0 | `more` | [util-linux](https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/) | 612 | 2071 | 10 | 0 | 1 | 10 | 3 | 1.1x | 0 | `src/commands/more.cpp` | Interactive terminal behavior needs PTY/manual coverage.<br>Has compatibility placeholder/no-op option(s).<br>Performance probes: 3. |
+| P1 | `cygpath` | [cygpath](https://cygwin.com/cygwin-ug-net/cygpath.html) | 501 | 1001 | 23 | 0 | 0 | 12 | 3 | 1.4x | 0 | `src/commands/cygpath.cpp` | Performance probes: 3. |
+| P1 | `strings` | [gnu-binutils](https://www.gnu.org/software/binutils/) | 386 | 1147 | 12 | 0 | 3 | 11 | 1 | 1.2x | 0 | `src/commands/strings.cpp` | Has compatibility placeholder/no-op option(s).<br>Performance probes: 1. |
+| P1 | `b2sum` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 366 | 2346 | 11 | 0 | 0 | 24 | 1 | 0.9x | 0 | `src/commands/b2sum.cpp` | Performance probes: 1. |
 | P1 | `basename` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 159 | 166 | 6 | 0 | 0 | 16 | 1 | 1.5x | 0 | `src/commands/basename.cpp` | Performance probes: 1. |
 | P1 | `chgrp` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 510 | 2 | 14 | 0 | 0 | 16 | 1 | 0.4x | 0 | `src/commands/chgrp.cpp` | Performance probes: 1. |
 | P1 | `chmod` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 633 | 602 | 12 | 0 | 0 | 20 | 2 | 1.0x | 0 | `src/commands/chmod.cpp` | Performance probes: 2. |
 | P1 | `chown` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 635 | 318 | 14 | 0 | 0 | 23 | 1 | 0.7x | 0 | `src/commands/chown.cpp` | Performance probes: 1. |
-| P1 | `cksum` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 660 | 2023 | 14 | 0 | 0 | 20 | 1 | 0.8x | 0 | `src/commands/cksum.cpp` | Performance probes: 1. |
+| P1 | `cksum` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 667 | 2023 | 14 | 0 | 0 | 20 | 1 | 0.8x | 0 | `src/commands/cksum.cpp` | Performance probes: 1. |
 | P1 | `comm` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 406 | 424 | 8 | 0 | 0 | 16 | 2 | 1.4x | 0 | `src/commands/comm.cpp` | Performance probes: 2. |
-| P1 | `csplit` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 515 | 1210 | 8 | 0 | 0 | 11 | 1 | 0.9x | 0 | `src/commands/csplit.cpp` | Regex behavior is command-owned, not shell-owned.<br>Performance probes: 1. |
+| P1 | `csplit` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 512 | 1210 | 8 | 0 | 0 | 11 | 1 | 0.9x | 0 | `src/commands/csplit.cpp` | Regex behavior is command-owned, not shell-owned.<br>Performance probes: 1. |
 | P1 | `dd` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 417 | 2235 | 11 | 0 | 0 | 8 | 1 | 0.9x | 0 | `src/commands/dd.cpp` | Performance probes: 1. |
-| P1 | `df` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 906 | 1600 | 15 | 0 | 0 | 17 | 2 | 1.2x | 0 | `src/commands/df.cpp` | Performance probes: 2. |
+| P1 | `df` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 903 | 1600 | 15 | 0 | 0 | 17 | 2 | 1.2x | 0 | `src/commands/df.cpp` | Performance probes: 2. |
 | P1 | `dir` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 198 | 4888 | 36 | 0 | 0 | 7 | 1 | 1.0x | 0 | `src/commands/dir.cpp` | Performance probes: 1. |
 | P1 | `install` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 581 | 973 | 19 | 0 | 1 | 19 | 2 | 1.7x | 0 | `src/commands/install.cpp` | Has compatibility placeholder/no-op option(s).<br>Performance probes: 2. |
-| P1 | `join` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 605 | 1052 | 13 | 0 | 0 | 12 | 1 | 1.1x | 0 | `src/commands/join.cpp` | Performance probes: 1. |
-| P1 | `kill` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 655 | 1858 | 86 | 0 | 3 | 24 | 2 | 2.5x | 0 | `src/commands/kill.cpp` | Signal conversion follows GNU/procps behavior; Windows signal numbers are aligned to Cygwin/MSYS local references.<br>Has compatibility placeholder/no-op option(s).<br>Performance probes: 2. |
+| P1 | `join` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 602 | 1052 | 13 | 0 | 0 | 12 | 1 | 1.1x | 0 | `src/commands/join.cpp` | Performance probes: 1. |
+| P1 | `kill` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 654 | 1858 | 86 | 0 | 3 | 24 | 2 | 2.5x | 0 | `src/commands/kill.cpp` | Signal conversion follows GNU/procps behavior; Windows signal numbers are aligned to Cygwin/MSYS local references.<br>Has compatibility placeholder/no-op option(s).<br>Performance probes: 2. |
 | P1 | `md5sum` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 383 | 1741 | 10 | 0 | 0 | 22 | 1 | 1.2x | 0 | `src/commands/md5sum.cpp` | Performance probes: 1. |
-| P1 | `mktemp` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 348 | 321 | 6 | 0 | 0 | 11 | 1 | 0.9x | 0 | `src/commands/mktemp.cpp` | Performance probes: 1. |
-| P1 | `nl` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 413 | 554 | 11 | 0 | 0 | 13 | 1 | 1.2x | 0 | `src/commands/nl.cpp` | Regex behavior is command-owned, not shell-owned.<br>Performance probes: 1. |
+| P1 | `mktemp` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 405 | 321 | 6 | 0 | 0 | 11 | 1 | 0.9x | 0 | `src/commands/mktemp.cpp` | Performance probes: 1. |
+| P1 | `nl` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 410 | 554 | 11 | 0 | 0 | 13 | 1 | 1.2x | 0 | `src/commands/nl.cpp` | Regex behavior is command-owned, not shell-owned.<br>Performance probes: 1. |
 | P1 | `od` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 607 | 1792 | 13 | 0 | 0 | 15 | 1 | 0.7x | 0 | `src/commands/od.cpp` | Performance probes: 1. |
 | P1 | `paste` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 399 | 477 | 3 | 0 | 0 | 12 | 1 | 0.8x | 0 | `src/commands/paste.cpp` | Performance probes: 1. |
 | P1 | `pr` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 663 | 2466 | 26 | 0 | 0 | 14 | 1 | 1.0x | 0 | `src/commands/pr.cpp` | Performance probes: 1. |
 | P1 | `printf` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 518 | 701 | 1 | 0 | 0 | 8 | 1 | 0.7x | 0 | `src/commands/printf.cpp` | Performance probes: 1. |
-| P1 | `readlink` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 455 | 181 | 8 | 0 | 0 | 15 | 1 | 1.3x | 0 | `src/commands/readlink.cpp` | Performance probes: 1. |
+| P1 | `readlink` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 429 | 181 | 8 | 0 | 0 | 15 | 1 | 1.3x | 0 | `src/commands/readlink.cpp` | Performance probes: 1. |
 | P1 | `realpath` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 412 | 269 | 11 | 0 | 0 | 19 | 1 | 0.7x | 0 | `src/commands/realpath.cpp` | Performance probes: 1. |
-| P1 | `seq` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 413 | 605 | 32 | 0 | 0 | 20 | 1 | 1.4x | 0 | `src/commands/seq.cpp` | Performance probes: 1. |
+| P1 | `seq` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 408 | 605 | 32 | 0 | 0 | 20 | 1 | 1.4x | 0 | `src/commands/seq.cpp` | Performance probes: 1. |
 | P1 | `sha224sum` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 318 | 1741 | 10 | 0 | 0 | 21 | 1 | 1.1x | 0 | `src/commands/sha224sum.cpp` | Performance probes: 1. |
 | P1 | `sha384sum` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 318 | 1741 | 10 | 0 | 0 | 21 | 1 | 1.0x | 0 | `src/commands/sha384sum.cpp` | Performance probes: 1. |
 | P1 | `sha512sum` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 387 | 1741 | 10 | 0 | 0 | 21 | 1 | 1.1x | 0 | `src/commands/sha512sum.cpp` | Performance probes: 1. |
 | P1 | `shuf` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 712 | 530 | 8 | 0 | 0 | 22 | 1 | 1.0x | 0 | `src/commands/shuf.cpp` | Performance probes: 1. |
-| P1 | `split` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 691 | 1546 | 13 | 0 | 0 | 19 | 1 | 1.1x | 0 | `src/commands/split.cpp` | Performance probes: 1. |
+| P1 | `split` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 709 | 1546 | 13 | 0 | 0 | 19 | 1 | 1.1x | 0 | `src/commands/split.cpp` | Performance probes: 1. |
 | P1 | `stat` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 648 | 1862 | 6 | 0 | 1 | 14 | 1 | 0.5x | 0 | `src/commands/stat.cpp` | Has compatibility placeholder/no-op option(s).<br>Performance probes: 1. |
-| P1 | `tac` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 231 | 507 | 3 | 0 | 0 | 11 | 1 | 1.5x | 0 | `src/commands/tac.cpp` | Regex behavior is command-owned, not shell-owned.<br>Performance probes: 1. |
+| P1 | `tac` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 207 | 507 | 3 | 0 | 0 | 13 | 1 | 1.5x | 0 | `src/commands/tac.cpp` | Regex behavior is command-owned, not shell-owned.<br>Performance probes: 1. |
 | P1 | `timeout` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 350 | 593 | 5 | 0 | 0 | 22 | 1 | 1.2x | 0 | `src/commands/timeout.cpp` | Performance probes: 1. |
-| P1 | `uniq` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 349 | 579 | 10 | 0 | 0 | 15 | 4 | 1.6x | 0 | `src/commands/uniq.cpp` | Performance probes: 4. |
-| P1 | `unlink` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 126 | 68 | 1 | 0 | 0 | 10 | 1 | 0.8x | 0 | `src/commands/unlink.cpp` | Performance probes: 1. |
+| P1 | `uniq` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 347 | 579 | 10 | 0 | 0 | 17 | 4 | 1.6x | 0 | `src/commands/uniq.cpp` | Performance probes: 4. |
+| P1 | `unlink` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 134 | 68 | 1 | 0 | 0 | 11 | 1 | 0.8x | 0 | `src/commands/unlink.cpp` | Performance probes: 1. |
 | P1 | `vdir` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 208 | 4888 | 38 | 0 | 0 | 7 | 1 | 1.1x | 0 | `src/commands/vdir.cpp` | Performance probes: 1. |
 | P1 | `cmp` | [gnu-diffutils](https://www.gnu.org/software/diffutils/manual/) | 446 | 637 | 5 | 0 | 0 | 15 | 1 | 0.4x | 0 | `src/commands/cmp.cpp` | Performance probes: 1. |
-| P1 | `column` | [util-linux](https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/) | 433 | 1158 | 28 | 0 | 0 | 14 | 2 | 1.0x | 0 | `src/commands/column.cpp` | Performance probes: 2. |
+| P1 | `column` | [util-linux](https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/) | 432 | 1158 | 27 | 0 | 0 | 14 | 2 | 1.0x | 0 | `src/commands/column.cpp` | Performance probes: 2. |
 | P2 | `getconf` | [cygwin](https://cygwin.com/) | 113 | 603 | 2 | 0 | 0 | 4 | 1 | 0.8x | 0 | `src/commands/getconf.cpp` | Performance probes: 1. |
 | P2 | `locale` | [cygwin](https://cygwin.com/) | 143 | 694 | 3 | 0 | 0 | 3 | 1 | 0.5x | 0 | `src/commands/locale.cpp` | Performance probes: 1. |
 | P2 | `d2u` | [dos2unix](https://waterlan.home.xs4all.nl/dos2unix.html) | 145 | 3334 | 1 | 0 | 0 | 3 | 1 | 0.9x | 0 | `src/commands/d2u.cpp` | Performance probes: 1. |
@@ -119,45 +119,45 @@ Scope excludes `wpm` by release policy.
 | P2 | `unix2dos` | [dos2unix](https://waterlan.home.xs4all.nl/dos2unix.html) | 146 | 3334 | 1 | 0 | 0 | 1 | 1 | 0.8x | 0 | `src/commands/unix2dos.cpp` | Performance probes: 1. |
 | P2 | `file` | [file](https://www.darwinsys.com/file/) | 292 | 6615 | 4 | 0 | 0 | 4 | 1 | 0.1x | 0 | `src/commands/file.cpp` | Performance probes: 1. |
 | P2 | `arch` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 98 | 334 | 1 | 0 | 0 | 2 | 1 | 0.4x | 0 | `src/commands/arch.cpp` | Performance probes: 1. |
-| P2 | `base32` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 218 | 1556 | 3 | 0 | 0 | 12 | 2 | 1.0x | 0 | `src/commands/base32.cpp` | Performance probes: 2. |
-| P2 | `base64` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 220 | 1556 | 3 | 0 | 0 | 11 | 2 | 1.3x | 0 | `src/commands/base64.cpp` | Performance probes: 2. |
-| P2 | `basenc` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 479 | 1556 | 13 | 0 | 0 | 16 | 2 | 1.1x | 0 | `src/commands/basenc.cpp` | Performance probes: 2. |
+| P2 | `base32` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 190 | 1556 | 3 | 0 | 0 | 12 | 2 | 1.0x | 0 | `src/commands/base32.cpp` | Performance probes: 2. |
+| P2 | `base64` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 192 | 1556 | 3 | 0 | 0 | 12 | 2 | 1.3x | 0 | `src/commands/base64.cpp` | Performance probes: 2. |
+| P2 | `basenc` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 594 | 1556 | 13 | 0 | 0 | 19 | 2 | 1.1x | 0 | `src/commands/basenc.cpp` | Performance probes: 2. |
 | P2 | `chcon` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 151 | 522 | 14 | 0 | 0 | 6 | 2 | 1.5x | 0 | `src/commands/chcon.cpp` | Performance probes: 2. |
-| P2 | `chroot` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 76 | 372 | 3 | 0 | 0 | 5 | 2 | 1.4x | 0 | `src/commands/chroot.cpp` | Performance probes: 2. |
+| P2 | `chroot` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 75 | 372 | 3 | 0 | 0 | 5 | 2 | 1.4x | 0 | `src/commands/chroot.cpp` | Performance probes: 2. |
 | P2 | `dircolors` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 258 | 467 | 4 | 0 | 0 | 4 | 1 | 1.3x | 0 | `src/commands/dircolors.cpp` | Performance probes: 1. |
 | P2 | `expand` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 301 | 193 | 2 | 0 | 0 | 12 | 1 | 0.8x | 0 | `src/commands/expand.cpp` | Performance probes: 1. |
 | P2 | `expr` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 508 | 856 | 1 | 0 | 0 | 11 | 2 | 1.0x | 0 | `src/commands/expr.cpp` | Performance probes: 2. |
-| P2 | `factor` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 131 | 1756 | 1 | 0 | 0 | 2 | 1 | 0.9x | 0 | `src/commands/factor.cpp` | Performance probes: 1. |
+| P2 | `factor` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 140 | 1756 | 1 | 0 | 0 | 2 | 1 | 0.9x | 0 | `src/commands/factor.cpp` | Performance probes: 1. |
 | P2 | `false` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 59 | 61 | 1 | 0 | 0 | 2 | 1 | 0.9x | 0 | `src/commands/false.cpp` | Performance probes: 1. |
 | P2 | `fmt` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 659 | 874 | 12 | 0 | 0 | 19 | 1 | 1.1x | 0 | `src/commands/fmt.cpp` | Performance probes: 1. |
 | P2 | `fold` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 334 | 306 | 4 | 0 | 0 | 15 | 1 | 0.6x | 0 | `src/commands/fold.cpp` | Performance probes: 1. |
 | P2 | `groups` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 93 | 122 | 1 | 0 | 0 | 2 | 1 | 1.0x | 0 | `src/commands/groups.cpp` | Performance probes: 1. |
 | P2 | `hostid` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 95 | 64 | 1 | 0 | 0 | 2 | 1 | 1.0x | 0 | `src/commands/hostid.cpp` | Performance probes: 1. |
 | P2 | `hostname` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 184 | 94 | 10 | 4 | 0 | 2 | 1 | 0.7x | 0 | `src/commands/hostname.cpp` | Has explicitly unsupported declared option(s).<br>Performance probes: 1. |
-| P2 | `id` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 308 | 411 | 8 | 0 | 0 | 13 | 3 | 1.1x | 0 | `src/commands/id.cpp` | Performance probes: 3. |
+| P2 | `id` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 234 | 411 | 8 | 0 | 0 | 13 | 3 | 1.1x | 0 | `src/commands/id.cpp` | Performance probes: 3. |
 | P2 | `link` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 114 | 73 | 1 | 0 | 0 | 11 | 1 | 1.0x | 0 | `src/commands/link.cpp` | Performance probes: 1. |
 | P2 | `logname` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 69 | 64 | 1 | 0 | 0 | 2 | 1 | 0.8x | 0 | `src/commands/logname.cpp` | Performance probes: 1. |
 | P2 | `mkfifo` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 110 | 166 | 3 | 0 | 0 | 5 | 2 | 1.8x | 0 | `src/commands/mkfifo.cpp` | Performance probes: 2. |
 | P2 | `mknod` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 160 | 245 | 3 | 0 | 0 | 6 | 4 | 1.4x | 0 | `src/commands/mknod.cpp` | Performance probes: 4. |
-| P2 | `nice` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 169 | 219 | 1 | 0 | 0 | 14 | 1 | 0.8x | 0 | `src/commands/nice.cpp` | Performance probes: 1. |
+| P2 | `nice` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 148 | 219 | 1 | 0 | 0 | 14 | 1 | 0.8x | 0 | `src/commands/nice.cpp` | Performance probes: 1. |
 | P2 | `nohup` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 163 | 198 | 1 | 0 | 0 | 7 | 1 | 1.0x | 0 | `src/commands/nohup.cpp` | Performance probes: 1. |
 | P2 | `nproc` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 82 | 112 | 3 | 0 | 0 | 6 | 1 | 0.8x | 0 | `src/commands/nproc.cpp` | Performance probes: 1. |
-| P2 | `numfmt` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 284 | 1471 | 9 | 0 | 0 | 9 | 1 | 0.9x | 0 | `src/commands/numfmt.cpp` | Performance probes: 1. |
+| P2 | `numfmt` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 280 | 1471 | 9 | 0 | 0 | 9 | 1 | 0.9x | 0 | `src/commands/numfmt.cpp` | Performance probes: 1. |
 | P2 | `pathchk` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 190 | 354 | 2 | 0 | 0 | 14 | 1 | 0.6x | 0 | `src/commands/pathchk.cpp` | Performance probes: 1. |
 | P2 | `pinky` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 127 | 514 | 10 | 0 | 0 | 3 | 3 | 1.3x | 0 | `src/commands/pinky.cpp` | Performance probes: 3. |
 | P2 | `printenv` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 119 | 130 | 1 | 0 | 0 | 9 | 1 | 1.3x | 0 | `src/commands/printenv.cpp` | Performance probes: 1. |
-| P2 | `ptx` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 432 | 1647 | 18 | 0 | 0 | 11 | 3 | 1.0x | 0 | `src/commands/ptx.cpp` | Performance probes: 3. |
+| P2 | `ptx` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 428 | 1647 | 18 | 0 | 0 | 11 | 3 | 1.0x | 0 | `src/commands/ptx.cpp` | Performance probes: 3. |
 | P2 | `runcon` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 91 | 244 | 5 | 0 | 0 | 5 | 2 | 1.2x | 0 | `src/commands/runcon.cpp` | Performance probes: 2. |
 | P2 | `sha1sum` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 388 | 1741 | 10 | 0 | 0 | 17 | 1 | 0.9x | 0 | `src/commands/sha1sum.cpp` | Performance probes: 1. |
 | P2 | `sha256sum` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 386 | 1741 | 10 | 0 | 0 | 16 | 1 | 0.8x | 0 | `src/commands/sha256sum.cpp` | Performance probes: 1. |
-| P2 | `shred` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 166 | 1181 | 9 | 0 | 0 | 8 | 1 | 0.7x | 0 | `src/commands/shred.cpp` | Performance probes: 1. |
+| P2 | `shred` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 178 | 1181 | 9 | 0 | 0 | 8 | 1 | 0.7x | 0 | `src/commands/shred.cpp` | Performance probes: 1. |
 | P2 | `sleep` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 153 | 122 | 1 | 0 | 0 | 8 | 1 | 0.8x | 0 | `src/commands/sleep.cpp` | Performance probes: 1. |
 | P2 | `stdbuf` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 239 | 337 | 3 | 0 | 0 | 8 | 1 | 1.2x | 0 | `src/commands/stdbuf.cpp` | Performance probes: 1. |
-| P2 | `stty` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 471 | 2152 | 3 | 0 | 0 | 9 | 6 | 1.4x | 0 | `src/commands/stty.cpp` | Performance probes: 6. |
+| P2 | `stty` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 475 | 2152 | 4 | 0 | 0 | 9 | 6 | 1.4x | 0 | `src/commands/stty.cpp` | Performance probes: 6. |
 | P2 | `sum` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 194 | 190 | 2 | 0 | 0 | 9 | 1 | 0.9x | 0 | `src/commands/sum.cpp` | Performance probes: 1. |
-| P2 | `sync` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 155 | 191 | 2 | 0 | 0 | 12 | 1 | 0.3x | 0 | `src/commands/sync.cpp` | Performance probes: 1. |
+| P2 | `sync` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 153 | 191 | 2 | 0 | 0 | 12 | 1 | 0.3x | 0 | `src/commands/sync.cpp` | Performance probes: 1. |
 | P2 | `true` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 59 | 61 | 1 | 0 | 0 | 2 | 1 | 0.8x | 0 | `src/commands/true.cpp` | Performance probes: 1. |
-| P2 | `truncate` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 443 | 345 | 4 | 0 | 0 | 9 | 1 | 0.4x | 0 | `src/commands/truncate.cpp` | Performance probes: 1. |
+| P2 | `truncate` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 463 | 345 | 4 | 0 | 0 | 12 | 1 | 0.4x | 0 | `src/commands/truncate.cpp` | Performance probes: 1. |
 | P2 | `tsort` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 67 | 477 | 1 | 0 | 0 | 1 | 1 | 1.8x | 0 | `src/commands/tsort.cpp` | Performance probes: 1. |
 | P2 | `tty` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 86 | 112 | 2 | 0 | 0 | 6 | 2 | 1.2x | 0 | `src/commands/tty.cpp` | Performance probes: 2. |
 | P2 | `uname` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 193 | 334 | 9 | 0 | 0 | 3 | 1 | 0.4x | 0 | `src/commands/uname.cpp` | Performance probes: 1. |
@@ -166,21 +166,36 @@ Scope excludes `wpm` by release policy.
 | P2 | `users` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 84 | 118 | 1 | 0 | 0 | 1 | 1 | 0.8x | 0 | `src/commands/users.cpp` | Performance probes: 1. |
 | P2 | `who` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 138 | 724 | 15 | 0 | 0 | 14 | 1 | 1.2x | 0 | `src/commands/who.cpp` | Performance probes: 1. |
 | P2 | `whoami` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 99 | 70 | 1 | 0 | 0 | 2 | 1 | 2.1x | 0 | `src/commands/whoami.cpp` | Performance probes: 1. |
-| P2 | `yes` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 116 | 227 | 1 | 0 | 0 | 5 | 1 | 1.9x | 0 | `src/commands/yes.cpp` | Performance probes: 1. |
+| P2 | `yes` | [gnu-coreutils](https://www.gnu.org/software/coreutils/manual/) | 119 | 227 | 1 | 0 | 0 | 5 | 1 | 1.9x | 0 | `src/commands/yes.cpp` | Performance probes: 1. |
 | P2 | `cpio` | [gnu-cpio](https://www.gnu.org/software/cpio/) | 405 | 4676 | 6 | 0 | 0 | 2 | 1 |  | 0 | `src/commands/cpio.cpp` | Performance probes: 1. |
 | P2 | `diff3` | [gnu-diffutils](https://www.gnu.org/software/diffutils/manual/) | 318 | 1431 | 5 | 0 | 0 | 13 | 2 | 0.1x | 0 | `src/commands/diff3.cpp` | Performance probes: 2. |
-| P2 | `sdiff` | [gnu-diffutils](https://www.gnu.org/software/diffutils/manual/) | 326 | 997 | 8 | 0 | 0 | 10 | 1 | 0.2x | 0 | `src/commands/sdiff.cpp` | Performance probes: 1. |
+| P2 | `sdiff` | [gnu-diffutils](https://www.gnu.org/software/diffutils/manual/) | 324 | 997 | 8 | 0 | 0 | 10 | 1 | 0.2x | 0 | `src/commands/sdiff.cpp` | Performance probes: 1. |
 | P2 | `which` | [gnu-which](https://savannah.gnu.org/projects/which/) | 363 | 691 | 5 | 0 | 0 | 14 | 1 | 1.0x | 0 | `src/commands/which.cpp` | Performance probes: 1. |
 | P2 | `hmac256` | [libgcrypt](https://gnupg.org/software/libgcrypt/) | 99 | 711 | 1 | 0 | 0 | 1 | 2 | 1.4x | 0 | `src/commands/hmac256.cpp` | Performance probes: 2. |
-| P2 | `mpicalc` | [libgcrypt](https://gnupg.org/software/libgcrypt/) | 532 | 575 | 4 | 0 | 0 | 2 | 2 | 0.9x | 0 | `src/commands/mpicalc.cpp` | Performance probes: 2. |
-| P2 | `tzset` | local | 110 | 0 | 2 | 0 | 0 | 2 | 4 | 1.2x | 0 | `src/commands/tzset.cpp` | Performance probes: 4. |
-| P2 | `lsof` | [lsof](https://github.com/lsof-org/lsof) | 818 | 5202 | 7 | 0 | 0 | 7 | 2 |  | 0 | `src/commands/lsof.cpp` | Performance probes: 2. |
-| P2 | `man` | [man-db](https://www.nongnu.org/man-db/) | 82 | 3953 | 1 | 0 | 0 | 4 | 1 |  | 0 | `src/commands/man.cpp` | Performance probes: 1. |
+| P2 | `mpicalc` | [libgcrypt](https://gnupg.org/software/libgcrypt/) | 534 | 575 | 4 | 0 | 0 | 2 | 2 | 0.9x | 0 | `src/commands/mpicalc.cpp` | Performance probes: 2. |
+| P2 | `chattr` | local | 185 | 0 | 2 | 0 | 0 | 4 | 0 |  | 0 | `src/commands/chattr.cpp` |  |
+| P2 | `envsubst` | local | 167 | 0 | 1 | 0 | 0 | 3 | 0 |  | 0 | `src/commands/envsubst.cpp` |  |
+| P2 | `getfacl` | local | 154 | 0 | 2 | 0 | 0 | 3 | 0 |  | 0 | `src/commands/getfacl.cpp` |  |
+| P2 | `killall` | local | 127 | 0 | 10 | 0 | 0 | 3 | 0 |  | 0 | `src/commands/killall.cpp` |  |
+| P2 | `ldd` | local | 213 | 0 | 1 | 0 | 0 | 3 | 0 |  | 0 | `src/commands/ldd.cpp` |  |
+| P2 | `logger` | local | 106 | 0 | 4 | 0 | 0 | 2 | 0 |  | 0 | `src/commands/logger.cpp` |  |
+| P2 | `lsattr` | local | 150 | 0 | 2 | 0 | 0 | 2 | 0 |  | 0 | `src/commands/lsattr.cpp` |  |
+| P2 | `mkgroup` | local | 110 | 0 | 2 | 0 | 0 | 3 | 0 |  | 0 | `src/commands/mkgroup.cpp` |  |
+| P2 | `mkpasswd` | local | 123 | 0 | 4 | 0 | 0 | 3 | 0 |  | 0 | `src/commands/mkpasswd.cpp` |  |
+| P2 | `pgrep` | local | 117 | 0 | 6 | 0 | 0 | 3 | 0 |  | 0 | `src/commands/pgrep.cpp` |  |
+| P2 | `pidof` | local | 81 | 0 | 1 | 0 | 0 | 3 | 0 |  | 0 | `src/commands/pidof.cpp` |  |
+| P2 | `pkill` | local | 115 | 0 | 10 | 0 | 0 | 3 | 0 |  | 0 | `src/commands/pkill.cpp` |  |
+| P2 | `pldd` | local | 67 | 0 | 1 | 0 | 0 | 3 | 0 |  | 0 | `src/commands/pldd.cpp` |  |
+| P2 | `regtool` | local | 301 | 0 | 1 | 0 | 0 | 5 | 0 |  | 0 | `src/commands/regtool.cpp` |  |
+| P2 | `renice` | local | 112 | 0 | 2 | 0 | 0 | 3 | 0 |  | 0 | `src/commands/renice.cpp` |  |
+| P2 | `tzset` | local | 125 | 0 | 2 | 0 | 0 | 2 | 4 | 1.2x | 0 | `src/commands/tzset.cpp` | Performance probes: 4. |
+| P2 | `lsof` | [lsof](https://github.com/lsof-org/lsof) | 821 | 5202 | 7 | 0 | 0 | 7 | 2 |  | 0 | `src/commands/lsof.cpp` | Performance probes: 2. |
+| P2 | `man` | [man-db](https://www.nongnu.org/man-db/) | 85 | 3953 | 1 | 0 | 0 | 4 | 1 |  | 0 | `src/commands/man.cpp` | Performance probes: 1. |
 | P2 | `clear` | [ncurses](https://invisible-island.net/ncurses/) | 62 | 96 | 1 | 0 | 0 | 1 | 1 | 1.1x | 0 | `src/commands/clear.cpp` | Performance probes: 1. |
 | P2 | `infocmp` | [ncurses](https://invisible-island.net/ncurses/) | 27 | 1713 | 1 | 0 | 0 | 1 | 1 | 1.0x | 0 | `src/commands/infocmp.cpp` | Performance probes: 1. |
 | P2 | `reset` | [ncurses](https://invisible-island.net/ncurses/) | 45 | 603 | 6 | 0 | 0 | 3 | 1 | 1.2x | 0 | `src/commands/reset.cpp` | Performance probes: 1. |
 | P2 | `tic` | [ncurses](https://invisible-island.net/ncurses/) | 35 | 3105 | 6 | 0 | 0 | 2 | 2 | 1.2x | 0 | `src/commands/tic.cpp` | Performance probes: 2. |
-| P2 | `toe` | [ncurses](https://invisible-island.net/ncurses/) | 32 | 677 | 7 | 0 | 0 | 1 | 1 | 0.7x | 0 | `src/commands/toe.cpp` | Performance probes: 1. |
+| P2 | `toe` | [ncurses](https://invisible-island.net/ncurses/) | 33 | 677 | 7 | 0 | 0 | 1 | 1 | 0.7x | 0 | `src/commands/toe.cpp` | Performance probes: 1. |
 | P2 | `tput` | [ncurses](https://invisible-island.net/ncurses/) | 41 | 409 | 1 | 0 | 0 | 7 | 1 | 0.8x | 0 | `src/commands/tput.cpp` | Performance probes: 1. |
 | P2 | `patch` | [patch](https://savannah.gnu.org/projects/patch/) | 351 | 4108 | 6 | 0 | 0 | 1 | 1 | 0.6x | 0 | `src/commands/patch.cpp` | Performance probes: 1. |
 | P2 | `free` | [procps-ng](https://gitlab.com/procps-ng/procps) | 211 | 389 | 10 | 0 | 0 | 4 | 1 |  | 0 | `src/commands/free.cpp` | Performance probes: 1. |
@@ -188,8 +203,9 @@ Scope excludes `wpm` by release policy.
 | P2 | `top` | [procps-ng](https://gitlab.com/procps-ng/procps) | 993 | 7004 | 14 | 0 | 0 | 15 | 1 |  | 0 | `src/commands/top.cpp` | Performance probes: 1. |
 | P2 | `watch` | [procps-ng](https://gitlab.com/procps-ng/procps) | 179 | 1284 | 5 | 0 | 0 | 3 | 2 |  | 0 | `src/commands/watch.cpp` | Performance probes: 2. |
 | P2 | `tree` | [tree](https://oldmanprogrammer.net/source.php?dir=projects/tree) | 560 | 1727 | 10 | 0 | 0 | 10 | 1 |  | 0 | `src/commands/tree.cpp` | Performance probes: 1. |
-| P2 | `cal` | [util-linux](https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/) | 171 | 1212 | 1 | 0 | 0 | 4 | 1 | 0.5x | 0 | `src/commands/cal.cpp` | Performance probes: 1. |
-| P2 | `col` | [util-linux](https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/) | 181 | 641 | 5 | 0 | 0 | 6 | 1 | 0.6x | 0 | `src/commands/col.cpp` | Performance probes: 1. |
+| P2 | `cal` | [util-linux](https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/) | 167 | 1212 | 1 | 0 | 0 | 4 | 1 | 0.5x | 0 | `src/commands/cal.cpp` | Performance probes: 1. |
+| P2 | `col` | [util-linux](https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/) | 182 | 641 | 5 | 0 | 0 | 6 | 1 | 0.6x | 0 | `src/commands/col.cpp` | Performance probes: 1. |
+| P2 | `getopt` | [util-linux](https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/) | 167 | 0 | 4 | 0 | 0 | 4 | 0 |  | 0 | `src/commands/getopt.cpp` | No local upstream source file mapped yet. |
 | P2 | `hexdump` | [util-linux](https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/) | 347 | 250 | 11 | 0 | 0 | 10 | 2 | 1.0x | 0 | `src/commands/hexdump.cpp` | Performance probes: 2. |
 | P2 | `rev` | [util-linux](https://mirrors.edge.kernel.org/pub/linux/utils/util-linux/) | 166 | 180 | 1 | 0 | 0 | 8 | 2 | 1.0x | 0 | `src/commands/rev.cpp` | Performance probes: 2. |
 | P2 | `xxd` | [xxd](https://www.vim.org/) | 111 | 1183 | 1 | 0 | 0 | 2 | 1 | 1.1x | 0 | `src/commands/xxd.cpp` | Performance probes: 1. |

--- a/README-zh.md
+++ b/README-zh.md
@@ -116,7 +116,7 @@ winuxsh release 包会自带架构匹配的 `winuxcmd/` 目录。它应该和 wi
 
 ## 自带什么
 
-WinuxCmd 目前实现 153 个命令，覆盖这些常见场景：
+WinuxCmd 目前实现 171 个命令，覆盖这些常见场景：
 
 - 文件：`ls`、`cp`、`mv`、`rm`、`mkdir`、`ln`、`stat`、`readlink`、`realpath`
 - 文本：`cat`、`grep`、`sed`、`sort`、`uniq`、`cut`、`head`、`tail`、`wc`
@@ -152,4 +152,3 @@ ctest --test-dir build-vs -R "^(grep|find|rm)\." --output-on-failure
 - [WPM source](https://github.com/unixwin/wpm-source)
 - [贡献指南](CONTRIBUTING_ZH.MD)
 - [构建模式文档](DOCS/zh/build_modes.md)
-

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ arm64 shell bundles stay reproducible.
 
 ## What Ships
 
-WinuxCmd currently implements 153 commands, including practical coverage across:
+WinuxCmd currently implements 171 commands, including practical coverage across:
 
 - Files: `ls`, `cp`, `mv`, `rm`, `mkdir`, `ln`, `stat`, `readlink`, `realpath`
 - Text: `cat`, `grep`, `sed`, `sort`, `uniq`, `cut`, `head`, `tail`, `wc`
@@ -159,4 +159,3 @@ ctest --test-dir build-vs -R "^(grep|find|rm)\." --output-on-failure
 - [WPM source](https://github.com/unixwin/wpm-source)
 - [Contributing Guide](CONTRIBUTING.md)
 - [Build Modes](DOCS/en/build_modes_en.md)
-


### PR DESCRIPTION
## Summary
- Update README command totals to 171 registered commands
- Refresh generated command compatibility matrix to 170 release-scope commands excluding wpm

## Verification
- Verified generated matrix JSON has 170 commands, excludes wpm, and includes the new native commands
- Ran git diff --check