### PR TITLE
fix: make shell globbing the default

### DIFF
--- a/DOCS/README.md
+++ b/DOCS/README.md
@@ -29,6 +29,10 @@ next to the workspace integration scripts.
 - Keep GNU references pointed at the official manuals.
 - Track compatibility as a matrix, not as copied manual text.
 - Keep file-operand wildcard expansion limited to commands that explicitly opt in.
+- Treat Winuxsh as the authoritative owner of shell glob expansion; command-level
+  expansion is only a compatibility fallback for direct native callers.
+- The default is shell-owned expansion (`done`). PowerShell activation sets
+  `WINUX_SHELL_GLOB=native` to opt into the direct-native fallback.
 - For fixed-arity file commands such as `diff`, `diff3`, `split`, and
   `csplit`, wildcard expansion must resolve to the exact number of operands
   the command expects.

--- a/DOCS/README_zh.md
+++ b/DOCS/README_zh.md
@@ -28,6 +28,10 @@ release 包应同时附带 Windows binaries 和 `WinuxCmd-skill-v<version>.zip`�
 - GNU 参考只链接官方手册。
 - 兼容性用矩阵维护，不直接复制手册正文。
 - 只有显式接入 `contains_wildcard` / `glob_expand` 的命令才展开通配符。
+- Winuxsh 是 shell 通配符展开的唯一权威；命令层展开只作为直接调用原生
+  WinuxCmd 时的兼容 fallback。
+- 默认就是 shell-owned 展开（`done`）；PowerShell 激活时设置
+  `WINUX_SHELL_GLOB=native`，显式启用 direct-native fallback。
 - 对于 `diff`、`diff3`、`split`、`csplit` 这类固定参数个数的命令，
   通配符展开必须精确匹配命令期望的参数数量。
 - 工作区激活不要污染全局 PATH。

--- a/DOCS/en/gnu_coreutils_parity.md
+++ b/DOCS/en/gnu_coreutils_parity.md
@@ -28,9 +28,11 @@ ripgrep through WPM.
 
 ## Wildcard expansion policy
 
-- Only commands wired to `contains_wildcard` / `glob_expand` expand wildcards.
-- WinuxCmd receives arguments after shell parsing; wildcard-aware commands
-  expand file-like operands according to their own command policy.
+- Only commands wired to the shared file-operand helper expand wildcards.
+- Winuxsh owns shell glob expansion. The command-level helper is a compatibility
+  fallback for direct native callers that pass an unexpanded file operand.
+- Shell-owned expansion is the default. PowerShell activation sets
+  `WINUX_SHELL_GLOB=native` to opt into the direct-native fallback.
 - Expansion still prefers the literal path first for ordinary `*` / `?`
   patterns, but `[]` character-class patterns now try glob expansion first
   even when a same-spelling literal path exists; if no `[]` matches are found,

--- a/DOCS/zh/gnu_coreutils_parity.md
+++ b/DOCS/zh/gnu_coreutils_parity.md
@@ -23,8 +23,11 @@ clean-room BRE/ERE matcher。PCRE2 JIT 默认关闭，以保持原生工具集�
 
 ## 通配符展开规则
 
-- 只有显式接入 `contains_wildcard` / `glob_expand` 的命令才会展开通配符。
-- WinuxCmd 接收的是 shell 解析后的参数；支持通配符的命令会按各自的文件参数策略展开。
+- 只有显式接入共享文件参数 helper 的命令才会展开通配符。
+- Winuxsh 负责 shell 通配符展开；命令层 helper 只为直接调用原生 WinuxCmd
+  且仍传入未展开文件参数的场景提供兼容 fallback。
+- 默认就是 shell-owned 展开；PowerShell 激活时设置
+  `WINUX_SHELL_GLOB=native`，显式启用 direct-native fallback。
 - 普通 `*` / `?` 模式仍然优先尝试字面路径；但 `[]` 字符类模式现在会先
   按 glob 展开，即使同名的字面路径真实存在；只有在 `[]` 没有匹配结果时，
   才回退到原始字面路径。

--- a/scripts/winux.ps1
+++ b/scripts/winux.ps1
@@ -148,6 +148,10 @@ function Invoke-Activate {
     Save-ConflictedAliases
     Set-WinuxAliases
 
+    # PowerShell leaves wildcard-looking arguments literal. Opt into the
+    # WinuxCmd native fallback while this PowerShell workspace is active.
+    $env:WINUX_SHELL_GLOB = "native"
+
     # Add WinuxCmd bin directory to PATH
     if ($env:PATH -notlike "$ScriptDir*") {
         $env:PATH = "$ScriptDir;$env:PATH"
@@ -167,6 +171,7 @@ function Invoke-Deactivate {
     Write-Host "Deactivating WinuxCmd..." -ForegroundColor Green
 
     Restore-ConflictedAliases
+    Remove-Item Env:WINUX_SHELL_GLOB -ErrorAction SilentlyContinue
 
     Write-Host "Deactivation complete! All original aliases restored." -ForegroundColor Green
 }

--- a/src/commands/b2sum.cpp
+++ b/src/commands/b2sum.cpp
@@ -132,16 +132,9 @@ auto build_config(const CommandContext<B2SUM_OPTIONS.size()>& ctx)
 
   for (auto arg : ctx.positionals) {
     std::string file_arg(arg);
-    if (contains_wildcard(file_arg)) {
-      auto glob_result = glob_expand(file_arg);
-      if (glob_result.expanded) {
-        for (const auto& file : glob_result.files) {
-          cfg.files.push_back(wstring_to_utf8(file));
-        }
-        continue;
-      }
+    for (const auto& file : expand_file_operand(file_arg)) {
+      cfg.files.push_back(file);
     }
-    cfg.files.push_back(file_arg);
   }
 
   if (cfg.files.empty() && !cfg.check_mode) {

--- a/src/commands/base32.cpp
+++ b/src/commands/base32.cpp
@@ -147,16 +147,9 @@ auto build_config(const CommandContext<BASE32_OPTIONS.size()>& ctx)
   SmallVector<std::string, 16> files;
   for (auto arg : ctx.positionals) {
     std::string file_arg(arg);
-    if (contains_wildcard(file_arg)) {
-      auto glob_result = glob_expand(file_arg);
-      if (glob_result.expanded) {
-        for (const auto& file : glob_result.files) {
-          files.push_back(wstring_to_utf8(file));
-        }
-        continue;
-      }
+    for (const auto& file : expand_file_operand(file_arg)) {
+      files.push_back(file);
     }
-    files.push_back(file_arg);
   }
 
   if (files.size() > 1) {

--- a/src/commands/base64.cpp
+++ b/src/commands/base64.cpp
@@ -146,16 +146,9 @@ auto build_config(const CommandContext<BASE64_OPTIONS.size()>& ctx)
   SmallVector<std::string, 16> files;
   for (auto arg : ctx.positionals) {
     std::string file_arg(arg);
-    if (contains_wildcard(file_arg)) {
-      auto glob_result = glob_expand(file_arg);
-      if (glob_result.expanded) {
-        for (const auto& file : glob_result.files) {
-          files.push_back(wstring_to_utf8(file));
-        }
-        continue;
-      }
+    for (const auto& file : expand_file_operand(file_arg)) {
+      files.push_back(file);
     }
-    files.push_back(file_arg);
   }
 
   if (files.size() > 1) {

--- a/src/commands/cat.cpp
+++ b/src/commands/cat.cpp
@@ -90,21 +90,9 @@ auto validate_arguments(const CommandContext<CAT_OPTIONS.size()> &ctx,
     -> cp::Result<void> {
   for (auto arg : ctx.positionals) {
     std::string file_arg(arg);
-
-    // Smart glob expansion for wildcard patterns
-    if (contains_wildcard(file_arg)) {
-      auto glob_result = glob_expand(file_arg);
-      if (glob_result.expanded) {
-        // Pattern was expanded, add all matched files
-        for (const auto &file : glob_result.files) {
-          out_files.push_back(wstring_to_utf8(file));
-        }
-        continue;
-      }
+    for (const auto& file : expand_file_operand(file_arg)) {
+      out_files.push_back(file);
     }
-
-    // Not a wildcard or expansion failed, use as-is
-    out_files.push_back(file_arg);
   }
 
   if (out_files.empty()) {

--- a/src/commands/cksum.cpp
+++ b/src/commands/cksum.cpp
@@ -161,16 +161,9 @@ auto build_config(const CommandContext<CKSUM_OPTIONS.size()>& ctx)
 
   for (auto arg : ctx.positionals) {
     std::string file_arg(arg);
-    if (contains_wildcard(file_arg)) {
-      auto glob_result = glob_expand(file_arg);
-      if (glob_result.expanded) {
-        for (const auto& file : glob_result.files) {
-          cfg.files.push_back(wstring_to_utf8(file));
-        }
-        continue;
-      }
+    for (const auto& file : expand_file_operand(file_arg)) {
+      cfg.files.push_back(file);
     }
-    cfg.files.push_back(file_arg);
   }
 
   if (cfg.files.empty() && !cfg.check_mode) {

--- a/src/commands/md5sum.cpp
+++ b/src/commands/md5sum.cpp
@@ -126,16 +126,9 @@ auto build_config(const CommandContext<MD5SUM_OPTIONS.size()>& ctx)
 
   for (auto arg : ctx.positionals) {
     std::string file_arg(arg);
-    if (contains_wildcard(file_arg)) {
-      auto glob_result = glob_expand(file_arg);
-      if (glob_result.expanded) {
-        for (const auto& file : glob_result.files) {
-          cfg.files.push_back(wstring_to_utf8(file));
-        }
-        continue;
-      }
+    for (const auto& file : expand_file_operand(file_arg)) {
+      cfg.files.push_back(file);
     }
-    cfg.files.push_back(file_arg);
   }
 
   if (cfg.files.empty() && !cfg.check_mode) {

--- a/src/utils/wildcard.cppm
+++ b/src/utils/wildcard.cppm
@@ -39,6 +39,16 @@ import :path;
 
 namespace wildcard_impl {
 
+static bool shell_owns_glob_expansion() {
+  char state[8] = {};
+  size_t length = GetEnvironmentVariableA("WINUX_SHELL_GLOB", state,
+                                          sizeof(state));
+  // Winuxsh is the default shell contract. Native fallback is opt-in for
+  // callers such as PowerShell that do not expand file globs.
+  return !(length > 0 && length < sizeof(state) &&
+           std::string_view(state, length) == "native");
+}
+
 static bool component_contains_wildcard(std::wstring_view segment) {
   return segment.find(L'*') != std::wstring_view::npos ||
          segment.find(L'?') != std::wstring_view::npos ||
@@ -268,14 +278,8 @@ export bool wildcard_match(const std::wstring &pattern,
  * @param str The string to check
  * @return true if the string contains wildcard characters, false otherwise
  *
- * Note: If the string starts with \x01, it was quoted in the shell
- * and should not be treated as a wildcard pattern.
  */
 export bool contains_wildcard(std::wstring_view str) {
-  // Check for quote protection marker
-  if (!str.empty() && str[0] == L'\x01') {
-    return false;
-  }
   return str.find(L'*') != std::wstring_view::npos ||
          str.find(L'?') != std::wstring_view::npos ||
          str.find(L'[') != std::wstring_view::npos;
@@ -290,23 +294,22 @@ export struct GlobResult {
 };
 
 /**
- * @brief Smart glob expansion that handles all environments
+ * @brief Expand a raw file operand using the native Windows fallback
  * @param pattern The wildcard pattern or literal file path
  * @return GlobResult containing matched files and expansion status
  *
- * This function implements smart wildcard expansion:
- * 1. First tries the pattern as a literal file path
- * 2. If that fails, tries wildcard expansion using FindFirstFileW
- * 3. If expansion fails, returns the original pattern as a literal value
- *
- * This approach works correctly in all environments:
- * - PowerShell: expanded parameters don't contain wildcards, used as literal
- * paths
- * - cmd.exe: wildcard arguments are passed through and expanded here
- * - Supports literal filenames like "*.txt" (a file actually named "*.txt")
+ * The shell is the authoritative owner of expansion.  This function exists
+ * only for direct native callers that pass an unexpanded file-like operand;
+ * unmatched patterns remain literal so command diagnostics stay useful.
  */
 export GlobResult glob_expand(std::wstring_view pattern) {
   GlobResult result;
+
+  if (wildcard_impl::shell_owns_glob_expansion()) {
+    result.files.push_back(std::wstring(pattern));
+    result.expanded = false;
+    return result;
+  }
 
   // Character-class patterns behave more like GNU shell globs on Windows:
   // even if a literal "[ab].txt" path exists, treat it as a glob first so it
@@ -406,15 +409,27 @@ export bool wildcard_match(const std::string &pattern, const std::string &text,
  * @param str The string to check
  * @return true if the string contains wildcard characters, false otherwise
  *
- * Note: If the string starts with \x01, it was quoted in the shell
- * and should not be treated as a wildcard pattern.
  */
 export bool contains_wildcard(std::string_view str) {
-  // Check for quote protection marker
-  if (!str.empty() && str[0] == '\x01') {
-    return false;
-  }
   return str.find('*') != std::string_view::npos ||
          str.find('?') != std::string_view::npos ||
          str.find('[') != std::string_view::npos;
+}
+
+/**
+ * @brief Expand one file-like operand for a command.
+ *
+ * Commands should use this boundary instead of duplicating wildcard
+ * detection and UTF-16 conversion. Unmatched patterns remain literal.
+ */
+export std::vector<std::string> expand_file_operand(std::string_view operand) {
+  if (!contains_wildcard(operand)) return {std::string(operand)};
+
+  auto result = glob_expand(operand);
+  std::vector<std::string> paths;
+  paths.reserve(result.files.size());
+  for (const auto& file : result.files) {
+    paths.push_back(wstring_to_utf8(file));
+  }
+  return paths;
 }

--- a/tests/framework/pipeline.cpp
+++ b/tests/framework/pipeline.cpp
@@ -269,6 +269,7 @@ CommandResult Pipeline::run() {
       }
 
       // Apply overrides from test pipeline.
+      vars[L"WINUX_SHELL_GLOB"] = L"native";
       for (auto &[k, v] : this->env_) {
         vars[k] = v;
       }
@@ -287,11 +288,9 @@ CommandResult Pipeline::run() {
     LPVOID env_ptr = nullptr;
     DWORD creation_flags = 0;
 
-    if (!env_.empty()) {
-      env_block = build_env_block();
-      env_ptr = env_block.data();
-      creation_flags |= CREATE_UNICODE_ENVIRONMENT;
-    }
+    env_block = build_env_block();
+    env_ptr = env_block.data();
+    creation_flags |= CREATE_UNICODE_ENVIRONMENT;
 
     auto set_child_inherit = [](HANDLE h, bool inherit) {
       if (h && h != INVALID_HANDLE_VALUE) {

--- a/tests/unit/cat/cat_unit_test.cpp
+++ b/tests/unit/cat/cat_unit_test.cpp
@@ -130,6 +130,22 @@ TEST(cat, cat_wildcard) {
   EXPECT_TRUE(r.stdout_text.find("log content") == std::string::npos);
 }
 
+TEST(cat, cat_trusts_shell_owned_glob_arguments) {
+  TempDir tmp;
+  tmp.write("file.txt", "content\n");
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.set_env(L"WINUX_SHELL_GLOB", L"done");
+  p.add(L"cat.exe", {L"*.txt"});
+
+  auto r = p.run();
+
+  EXPECT_NE(r.exit_code, 0);
+  EXPECT_TRUE(r.stderr_text.find("*.txt") != std::string::npos);
+  EXPECT_TRUE(r.stdout_text.find("content") == std::string::npos);
+}
+
 TEST(cat, cat_wildcard_question_mark) {
   TempDir tmp;
   tmp.write("file1.txt", "content1\n");


### PR DESCRIPTION
Apply the shell-owned globbing default and retain native expansion only as an explicit compatibility fallback.