### PR TITLE
fix: close issue 140 coreutils parity gaps

### DIFF
--- a/.github/workflows/gnu-parity.yml
+++ b/.github/workflows/gnu-parity.yml
@@ -1,0 +1,24 @@
+name: GNU differential parity
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  differential:
+    runs-on: windows-2025
+    steps:
+      - uses: actions/checkout@v6
+      - name: Build WinuxCmd
+        shell: pwsh
+        run: ./scripts/build-with-vs.ps1 -BuildDir build-differential -Target winuxcmd -Configuration Release
+      - name: Run differential corpus
+        shell: bash
+        env:
+          WINUXCMD_BIN: build-differential
+        run: tests/differential/runner.sh
+      - name: Upload report
+        uses: actions/upload-artifact@v7
+        with:
+          name: gnu-differential-report
+          path: tests/differential/report.md

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 build**/
 
+winuxcmd-build-*/
+
 cmake-build-*/
 
 out/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -530,6 +530,7 @@ macro(create_command_executable CMD)
             src/utils/utf8.cppm
             src/utils/win32.cppm
             src/utils/json.cppm
+            src/utils/i18n.cppm
             src/utils/file_io.cppm
             src/utils/cppbar.cppm
             src/utils/encoding.cppm
@@ -624,6 +625,7 @@ if(BUILD_STANDALONE)
         src/utils/win32.cppm
         src/utils/wildcard.cppm
         src/utils/json.cppm
+        src/utils/i18n.cppm
         src/utils/file_io.cppm
         src/utils/cppbar.cppm
         src/utils/encoding.cppm
@@ -711,6 +713,7 @@ if(BUILD_STANDALONE)
             src/utils/win32.cppm
             src/utils/wildcard.cppm
             src/utils/json.cppm
+            src/utils/i18n.cppm
             src/utils/file_io.cppm
             src/utils/cppbar.cppm
             src/utils/encoding.cppm

--- a/DOCS/i18n.md
+++ b/DOCS/i18n.md
@@ -1,0 +1,95 @@
+# WinuxCmd I18N
+
+WinuxCmd keeps English text in the executable. An external catalog is used
+only when a matching package has been installed, so removing the package or
+missing a translation key always falls back to English.
+
+## Catalog Location
+
+WPM-managed catalogs live below the WinuxCmd root:
+
+```text
+.wpm/i18n/<locale>/catalog.json
+```
+
+For example:
+
+```text
+.wpm/i18n/zh-CN/catalog.json
+```
+
+I18N is explicitly enabled only by `WINUX_LANG`. When it is unset, WinuxCmd
+does not probe the Windows locale, touch `.wpm`, or parse JSON. This keeps the
+normal startup path free of I18N file I/O. Set `WINUX_LANG=off` to explicitly
+disable it. Locale names using `_` are normalized to `-`; a `zh-CN` catalog
+also allows a `zh` fallback catalog.
+
+## Catalog Format
+
+Catalogs use stable message IDs rather than English text as keys:
+
+```json
+{
+  "schema": 1,
+  "locale": "zh-CN",
+  "messages": {
+    "command.ls.description": "列出目录内容",
+    "command.ls.option.all": "显示隐藏条目"
+  }
+}
+```
+
+The first implementation translates command help descriptions and option
+descriptions. Missing keys remain in English. Runtime diagnostics can be added
+later using the same `messages` map without changing the package layout.
+
+## Translation Workflow
+
+The English command metadata in `REGISTER_COMMAND` and `OPTION` declarations is
+the source text. A release tool should export those declarations into a catalog
+template, a translator or language model may create a draft, and CI must check
+that IDs and placeholders are preserved. Model output is only a draft and must
+be reviewed before publishing a WPM package.
+
+Language packages should be published as ordinary WPM artifacts with files
+under `.wpm/i18n/<locale>/`. The core executable must not depend on a network
+service or a translation provider at runtime.
+
+## Batch Translation Tool
+
+The repository provides `scripts/i18n_batch.py`. It only processes catalog
+JSON and never edits C++ source files. It uses the OpenAI-compatible gateway
+already configured in Winuxsh (`OPENAI_BASE_URL` and `OPENAI_API_KEY`) and
+defaults to the LUNA model name `gpt-5.6-luna`.
+
+```sh
+python scripts/i18n_batch.py extract --output en-US.json
+python scripts/i18n_batch.py translate --input en-US.json \
+  --output zh-CN.json --locale zh-CN --batch-size 40 --concurrency 2
+python scripts/i18n_batch.py validate --base en-US.json \
+  --translated zh-CN.json
+```
+
+Each request translates a batch of messages. `--batch-size` defaults to 40 and
+`--concurrency` defaults to 2, keeping gateway load bounded while avoiding one
+request per key. Completed batches are written to a `.partial` checkpoint so
+an interrupted run can resume. `OPENAI_I18N_MODEL` or `--model` can override
+the model. Translation output is a draft and must be reviewed before
+packaging.
+
+## Manual Help Entries
+
+Commands with their own help renderer use stable `custom_help` IDs. These
+entries are maintained manually because their formatting and command syntax
+must remain exact:
+
+```text
+command.top.custom_help
+command.mpicalc.custom_help
+command.tzset.custom_help
+command.wpm.custom_help
+```
+
+The extractor adds these English baselines but does not overwrite existing
+translations. Parser-only options with empty descriptions, such as `seq`'s
+negative-number sentinels, are excluded from catalogs and help output.

--- a/README-zh.md
+++ b/README-zh.md
@@ -102,6 +102,16 @@ winuxcmd wpm links rebuild --root "C:\path\to\winuxcmd"
 包在没有架构 URL、SHA-256 和文件映射之前只会显示为 `index-only`。这样
 WPM 可以先展示元数据，但只有经过校验的二进制才会真正安装。
 
+更新 WPM 管理的 WinuxCmd 安装目录：
+
+```sh
+winuxcmd wpm update winuxcmd
+```
+
+WPM 会先下载并校验新产物，再启动辅助进程，等当前进程退出后替换
+`winuxcmd.exe`。它只更新当前 WinuxCmd 根目录，不会修改单独 Winuxsh
+release 包内自带的 `winuxcmd/` 副本。
+
 ## Winuxsh
 
 如果你想要更接近 bash 的 Windows 终端，可以直接用
@@ -113,6 +123,25 @@ winuxsh = rubash shell engine + reedline frontend + winuxcmd command layer
 
 winuxsh release 包会自带架构匹配的 `winuxcmd/` 目录。它应该和 winget
 安装的 WinuxCmd 分开，这样 x64 和 arm64 shell bundle 才能稳定复现。
+
+### 可选 I18N
+
+通过 WPM 安装可选中文语言包，然后显式启用：
+
+```sh
+winuxcmd wpm install winuxcmd-i18n-zh-cn
+```
+
+Winuxsh 是主要支持的使用方式。把下面一行加入 `~/.winuxshrc`，这样每次
+打开新的 Winuxsh 都会自动启用语言包：
+
+```sh
+export WINUX_LANG=zh-CN
+```
+
+重新加载 profile 或启动新的 shell，然后运行 `winuxcmd ls --help`。使用
+`WINUX_LANG=off` 可以关闭语言包。Winuxsh 的 `export` builtin 会修改当前
+shell 及其子进程；把同一行写入 `~/.winuxshrc`，就是持久化的 Winuxsh 配置。
 
 ## 自带什么
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,16 @@ Packages remain `index-only` until the source provides architecture-specific
 URLs, SHA-256 hashes, and file mappings. That keeps WPM simple and auditable:
 metadata can be listed early, but only verified binary artifacts are installed.
 
+To update the WinuxCmd installation managed by WPM, run:
+
+```sh
+winuxcmd wpm update winuxcmd
+```
+
+WPM stages and verifies the new artifact, then uses a helper process to replace
+the executable after the current process exits. This updates that WinuxCmd
+root; it does not change the copy bundled inside a separate Winuxsh release.
+
 ## Winuxsh
 
 [winuxsh](https://github.com/unixwin/winuxsh) is the recommended entry point if
@@ -119,6 +129,26 @@ winuxsh = rubash shell engine + reedline frontend + winuxcmd command layer
 The winuxsh release bundle carries its own architecture-matched `winuxcmd/`
 directory. Keep that copy separate from a winget-installed WinuxCmd so x64 and
 arm64 shell bundles stay reproducible.
+
+### Optional I18N
+
+Install the optional language package through WPM, then enable it explicitly:
+
+```sh
+winuxcmd wpm install winuxcmd-i18n-zh-cn
+```
+
+Winuxsh is the primary supported setup. Add this line to `~/.winuxshrc` so
+every new Winuxsh session enables the catalog:
+
+```sh
+export WINUX_LANG=zh-CN
+```
+
+Reload the profile or start a new shell, then run `winuxcmd ls --help`.
+`WINUX_LANG=off` disables the catalog. The Winuxsh `export` builtin changes the
+current shell and its children; placing the same command in `~/.winuxshrc` is
+the persistent Winuxsh configuration.
 
 ## What Ships
 

--- a/scripts/build-with-vs.ps1
+++ b/scripts/build-with-vs.ps1
@@ -14,7 +14,7 @@ param(
     [string]$BuildDir = "build-vs",
     [string]$Target = "winuxcmd-tests",
     [string]$Configuration = "Debug",
-    [string]$VsEnvScript = "C:\Program Files\Microsoft Visual Studio\18\Community\VC\Auxiliary\Build\vcvars64.bat",
+    [string]$VsEnvScript,
     [string[]]$VsEnvArgs,
     [string]$Arch = "x64",
     [string]$Generator = "Ninja",
@@ -44,6 +44,22 @@ function Quote-CmdArg {
 $rootPath = Resolve-Root -Value $Root
 $buildPath = Join-Path $rootPath $BuildDir
 $cmdExe = Join-Path $env:SystemRoot "System32\cmd.exe"
+
+if ([string]::IsNullOrWhiteSpace($VsEnvScript)) {
+    $vswhere = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vswhere.exe"
+    if (Test-Path -LiteralPath $vswhere -PathType Leaf) {
+        $VsEnvScript = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -find "VC\Auxiliary\Build\vcvars64.bat" |
+            Select-Object -First 1
+    }
+    if ([string]::IsNullOrWhiteSpace($VsEnvScript)) {
+        $candidates = @(
+            "${env:ProgramFiles}\Microsoft Visual Studio\18\Community\VC\Auxiliary\Build\vcvars64.bat",
+            "${env:ProgramFiles}\Microsoft Visual Studio\17\Community\VC\Auxiliary\Build\vcvars64.bat",
+            "${env:ProgramFiles(x86)}\Microsoft Visual Studio\17\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
+        )
+        $VsEnvScript = $candidates | Where-Object { Test-Path -LiteralPath $_ -PathType Leaf } | Select-Object -First 1
+    }
+}
 
 if (-not (Test-Path -LiteralPath $VsEnvScript -PathType Leaf)) {
     throw "Visual Studio environment script not found: $VsEnvScript"

--- a/scripts/i18n_batch.py
+++ b/scripts/i18n_batch.py
@@ -1,0 +1,333 @@
+#!/usr/bin/env python3
+"""Extract and translate WinuxCmd catalogs through an OpenAI-compatible API."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import json
+import os
+import re
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+import urllib.error
+import urllib.parse
+import urllib.request
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+# The configured OpenAI-compatible gateway exposes this model under the LUNA
+# name.  An environment override is useful for testing another gateway model.
+DEFAULT_MODEL = os.environ.get("OPENAI_I18N_MODEL", "gpt-5.6-luna")
+
+# Hand-maintained help blocks that bypass REGISTER_COMMAND's generic formatter.
+# Keep these stable IDs and review their translations manually.
+MANUAL_MESSAGES = {
+    "command.top.custom_help": (
+        "Usage: top [options]\n"
+        "  -b, --batch        Batch mode\n"
+        "  -d, --delay DELAY  Update interval (default: 3s)\n"
+        "  -n, --iterations N Exit after N iterations\n"
+        "  -o, --field-sort F Sort by CPU|MEM|TIME|PID|NAME\n"
+        "      --rows N       Limit number of displayed processes\n"
+        "      --help         Show help\n"
+        "  -v, --version      Show version\n"
+    ),
+    "command.mpicalc.custom_help": (
+        "+   add           [0] := [1] + [0]          {-1}\n"
+        "-   subtract      [0] := [1] - [0]          {-1}\n"
+        "*   multiply      [0] := [1] * [0]          {-1}\n"
+        "/   divide        [0] := [1] / [0]          {-1}\n"
+        "%   modulo        [0] := [1] % [0]          {-1}\n"
+        "<   left shift    [0] := [0] << 1           {0}\n"
+        ">   right shift   [0] := [0] >> 1           {0}\n"
+        "++  increment     [0] := [0]++              {0}\n"
+        "--  decrement     [0] := [0]--              {0}\n"
+        "m   multiply mod  [0] := [2] * [1] mod [0]  {-2}\n"
+        "^   power mod     [0] := [2] ^ [1] mod [0]  {-2}\n"
+        "G   gcd           [0] := gcd([1],[0])       {-1}\n"
+        "i   remove item   [0] := [1]                {-1}\n"
+        "d   dup item      [-1] := [0]               {+1}\n"
+        "r   reverse       [0] := [1], [1] := [0]    {0}\n"
+        "b   # of bits     [0] := nbits([0])         {0}\n"
+        "P   prime check   [0] := is_prime([0])?1:0  {0}\n"
+        "c   clear stack\n"
+        "p   print top item\n"
+        "f   print the stack\n"
+        "#   ignore until end of line\n"
+        "?   print this help\n"
+    ),
+    "command.tzset.custom_help": (
+        "Usage: tzset [OPTION]\n\n"
+        "Print POSIX-compatible timezone ID from current Windows timezone setting\n\n"
+        "Options:\n"
+        "      --help               output usage information and exit.\n"
+        "  -V, --version            output version information and exit.\n\n"
+        "Use tzset to set your TZ variable. In POSIX-compatible shells like bash,\n"
+        "dash, mksh, or zsh:\n\n"
+        "      export TZ=$(tzset)\n\n"
+        "In csh-compatible shells like tcsh:\n\n"
+        "      setenv TZ `tzset`\n"
+    ),
+    "command.wpm.custom_help": (
+        "Usage: wpm <command> [args] [options]\n\n"
+        "Commands:\n"
+        "  links list|rebuild|remove     manage WinuxCmd hardlinks\n"
+        "  index status|update           inspect or refresh local index\n"
+        "  source list|use|add           manage index sources\n"
+        "  list                          list indexed packages and install state\n"
+        "  search <query>                search names, commands, categories, licenses\n"
+        "  info <package>                show package metadata\n"
+        "  install <package>             install package from local index\n"
+        "  installed                     list packages present in this root\n"
+        "  update winuxcmd               update WinuxCmd from local index\n\n"
+        "Options:\n"
+        "  -r, --root <dir>              manage a specific WinuxCmd root\n"
+        "  -s, --source <name>           use a specific index source\n"
+        "  -a, --all                     show index-only packages in list output\n"
+        "  -f, --force                   overwrite existing files when safe\n"
+        "  -n, --dry-run                 show planned changes without writing\n"
+        "  -v, --verbose                 print detailed progress\n"
+        "      --help                    display this help and exit\n"
+        "  -V, --version                 output version information and exit\n"
+    ),
+}
+
+
+def json_load(path: Path) -> dict:
+    with path.open(encoding="utf-8") as stream:
+        value = json.load(stream)
+    if not isinstance(value, dict) or not isinstance(value.get("messages"), dict):
+        raise ValueError(f"{path}: expected an object with a messages object")
+    return value
+
+
+def string_value(text: str) -> str:
+    parts = re.findall(r'"(?:\\.|[^"\\])*"', text, re.S)
+    if not parts:
+        return ""
+    return "".join(ast.literal_eval(part) for part in parts)
+
+
+def strip_comments(text: str) -> str:
+    return re.sub(r"/\*.*?\*/|//[^\n]*", "", text, flags=re.S)
+
+
+def split_args(text: str) -> list[str]:
+    result, start, depth = [], 0, 0
+    quote = False
+    escape = False
+    for index, char in enumerate(text):
+        if quote:
+            if escape:
+                escape = False
+            elif char == "\\":
+                escape = True
+            elif char == '"':
+                quote = False
+            continue
+        if char == '"':
+            quote = True
+        elif char in "([{":
+            depth += 1
+        elif char in ")]}":
+            depth -= 1
+        elif char == "," and depth == 0:
+            result.append(text[start:index].strip())
+            start = index + 1
+    result.append(text[start:].strip())
+    return result
+
+
+def calls(source: str, name: str) -> list[str]:
+    result = []
+    for match in re.finditer(rf"\b{re.escape(name)}\s*\(", source):
+        start = match.end()
+        depth, quote, escape = 1, False, False
+        for index in range(start, len(source)):
+            char = source[index]
+            if quote:
+                if escape:
+                    escape = False
+                elif char == "\\":
+                    escape = True
+                elif char == '"':
+                    quote = False
+            elif char == '"':
+                quote = True
+            elif char == "(":
+                depth += 1
+            elif char == ")":
+                depth -= 1
+                if depth == 0:
+                    result.append(source[start:index])
+                    break
+    return result
+
+
+def extract(source_root: Path) -> dict:
+    messages: dict[str, str] = {}
+    for path in sorted(source_root.glob("*.cpp")):
+        source = path.read_text(encoding="utf-8", errors="replace")
+        option_arrays: dict[str, list[tuple[str, str, str]]] = {}
+        for match in re.finditer(
+            r"auto\s+constexpr\s+(\w+_OPTIONS)\s*=\s*std::array\s*\{(.*?)\};",
+            source,
+            re.S,
+        ):
+            options = []
+            for body in calls(match.group(2), "OPTION"):
+                args = split_args(body)
+                if len(args) >= 3:
+                    short, long = string_value(args[0]), string_value(args[1])
+                    desc = string_value(args[2])
+                    option = long.removeprefix("--") or short.removeprefix("-")
+                    if option and desc:
+                        options.append((option, desc, short + " " + long))
+            option_arrays[match.group(1)] = options
+
+        for body in calls(source, "REGISTER_COMMAND"):
+            args = split_args(body)
+            if len(args) < 4:
+                continue
+            command = args[0].strip()
+            if not re.fullmatch(r"[A-Za-z0-9_]+", command):
+                continue
+            description = string_value(args[3])
+            messages[f"command.{command}.description"] = description
+            array_name = strip_comments(args[-1]).strip().split()[-1]
+            for option, text, _ in option_arrays.get(array_name, []):
+                messages[f"command.{command}.option.{option}"] = text
+
+    messages["common.option.help"] = "display this help and exit"
+    messages["common.option.version"] = "output version information and exit"
+    messages.update(MANUAL_MESSAGES)
+    return {"schema": 1, "locale": "en-US", "messages": dict(sorted(messages.items()))}
+
+
+def placeholders(text: str) -> list[str]:
+    values = re.findall(r"%[-+#0-9.*]*[a-zA-Z]|\{[^{}]*\}|`[^`]+`|(?<![A-Za-z])(?:FILEs?|PATH|OPTION|NUM|ARGs?)(?![A-Za-z])", text)
+    return sorted({"FILE" if value == "FILEs" else "ARG" if value == "ARGs" else value for value in values})
+
+
+def validate(base: dict, translated: dict) -> list[str]:
+    errors = []
+    base_keys, translated_keys = set(base["messages"]), set(translated["messages"])
+    if base_keys != translated_keys:
+        errors.append(f"key mismatch: missing={sorted(base_keys-translated_keys)} extra={sorted(translated_keys-base_keys)}")
+    for key in sorted(base_keys & translated_keys):
+        if placeholders(str(base["messages"][key])) != placeholders(str(translated["messages"][key])):
+            errors.append(f"placeholder mismatch: {key}")
+        if key.startswith("command.") and ".option." in key:
+            original = str(base["messages"][key])
+            if any(token in str(translated["messages"][key]) for token in ("--", "-")) and re.search(r"(?:^|\s)-{1,2}[A-Za-z]", original):
+                for token in re.findall(r"(?<!\w)-{1,2}[A-Za-z][\w-]*", original):
+                    if token not in str(translated["messages"][key]):
+                        errors.append(f"option token changed: {key}: {token}")
+    return errors
+
+
+def api_url(path: str) -> str:
+    base = os.environ.get("OPENAI_BASE_URL") or os.environ.get("OPENAI_API_BASE")
+    if not base:
+        raise RuntimeError("OPENAI_BASE_URL or OPENAI_API_BASE is required")
+    return base.rstrip("/") + "/" + path.lstrip("/")
+
+
+def request(path: str, method: str = "GET", body: bytes | None = None, content_type: str = "application/json") -> dict:
+    token = os.environ.get("OPENAI_API_KEY")
+    if not token:
+        raise RuntimeError("OPENAI_API_KEY is not set; load it from your Winuxsh profile")
+    req = urllib.request.Request(api_url(path), data=body, method=method, headers={"Authorization": f"Bearer {token}", "Content-Type": content_type})
+    try:
+        with urllib.request.urlopen(req, timeout=120) as response:
+            return json.load(response)
+    except urllib.error.HTTPError as error:
+        detail = error.read().decode("utf-8", errors="replace")
+        raise RuntimeError(f"HTTP {error.code} from {path}: {detail[:1000]}") from error
+
+
+def translate_batch(model: str, locale: str, items: list[tuple[str, str]], retries: int) -> dict[str, str]:
+    prompt = {"locale": locale, "messages": dict(items)}
+    body = {"model": model, "temperature": 0, "response_format": {"type": "json_object"}, "messages": [
+        {"role": "system", "content": "Translate every value to the requested locale. Return only one JSON object mapping the exact input keys to translated strings. Preserve command options, placeholders, backticks, technical tokens, and newlines exactly. Never add or remove keys."},
+        {"role": "user", "content": json.dumps(prompt, ensure_ascii=False)},
+    ]}
+    for attempt in range(retries + 1):
+        try:
+            result = request("chat/completions", "POST", json.dumps(body, ensure_ascii=False).encode())
+            content = result["choices"][0]["message"]["content"]
+            translations = json.loads(content)
+            if not isinstance(translations, dict) or set(translations) != set(dict(items)):
+                raise ValueError("model returned a different key set")
+            if not all(isinstance(value, str) for value in translations.values()):
+                raise ValueError("model returned a non-string translation")
+            for key, original in items:
+                if placeholders(original) != placeholders(translations[key]):
+                    raise ValueError(f"placeholder mismatch: {key}")
+            return translations
+        except (KeyError, TypeError, ValueError, RuntimeError, urllib.error.URLError) as error:
+            if attempt == retries:
+                raise RuntimeError(f"batch failed after {retries + 1} attempts: {error}") from error
+            time.sleep(2 ** attempt)
+    raise AssertionError("unreachable")
+
+
+def cmd_translate(args: argparse.Namespace) -> None:
+    if not args.model:
+        raise RuntimeError("no model configured; pass --model or set OPENAI_I18N_MODEL")
+    base = json_load(Path(args.input))
+    output_path = Path(args.output)
+    checkpoint = output_path.with_suffix(output_path.suffix + ".partial")
+    translated = {}
+    if checkpoint.exists():
+        partial = json_load(checkpoint)
+        translated = partial["messages"]
+    pending = [(key, text) for key, text in sorted(base["messages"].items()) if key not in translated]
+    batches = [pending[i:i + args.batch_size] for i in range(0, len(pending), args.batch_size)]
+    print(f"translating {len(pending)} messages in {len(batches)} batches; concurrency={args.concurrency}")
+    with ThreadPoolExecutor(max_workers=args.concurrency) as pool:
+        futures = {pool.submit(translate_batch, args.model, args.locale, batch, args.retries): batch for batch in batches}
+        for index, future in enumerate(as_completed(futures), 1):
+            batch_result = future.result()
+            translated.update(batch_result)
+            checkpoint.write_text(json.dumps({"schema": 1, "locale": args.locale, "messages": dict(sorted(translated.items()))}, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+            print(f"completed {index}/{len(batches)} batches ({len(translated)} messages)")
+    result = {"schema": 1, "locale": args.locale, "messages": dict(sorted(translated.items()))}
+    errors = validate(base, result)
+    if errors:
+        raise RuntimeError("validation failed:\n" + "\n".join(errors))
+    output_path.write_text(json.dumps(result, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+    checkpoint.unlink(missing_ok=True)
+    print(f"wrote {len(translated)} translations to {output_path}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+    extract_parser = sub.add_parser("extract")
+    extract_parser.add_argument("--source", default=str(ROOT / "src" / "commands"))
+    extract_parser.add_argument("--output", required=True)
+    extract_parser.set_defaults(func=lambda a: Path(a.output).write_text(json.dumps(extract(Path(a.source)), ensure_ascii=False, indent=2) + "\n", encoding="utf-8"))
+    translate = sub.add_parser("translate")
+    translate.add_argument("--input", required=True)
+    translate.add_argument("--output", required=True)
+    translate.add_argument("--locale", required=True)
+    translate.add_argument("--model", default=DEFAULT_MODEL)
+    translate.add_argument("--batch-size", type=int, default=40)
+    translate.add_argument("--concurrency", type=int, default=2)
+    translate.add_argument("--retries", type=int, default=3)
+    translate.set_defaults(func=cmd_translate)
+    validate_parser = sub.add_parser("validate"); validate_parser.add_argument("--base", required=True); validate_parser.add_argument("--translated", required=True); validate_parser.set_defaults(func=lambda a: (print("valid") if not (errors := validate(json_load(Path(a.base)), json_load(Path(a.translated)))) else (_ for _ in ()).throw(RuntimeError("\n".join(errors)))))
+    args = parser.parse_args()
+    try:
+        args.func(args)
+        return 0
+    except (OSError, ValueError, RuntimeError, urllib.error.URLError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/Main/main.cpp
+++ b/src/Main/main.cpp
@@ -31,6 +31,29 @@ import utils;
 import version;
 
 namespace {
+static void applyInheritedStdbuf(const char* name, FILE* stream) {
+  const char* mode = std::getenv(name);
+  if (mode == nullptr || *mode == '\0') return;
+  if (std::strcmp(mode, "0") == 0) {
+    setvbuf(stream, nullptr, _IONBF, 0);
+    return;
+  }
+  if (std::strcmp(mode, "L") == 0) {
+    // MSVC's CRT cannot safely apply line buffering to an inherited stdin
+    // pipe. GNU's stdin line mode is not observable for a child that only
+    // reads input, so accept it without mutating the input stream.
+    if (stream == stdin) return;
+    setvbuf(stream, nullptr, _IOLBF, 0);
+    return;
+  }
+  char* end = nullptr;
+  const auto size = std::strtoull(mode, &end, 10);
+  if (end != mode && *end == '\0' && size > 0 &&
+      size <= std::numeric_limits<size_t>::max()) {
+    setvbuf(stream, nullptr, _IOFBF, static_cast<size_t>(size));
+  }
+}
+
 static std::string toLowerAscii(std::string s) {
   std::ranges::transform(s, s.begin(), [](unsigned char c) {
     return static_cast<char>(std::tolower(c));
@@ -117,6 +140,9 @@ int main(int argc, char *argv[]) noexcept {
   }
   // Automatically set console or pipe output.
   setupConsoleForUnicode();
+  applyInheritedStdbuf("WINUX_STDBUF_I", stdin);
+  applyInheritedStdbuf("WINUX_STDBUF_O", stdout);
+  applyInheritedStdbuf("WINUX_STDBUF_E", stderr);
   // Get the executable name (stem only)
   std::string self_name = path::get_executable_name(argv[0]);
 

--- a/src/commands/cat.cpp
+++ b/src/commands/cat.cpp
@@ -303,23 +303,34 @@ REGISTER_COMMAND(cat, "cat",
       return true;
     }
 
-    auto content = file_io::read_all_file(path);
-    if (!content) {
-      const std::string prefix =
-          "cannot open '" + std::string(path) + "' for reading: ";
+    auto operand = native_path::make_api_path_operand(path);
+    const DWORD operand_attrs = native_path::attributes_w(operand.extended);
+    if (operand.had_trailing_separator &&
+        native_path::attributes_are_regular_file(operand_attrs)) {
+      safeErrorPrint("cat: ");
+      safeErrorPrint(path);
+      safeErrorPrintLn(": Not a directory");
+      return false;
+    }
+    std::ifstream file(std::filesystem::path(operand.extended),
+                       std::ios::binary);
+    if (!file) {
       safeErrorPrint("cat: ");
       safeErrorPrint(path);
       safeErrorPrint(": ");
-      if (content.error().starts_with(prefix)) {
-        safeErrorPrint(std::string_view(content.error()).substr(prefix.size()));
+      const DWORD attrs = native_path::attributes_w(operand.extended);
+      if (operand.had_trailing_separator &&
+          native_path::attributes_are_regular_file(attrs)) {
+        safeErrorPrint("Not a directory");
+      } else if (native_path::attributes_are_directory(attrs)) {
+        safeErrorPrint("Is a directory");
       } else {
-        safeErrorPrint(content.error());
+        safeErrorPrint("No such file or directory");
       }
       safeErrorPrint("\n");
       return false;
     }
 
-    std::istringstream file(*content);
     process_stream(file, ctx, state);
 
     if (file.bad()) {

--- a/src/commands/chmod.cpp
+++ b/src/commands/chmod.cpp
@@ -350,7 +350,7 @@ auto parse_mode(std::string_view mode_str) -> cp::Result<ParsedMode> {
   ParsedMode parsed_mode;
 
   // Check if it's a numeric mode (e.g., "755", "644")
-  if (mode_str.size() == 3 || mode_str.size() == 4) {
+  if (mode_str.size() >= 1 && mode_str.size() <= 4) {
     bool all_digits = true;
     for (char c : mode_str) {
       if (c < '0' || c > '7') {

--- a/src/commands/cp.cpp
+++ b/src/commands/cp.cpp
@@ -201,7 +201,7 @@ auto validate_arguments(const CommandContext<CP_OPTIONS.size()>& ctx)
           "cannot combine --target-directory and --no-target-directory");
     }
 
-    DWORD attr = GetFileAttributesW(utf8_to_wstring(target_dir).c_str());
+    DWORD attr = native_path::attributes_w(utf8_to_wstring(target_dir));
     if (attr == INVALID_FILE_ATTRIBUTES || !(attr & FILE_ATTRIBUTE_DIRECTORY)) {
       return std::unexpected("target is not a directory");
     }
@@ -244,8 +244,7 @@ auto check_destination(
     -> cp::Result<std::tuple<std::vector<std::string>, std::string, bool>> {
   const auto& [sourcePaths, destPath] = paths;
 
-  std::wstring wdestPath = utf8_to_wstring(destPath);
-  DWORD attr = GetFileAttributesW(wdestPath.c_str());
+  DWORD attr = native_path::attributes_w(utf8_to_wstring(destPath));
   bool destIsDir = !no_target_directory && (attr != INVALID_FILE_ATTRIBUTES) &&
                    (attr & FILE_ATTRIBUTE_DIRECTORY);
 
@@ -260,8 +259,8 @@ auto check_destination(
 // 3. Create directory recursively
 // ----------------------------------------------
 auto create_directory_recursive(const std::string& path) -> cp::Result<bool> {
-  std::wstring wpath = utf8_to_wstring(path);
-  if (CreateDirectoryW(wpath.c_str(), NULL) ||
+  auto operand = native_path::make_api_path_operand(path);
+  if (CreateDirectoryW(operand.extended.c_str(), NULL) ||
       GetLastError() == ERROR_ALREADY_EXISTS) {
     return true;
   }
@@ -279,7 +278,7 @@ auto create_directory_recursive(const std::string& path) -> cp::Result<bool> {
   }
 
   // Now create the current directory
-  if (CreateDirectoryW(wpath.c_str(), NULL) == 0) {
+  if (CreateDirectoryW(operand.extended.c_str(), NULL) == 0) {
     return std::unexpected("cannot create directory");
   }
 
@@ -290,17 +289,15 @@ auto create_directory_recursive(const std::string& path) -> cp::Result<bool> {
 // 4. Check if path exists
 // ----------------------------------------------
 auto path_exists(const std::string& path) -> cp::Result<bool> {
-  std::wstring wpath = utf8_to_wstring(path);
-  DWORD attr = GetFileAttributesW(wpath.c_str());
-  return attr != INVALID_FILE_ATTRIBUTES;
+  return native_path::valid_attributes(
+      native_path::attributes_w(utf8_to_wstring(path)));
 }
 
 // ----------------------------------------------
 // 5. Check if path exists and is directory
 // ----------------------------------------------
 auto path_exists_and_is_directory(const std::string& path) -> cp::Result<bool> {
-  std::wstring wpath = utf8_to_wstring(path);
-  DWORD attr = GetFileAttributesW(wpath.c_str());
+  DWORD attr = native_path::attributes_w(utf8_to_wstring(path));
   return (attr != INVALID_FILE_ATTRIBUTES) && (attr & FILE_ATTRIBUTE_DIRECTORY);
 }
 
@@ -322,11 +319,12 @@ auto preserve_metadata_enabled(const CommandContext<CP_OPTIONS.size()>& ctx)
 
 auto preserve_metadata(const std::string& srcPath, const std::string& destPath)
     -> cp::Result<bool> {
-  std::wstring wsrc = utf8_to_wstring(srcPath);
-  std::wstring wdest = utf8_to_wstring(destPath);
+  auto src_operand = native_path::make_api_path_operand(srcPath);
+  auto dest_operand = native_path::make_api_path_operand(destPath);
 
   WIN32_FILE_ATTRIBUTE_DATA src_data{};
-  if (!GetFileAttributesExW(wsrc.c_str(), GetFileExInfoStandard, &src_data)) {
+  if (!GetFileAttributesExW(src_operand.extended.c_str(),
+                            GetFileExInfoStandard, &src_data)) {
     return std::unexpected("cannot read source metadata");
   }
 
@@ -334,7 +332,7 @@ auto preserve_metadata(const std::string& srcPath, const std::string& destPath)
                           ? FILE_FLAG_BACKUP_SEMANTICS
                           : 0;
   HANDLE handle =
-      CreateFileW(wdest.c_str(), FILE_WRITE_ATTRIBUTES,
+      CreateFileW(dest_operand.extended.c_str(), FILE_WRITE_ATTRIBUTES,
                   FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
                   nullptr, OPEN_EXISTING, flags, nullptr);
   if (handle == INVALID_HANDLE_VALUE) {
@@ -349,7 +347,8 @@ auto preserve_metadata(const std::string& srcPath, const std::string& destPath)
     return std::unexpected("cannot preserve timestamps");
   }
 
-  if (!SetFileAttributesW(wdest.c_str(), src_data.dwFileAttributes)) {
+  if (!SetFileAttributesW(dest_operand.extended.c_str(),
+                          src_data.dwFileAttributes)) {
     return std::unexpected("cannot preserve attributes");
   }
   return true;
@@ -383,13 +382,15 @@ auto backup_existing_destination(const std::string& destPath,
     return true;
   }
 
-  std::wstring wdest = utf8_to_wstring(destPath);
-  if (GetFileAttributesW(wdest.c_str()) == INVALID_FILE_ATTRIBUTES) {
+  auto dest_operand = native_path::make_api_path_operand(destPath);
+  if (!native_path::valid_attributes(
+          native_path::attributes_w(dest_operand.extended))) {
     return true;
   }
 
-  std::wstring backup_path = wdest + utf8_to_wstring(backup_suffix(ctx));
-  if (!MoveFileExW(wdest.c_str(), backup_path.c_str(),
+  std::wstring backup_path = dest_operand.extended +
+                             utf8_to_wstring(backup_suffix(ctx));
+  if (!MoveFileExW(dest_operand.extended.c_str(), backup_path.c_str(),
                    MOVEFILE_REPLACE_EXISTING)) {
     return std::unexpected("cannot create backup for destination");
   }
@@ -434,6 +435,24 @@ auto copy_file(const std::string& srcPath, const std::string& destPath,
     return copy_self_with_backup(srcPath, ctx);
   }
 
+  if (ctx.get<bool>("--link", false) || ctx.get<bool>("-l", false)) {
+    std::wstring source = utf8_to_wstring(srcPath);
+    std::wstring dest = utf8_to_wstring(destPath);
+    if (CreateHardLinkW(dest.c_str(), source.c_str(), nullptr)) return true;
+    return std::unexpected("cannot create hard link");
+  }
+
+  if (ctx.get<bool>("--symbolic-link", false) ||
+      ctx.get<bool>("-s", false)) {
+    std::wstring source = utf8_to_wstring(srcPath);
+    std::wstring dest = utf8_to_wstring(destPath);
+    DWORD attrs = FILE_ATTRIBUTE_NORMAL;
+    auto is_dir = path_exists_and_is_directory(srcPath);
+    if (is_dir && *is_dir) attrs |= SYMBOLIC_LINK_FLAG_DIRECTORY;
+    if (CreateSymbolicLinkW(dest.c_str(), source.c_str(), attrs)) return true;
+    return std::unexpected("cannot create symbolic link");
+  }
+
   if (no_clobber && std::filesystem::exists(destPath)) {
     return true;
   }
@@ -441,10 +460,12 @@ auto copy_file(const std::string& srcPath, const std::string& destPath,
   if (update && std::filesystem::exists(destPath)) {
     WIN32_FILE_ATTRIBUTE_DATA src_data{};
     WIN32_FILE_ATTRIBUTE_DATA dest_data{};
-    std::wstring wsrc = utf8_to_wstring(srcPath);
-    std::wstring wdst = utf8_to_wstring(destPath);
-    if (GetFileAttributesExW(wsrc.c_str(), GetFileExInfoStandard, &src_data) &&
-        GetFileAttributesExW(wdst.c_str(), GetFileExInfoStandard, &dest_data)) {
+    auto src_operand = native_path::make_api_path_operand(srcPath);
+    auto dst_operand = native_path::make_api_path_operand(destPath);
+    if (GetFileAttributesExW(src_operand.extended.c_str(),
+                             GetFileExInfoStandard, &src_data) &&
+        GetFileAttributesExW(dst_operand.extended.c_str(),
+                             GetFileExInfoStandard, &dest_data)) {
       if (CompareFileTime(&src_data.ftLastWriteTime,
                           &dest_data.ftLastWriteTime) <= 0) {
         return true;
@@ -469,14 +490,14 @@ auto copy_file(const std::string& srcPath, const std::string& destPath,
 
   // --remove-destination: remove existing dest before opening
   if (remove_dest) {
-    std::wstring wdest = utf8_to_wstring(destPath);
-    DWORD dest_attrs = GetFileAttributesW(wdest.c_str());
+    auto dest_operand = native_path::make_api_path_operand(destPath);
+    DWORD dest_attrs = native_path::attributes_w(dest_operand.extended);
     if (dest_attrs != INVALID_FILE_ATTRIBUTES) {
       if (dest_attrs & FILE_ATTRIBUTE_DIRECTORY) {
-        RemoveDirectoryW(wdest.c_str());
+        RemoveDirectoryW(dest_operand.extended.c_str());
       } else {
-        SetFileAttributesW(wdest.c_str(), FILE_ATTRIBUTE_NORMAL);
-        DeleteFileW(wdest.c_str());
+        SetFileAttributesW(dest_operand.extended.c_str(), FILE_ATTRIBUTE_NORMAL);
+        DeleteFileW(dest_operand.extended.c_str());
       }
     }
   }
@@ -503,23 +524,23 @@ auto copy_file(const std::string& srcPath, const std::string& destPath,
   }
 
   // Check if source file exists and is readable
-  std::ifstream src(srcPath, std::ios::binary);
+  std::ifstream src = file_io::open_binary_file(srcPath);
   if (!src) {
     return std::unexpected("cannot open for reading");
   }
 
   // Open destination file
-  std::ofstream dest(destPath, std::ios::binary);
+  std::ofstream dest = file_io::create_binary_file(destPath);
   if (!dest) {
     bool force = ctx.get<bool>("--force", false) || ctx.get<bool>("-f", false);
     if (!force) {
       return std::unexpected("cannot open for writing");
     }
 
-    std::wstring wdest = utf8_to_wstring(destPath);
-    SetFileAttributesW(wdest.c_str(), FILE_ATTRIBUTE_NORMAL);
-    DeleteFileW(wdest.c_str());
-    dest.open(destPath, std::ios::binary);
+    auto dest_operand = native_path::make_api_path_operand(destPath);
+    SetFileAttributesW(dest_operand.extended.c_str(), FILE_ATTRIBUTE_NORMAL);
+    DeleteFileW(dest_operand.extended.c_str());
+    dest = file_io::create_binary_file(destPath);
     if (!dest) {
       return std::unexpected("cannot open for writing");
     }
@@ -527,7 +548,7 @@ auto copy_file(const std::string& srcPath, const std::string& destPath,
 
   // Copy file content
   dest << src.rdbuf();
-  if (!dest) {
+  if (dest.bad()) {
     return std::unexpected("error writing");
   }
 
@@ -590,8 +611,8 @@ auto copy_directory_helper(const std::string& srcPath,
   }
 
   // Open source directory
-  std::wstring wsrcPath = utf8_to_wstring(srcPath);
-  std::wstring searchPath = wsrcPath + L"\\*";
+  std::wstring searchPath = utf8_to_wstring(srcPath) + L"\\*";
+  searchPath = native_path::make_api_path_operand_w(searchPath).extended;
   WIN32_FIND_DATAW findData;
   HANDLE hFind = FindFirstFileW(searchPath.c_str(), &findData);
   if (hFind == INVALID_HANDLE_VALUE) {
@@ -635,7 +656,7 @@ auto copy_directory_helper(const std::string& srcPath,
       }
 
       // Verify it's actually a directory
-      DWORD attr = GetFileAttributesW(utf8_to_wstring(srcItemPath).c_str());
+      DWORD attr = native_path::attributes_w(utf8_to_wstring(srcItemPath));
       if (attr != INVALID_FILE_ATTRIBUTES &&
           (attr & FILE_ATTRIBUTE_DIRECTORY)) {
         // Recursively copy subdirectory with increased depth
@@ -726,28 +747,14 @@ auto process_source_paths(
         std::wstring wsrcPath = utf8_to_wstring(srcPath);
         LPWSTR fileName = PathFindFileNameW(wsrcPath.c_str());
 
-        // OPTIMIZED: Use stack buffer
-        char fileNameBuf[MAX_PATH * 3];
-        int fileNameLength =
-            WideCharToMultiByte(CP_UTF8, 0, fileName, -1, fileNameBuf,
-                                sizeof(fileNameBuf), NULL, NULL);
-
-        if (fileNameLength > 0 && fileNameLength < sizeof(fileNameBuf)) {
-          finalDestPath += "\\" + std::string(fileNameBuf);
-        } else {
-          // Fallback to dynamic allocation if needed
-          std::string fileNameStr(fileNameLength, 0);
-          WideCharToMultiByte(CP_UTF8, 0, fileName, -1, &fileNameStr[0],
-                              fileNameLength, NULL, NULL);
-          finalDestPath += "\\" + fileNameStr;
-        }
+        finalDestPath += "\\" + wstring_to_utf8(fileName);
       }
     }
 
     if (srcIsDir) {
       if (recursive) {
         auto dirResult = copy_directory(srcPath, finalDestPath, ctx);
-        if (!dirResult) {
+        if (!dirResult || !*dirResult) {
           // OPTIMIZED: Avoid wstring concatenation
           safeErrorPrint("cp: error copying directory '");
           safeErrorPrint(srcPath);

--- a/src/commands/cut.cpp
+++ b/src/commands/cut.cpp
@@ -457,6 +457,11 @@ auto can_use_fast_field_stream(const Config& cfg) -> bool {
 
 auto append_fast_field_record(std::string_view rec, const Config& cfg,
                               std::string& output) -> bool {
+  if (rec.find(cfg.delimiter) == std::string_view::npos) {
+    if (cfg.only_delimited) return false;
+    output.append(rec);
+    return true;
+  }
   bool has_delim = false;
   bool wrote_selected = false;
   int field_index = 1;
@@ -475,12 +480,6 @@ auto append_fast_field_record(std::string_view rec, const Config& cfg,
 
     ++field_index;
     field_start = i + 1;
-  }
-
-  if (!has_delim) {
-    if (cfg.only_delimited) return false;
-    output.append(rec);
-    return true;
   }
 
   return true;

--- a/src/commands/d2u.cpp
+++ b/src/commands/d2u.cpp
@@ -113,22 +113,11 @@ REGISTER_COMMAND(d2u,
   };
 
   if (ctx.positionals.empty()) {
-    // Read from stdin, write to stdout
-    std::string line;
-    bool first = true;
-    while (std::getline(std::cin, line)) {
-      // Remove trailing \r if present
-      if (!line.empty() && line.back() == '\r') {
-        line.pop_back();
-      }
-      if (!first) {
-        safePrint("\n");
-      }
-      safePrint(line);
-      first = false;
-    }
-    if (!first) {
-      safePrint("\n");
+    std::string content((std::istreambuf_iterator<char>(std::cin)), {});
+    for (size_t i = 0; i < content.size(); ++i) {
+      if (content[i] == '\r' && i + 1 < content.size() && content[i + 1] == '\n')
+        continue;
+      safePrint(content.substr(i, 1));
     }
   } else {
     // Process each file in place

--- a/src/commands/date.cpp
+++ b/src/commands/date.cpp
@@ -544,6 +544,28 @@ auto current_time_value(bool use_utc) -> TimeValue {
 }
 
 auto parse_date_argument(const std::string &arg) -> std::optional<FILETIME> {
+  std::string value = trim_copy(arg);
+  std::string lower = lower_copy(value);
+  FILETIME now{};
+  GetSystemTimeAsFileTime(&now);
+  auto relative = [&](long long amount, long long unit) {
+    return add_seconds(now, amount * unit);
+  };
+  std::smatch match;
+  const std::regex relative_re(R"(^([+-])([0-9]+)\s*(second|seconds|minute|minutes|hour|hours|day|days|week|weeks)$)");
+  if (std::regex_match(lower, match, relative_re)) {
+    long long amount = std::stoll(match[2].str());
+    if (match[1].str() == "-") amount = -amount;
+    const auto unit = match[3].str();
+    long long seconds = 1;
+    if (unit.starts_with("minute")) seconds = 60;
+    else if (unit.starts_with("hour")) seconds = 3600;
+    else if (unit.starts_with("day")) seconds = 86400;
+    else if (unit.starts_with("week")) seconds = 604800;
+    return relative(amount, seconds);
+  }
+  if (lower == "tomorrow") return relative(1, 86400);
+  if (lower == "yesterday") return relative(-1, 86400);
   return parse_fixed_date_time(arg);
 }
 

--- a/src/commands/dd.cpp
+++ b/src/commands/dd.cpp
@@ -431,6 +431,7 @@ REGISTER_COMMAND(dd,
   std::vector<char> output_buffer;
   output_buffer.reserve(static_cast<size_t>(cfg.obs));
   CopyStats stats;
+  bool read_failed = false;
 
   while (!cfg.count_set || stats.in_records < cfg.count) {
     DWORD bytes_read = 0;
@@ -439,6 +440,7 @@ REGISTER_COMMAND(dd,
         static_cast<std::uintmax_t>(std::numeric_limits<DWORD>::max())));
     if (!ReadFile(hIn, input_buffer.data(), request, &bytes_read, nullptr)) {
       safeErrorPrintLn("dd: read error");
+      read_failed = true;
       break;
     }
     if (bytes_read == 0) break;
@@ -463,5 +465,5 @@ REGISTER_COMMAND(dd,
 
   report_stats(cfg, stats);
 
-  return flushed ? 0 : 1;
+  return flushed && !read_failed ? 0 : 1;
 }

--- a/src/commands/diff.cpp
+++ b/src/commands/diff.cpp
@@ -258,10 +258,6 @@ auto read_file_lines_result(const std::string &path)
   std::vector<std::string> lines;
   std::string line;
   while (std::getline(file, line)) {
-    // Remove carriage return if present
-    if (!line.empty() && line.back() == '\r') {
-      line.pop_back();
-    }
     lines.push_back(line);
   }
 
@@ -436,6 +432,18 @@ auto output_unified_diff(const std::string &path1, const std::string &path2,
         file2_start = std::min(file2_start, edit.line2_index);
         file2_end = std::max(file2_end, edit.line2_index + 1);
       }
+    }
+
+    // A pure insertion or deletion has no changed line on the other side.
+    // Use the edit's anchor position so the zero-length range does not
+    // underflow when its unified header is formatted.
+    if (file1_start == lines1.size()) {
+      file1_start = edits[hunk_start].line1_index;
+      file1_end = file1_start;
+    }
+    if (file2_start == lines2.size()) {
+      file2_start = edits[hunk_start].line2_index;
+      file2_end = file2_start;
     }
 
     // Add context lines

--- a/src/commands/dirname.cpp
+++ b/src/commands/dirname.cpp
@@ -116,6 +116,10 @@ auto get_dirname(std::string_view path) -> std::string {
     return ".";
   }
 
+  if (result.size() == root_len && root_len != 0) {
+    return result.substr(0, root_len);
+  }
+
   if (last_sep <= root_len) {
     return result.substr(0, root_len == 0 ? last_sep + 1 : root_len);
   }

--- a/src/commands/dos2unix.cpp
+++ b/src/commands/dos2unix.cpp
@@ -112,23 +112,14 @@ REGISTER_COMMAND(dos2unix,
   };
 
   if (ctx.positionals.empty()) {
-    // Read from stdin, write to stdout
-    std::string line;
-    bool first = true;
-    while (std::getline(std::cin, line)) {
-      // Remove trailing \r if present
-      if (!line.empty() && line.back() == '\r') {
-        line.pop_back();
-      }
-      if (!first) {
-        safePrint("\n");
-      }
-      safePrint(line);
-      first = false;
+    // Preserve stdin byte-for-byte except for CRLF pairs. getline() would
+    // manufacture a final newline for input that does not have one.
+    std::string content((std::istreambuf_iterator<char>(std::cin)), {});
+    size_t pos = 0;
+    while ((pos = content.find("\r\n", pos)) != std::string::npos) {
+      content.erase(pos, 1);
     }
-    if (!first) {
-      safePrint("\n");
-    }
+    safePrint(content);
   } else {
     // Process each file in place
     bool all_ok = true;

--- a/src/commands/grep.cpp
+++ b/src/commands/grep.cpp
@@ -922,8 +922,7 @@ auto load_patterns_from_file(const std::string& path)
   if (path == "-") {
     buf = read_text_stream(std::cin);
   } else {
-    std::ifstream in(std::filesystem::path(utf8_to_wstring(path)),
-                     std::ios::binary);
+    auto in = file_io::open_binary_file(path);
     if (!in.is_open()) {
       return std::unexpected("cannot open pattern file '" + path + "'");
     }

--- a/src/commands/head.cpp
+++ b/src/commands/head.cpp
@@ -86,6 +86,7 @@ namespace cp = core::pipeline;
 struct CountSpec {
   std::uintmax_t value = 10;
   bool all_but_last = false;
+  bool plus_form = false;
 };
 
 struct HeadConfig {
@@ -185,6 +186,12 @@ auto parse_count_spec(std::string spec_text, std::string_view opt_name)
   if (spec_text[0] == '-') {
     spec.all_but_last = true;
     spec_text = spec_text.substr(1);  // Avoid modifying original string
+    if (spec_text.empty()) {
+      return std::unexpected("invalid number of " + std::string(opt_name));
+    }
+  } else if (spec_text[0] == '+') {
+    spec.plus_form = true;
+    spec_text = spec_text.substr(1);
     if (spec_text.empty()) {
       return std::unexpected("invalid number of " + std::string(opt_name));
     }
@@ -354,6 +361,23 @@ auto output_first_records(std::istream& in, size_t records, char delimiter)
 }
 
 auto output_head(std::istream& in, const HeadConfig& config) -> void {
+  if (config.spec.plus_form) {
+    const size_t skip = config.spec.value > 0
+                            ? static_cast<size_t>(config.spec.value - 1)
+                            : 0;
+    if (config.by_bytes) {
+      in.ignore(static_cast<std::streamsize>(skip));
+    } else {
+      size_t remaining = skip;
+      char ch = '\0';
+      while (remaining > 0 && in.get(ch)) {
+        if (ch == config.delimiter) --remaining;
+      }
+    }
+    stream_all(in);
+    return;
+  }
+
   if (config.by_bytes) {
     size_t n = static_cast<size_t>(config.spec.value);
     if (config.spec.all_but_last) {
@@ -430,13 +454,12 @@ auto output_head(std::istream& in, const HeadConfig& config) -> void {
 }
 
 auto open_input_file(const std::string& file) -> std::ifstream {
-  return std::ifstream(std::filesystem::path(utf8_to_wstring(file)),
-                       std::ios::binary);
+  return file_io::open_binary_file(file);
 }
 
 auto describe_open_failure(const std::string& file) -> std::string {
   std::wstring wfile = utf8_to_wstring(file);
-  DWORD attrs = GetFileAttributesW(wfile.c_str());
+  DWORD attrs = native_path::attributes_w(utf8_to_wstring(file));
   if (attrs == INVALID_FILE_ATTRIBUTES) {
     return "No such file or directory";
   }

--- a/src/commands/id.cpp
+++ b/src/commands/id.cpp
@@ -63,6 +63,7 @@ using AccountInfo = Win32AccountInfo;
 
 struct ProcessIdentity {
   AccountInfo user;
+  AccountInfo primary_group;
   SmallVector<AccountInfo, 16> groups;
 };
 
@@ -91,6 +92,16 @@ auto current_identity() -> std::optional<ProcessIdentity> {
   identity.user = win32_account_from_sid(token_user->User.Sid);
   if (identity.user.name.empty()) {
     identity.user.name = win32_current_username();
+  }
+
+  auto primary_group_data = win32_token_information(token.get(), TokenPrimaryGroup);
+  if (!primary_group_data.empty()) {
+    auto* primary_group =
+        reinterpret_cast<TOKEN_PRIMARY_GROUP*>(primary_group_data.data());
+    identity.primary_group = win32_account_from_sid(primary_group->PrimaryGroup);
+  }
+  if (identity.primary_group.id.empty()) {
+    identity.primary_group = identity.user;
   }
 
   identity.groups.push_back(identity.user);
@@ -220,7 +231,7 @@ auto run(const Config& cfg) -> int {
   }
 
   if (cfg.print_group) {
-    safePrint(format_account(identity->user, cfg.print_name) + term);
+    safePrint(format_account(identity->primary_group, cfg.print_name) + term);
     return 0;
   }
 
@@ -230,7 +241,8 @@ auto run(const Config& cfg) -> int {
   }
 
   std::string out = "uid=" + format_full_account(identity->user) +
-                    " gid=" + format_full_account(identity->user) + " groups=";
+                    " gid=" + format_full_account(identity->primary_group) +
+                    " groups=";
   for (size_t i = 0; i < identity->groups.size(); ++i) {
     if (i > 0) out += ",";
     out += format_full_account(identity->groups[i]);

--- a/src/commands/join.cpp
+++ b/src/commands/join.cpp
@@ -405,7 +405,7 @@ auto read_lines(const std::string& filename, char delimiter)
       lines.emplace_back(trim_text_record(content.substr(start), delimiter));
     }
   } else {
-    std::ifstream f(filename, std::ios::binary);
+    auto f = file_io::open_binary_file(filename);
     if (!f) {
       return std::unexpected(join_input_open_error(filename));
     }

--- a/src/commands/killall.cpp
+++ b/src/commands/killall.cpp
@@ -48,7 +48,7 @@ auto constexpr KILLALL_OPTIONS = std::array{
 namespace killall_pipeline {
 
 struct Config {
-  bool exact = false;
+  bool exact = true;
   bool ignore_case = false;
   bool quiet = false;
   bool verbose = false;

--- a/src/commands/locale.cpp
+++ b/src/commands/locale.cpp
@@ -154,6 +154,43 @@ REGISTER_COMMAND(locale,
     return 0;
   }
 
+  if (!ctx.positionals.empty()) {
+    const auto keyword = std::string(ctx.positionals.front());
+    const auto value = get_system_locale();
+    if (keyword == "charmap") { safePrintLn("UTF-8"); return 0; }
+    if (keyword == "default_language") {
+      safePrintLn(value.substr(0, value.find_first_of("_-"))); return 0;
+    }
+    if (keyword == "decimal_point") { safePrintLn("."); return 0; }
+    if (keyword == "thousands_sep") { safePrintLn(""); return 0; }
+    if (keyword == "codeset") { safePrintLn("UTF-8"); return 0; }
+    if (keyword == "yesexpr") { safePrintLn("^[yY]"); return 0; }
+    if (keyword == "noexpr") { safePrintLn("^[nN]"); return 0; }
+    if (keyword == "yesstr") { safePrintLn("yes"); return 0; }
+    if (keyword == "nostr") { safePrintLn("no"); return 0; }
+    if (keyword == "era") { safePrintLn(""); return 0; }
+    if (keyword == "day") { safePrintLn("Sunday;Monday;Tuesday;Wednesday;Thursday;Friday;Saturday"); return 0; }
+    if (keyword == "abday") { safePrintLn("Sun;Mon;Tue;Wed;Thu;Fri;Sat"); return 0; }
+    if (keyword == "month") { safePrintLn("January;February;March;April;May;June;July;August;September;October;November;December"); return 0; }
+    if (keyword == "abmon") { safePrintLn("Jan;Feb;Mar;Apr;May;Jun;Jul;Aug;Sep;Oct;Nov;Dec"); return 0; }
+    if (keyword == "int_curr_symbol") { safePrintLn("USD "); return 0; }
+    if (keyword == "currency_symbol") { safePrintLn("$"); return 0; }
+    if (keyword == "mon_decimal_point") { safePrintLn("."); return 0; }
+    if (keyword == "mon_thousands_sep") { safePrintLn(","); return 0; }
+    if (keyword == "positive_sign" || keyword == "negative_sign") {
+      safePrintLn("");
+      return 0;
+    }
+    if (keyword == "frac_digits" || keyword == "int_frac_digits" ||
+        keyword == "p_cs_precedes" || keyword == "p_sep_by_space" ||
+        keyword == "n_cs_precedes" || keyword == "n_sep_by_space") {
+      safePrintLn("1");
+      return 0;
+    }
+    safeErrorPrintLn("locale: unknown keyword '" + keyword + "'");
+    return 1;
+  }
+
   // Print current locale settings
   print_locale_categories();
 

--- a/src/commands/ls.cpp
+++ b/src/commands/ls.cpp
@@ -433,11 +433,12 @@ auto normalize_lookup_path(const std::wstring &path) -> std::wstring {
 auto probe_path(const std::wstring &path) -> PathProbe {
   PathProbe probe{};
   const std::wstring lookup_path = normalize_lookup_path(path);
+  const auto operand = native_path::make_api_path_operand_w(lookup_path);
 
-  probe.attributes = GetFileAttributesW(lookup_path.c_str());
+  probe.attributes = native_path::attributes_w(operand.extended);
   probe.attributes_valid = probe.attributes != INVALID_FILE_ATTRIBUTES;
 
-  HANDLE hfind = FindFirstFileW(lookup_path.c_str(), &probe.find_data);
+  HANDLE hfind = FindFirstFileW(operand.extended.c_str(), &probe.find_data);
   if (hfind != INVALID_HANDLE_VALUE) {
     probe.found = true;
     FindClose(hfind);
@@ -1850,8 +1851,10 @@ auto try_get_dereferenced_find_data(
     return std::nullopt;
   }
 
+  auto target_operand = native_path::make_api_path_operand_w(target.wstring());
   WIN32_FILE_ATTRIBUTE_DATA attrs{};
-  if (!GetFileAttributesExW(target.c_str(), GetFileExInfoStandard, &attrs)) {
+  if (!GetFileAttributesExW(target_operand.extended.c_str(),
+                            GetFileExInfoStandard, &attrs)) {
     return std::nullopt;
   }
 
@@ -2044,8 +2047,9 @@ auto format_scaled_size(uint64_t size, SizeMode mode, uint64_t block_size)
 auto query_directory_standard_size_bytes(const std::wstring &path,
                                          bool allocation_size)
     -> std::optional<uint64_t> {
+  auto operand = native_path::make_api_path_operand_w(path);
   HANDLE handle =
-      CreateFileW(path.c_str(), FILE_READ_ATTRIBUTES,
+      CreateFileW(operand.extended.c_str(), FILE_READ_ATTRIBUTES,
                   FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
                   nullptr, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, nullptr);
   if (handle == INVALID_HANDLE_VALUE) {
@@ -2125,7 +2129,8 @@ auto get_file_index_string(const std::wstring &path,
   }
 
   HANDLE handle =
-      CreateFileW(path.c_str(), FILE_READ_ATTRIBUTES,
+      CreateFileW(native_path::make_api_path_operand_w(path).extended.c_str(),
+                  FILE_READ_ATTRIBUTES,
                   FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
                   nullptr, OPEN_EXISTING, flags, nullptr);
   if (handle == INVALID_HANDLE_VALUE) {
@@ -2139,7 +2144,6 @@ auto get_file_index_string(const std::wstring &path,
                            static_cast<ULONGLONG>(info.nFileIndexLow);
     result = std::to_string(file_index);
   }
-  CloseHandle(handle);
   return result;
 }
 
@@ -2159,7 +2163,8 @@ auto get_link_count(const std::wstring &path, const WIN32_FIND_DATAW &find_data,
   }
 
   HANDLE handle =
-      CreateFileW(path.c_str(), FILE_READ_ATTRIBUTES,
+      CreateFileW(native_path::make_api_path_operand_w(path).extended.c_str(),
+                  FILE_READ_ATTRIBUTES,
                   FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
                   nullptr, OPEN_EXISTING, flags, nullptr);
   if (handle == INVALID_HANDLE_VALUE) {
@@ -2328,54 +2333,16 @@ auto get_modification_time_string(const WIN32_FIND_DATAW &find_data,
  * @param use_numeric Whether to return numeric UID/GID (-n option)
  * @return Pair of (owner, group) strings
  */
-auto get_file_owner_and_group(bool use_numeric = false)
+auto get_file_owner_and_group(std::wstring_view path, bool use_numeric = false)
     -> std::pair<std::string, std::string> {
+  auto operand = native_path::make_api_path_operand_w(path);
+  auto accounts = win32_file_accounts(operand.extended);
   if (use_numeric) {
-    // Get Windows SID (simulate UID/GID)
-    HANDLE hToken;
-    if (OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &hToken)) {
-      DWORD bufferSize = 0;
-      GetTokenInformation(hToken, TokenUser, nullptr, 0, &bufferSize);
-      std::vector<BYTE> buffer(bufferSize);
-      PTOKEN_USER pTokenUser = reinterpret_cast<PTOKEN_USER>(buffer.data());
-      if (GetTokenInformation(hToken, TokenUser, pTokenUser, bufferSize,
-                              &bufferSize)) {
-        LPWSTR sidStr = nullptr;
-        if (ConvertSidToStringSidW(pTokenUser->User.Sid, &sidStr)) {
-          // Extract numeric part from SID (simulate UID 197121)
-          std::wstring sid(sidStr,
-                           wcslen(sidStr));  // Construct from known length
-          LocalFree(sidStr);
-
-          size_t lastDash = sid.find_last_of(L'-');
-          std::wstring uid_wstr = (lastDash != std::wstring::npos)
-                                      ? sid.substr(lastDash + 1)
-                                      : L"197121";
-
-          // Convert wide string to UTF-8
-          std::string uid = wstring_to_utf8(uid_wstr);
-          CloseHandle(hToken);
-          return {uid, uid};  // UID = GID (Windows default)
-        }
-      }
-      CloseHandle(hToken);
-    }
-    return {"197121", "197121"};  // Fallback
+    return {accounts.owner.id.empty() ? "0" : accounts.owner.id,
+            accounts.group.id.empty() ? "0" : accounts.group.id};
   }
-
-  // Return username using ANSI version for efficiency
-  char username[UNLEN + 1];
-  DWORD username_len = UNLEN + 1;
-  if (!GetUserNameA(username, &username_len)) {
-    return {"user", "group"};
-  }
-
-  std::string username_str = username;
-  size_t pos = username_str.find('\\');
-  if (pos != std::string::npos) {
-    username_str = username_str.substr(pos + 1);
-  }
-  return {username_str, username_str};
+  return {accounts.owner.name.empty() ? "UNKNOWN" : accounts.owner.name,
+          accounts.group.name.empty() ? "UNKNOWN" : accounts.group.name};
 }
 
 /**
@@ -2590,6 +2557,8 @@ auto list_directory(const std::string &path,
     -> cp::Result<bool> {
   std::wstring wpath = utf8_to_wstring(path);
   const std::wstring lookup_wpath = normalize_lookup_path(wpath);
+  const auto lookup_operand =
+      native_path::make_api_path_operand_w(lookup_wpath);
 
   // Check -d option: list directories themselves, not their contents
   bool list_dir_only =
@@ -2598,7 +2567,7 @@ auto list_directory(const std::string &path,
   if (list_dir_only) {
     // Get directory attributes
     WIN32_FIND_DATAW dir_data;
-    HANDLE hFind = FindFirstFileW(lookup_wpath.c_str(), &dir_data);
+    HANDLE hFind = FindFirstFileW(lookup_operand.extended.c_str(), &dir_data);
 
     if (hFind == INVALID_HANDLE_VALUE) {
       return std::unexpected("cannot access '" + path +
@@ -2612,6 +2581,7 @@ auto list_directory(const std::string &path,
 
   // Normal directory listing
   std::wstring search_path = lookup_wpath + L"\\*";
+  search_path = native_path::make_api_path_operand_w(search_path).extended;
   const std::wstring ignore_pattern = get_ignore_pattern(ctx);
   const std::wstring hide_pattern = get_hide_pattern(ctx);
 
@@ -2775,7 +2745,8 @@ auto list_directory(const std::string &path,
           get_time_string(display_find_data, time_mode, *time_style_selection);
 
       // Get owner and group
-      auto [owner, group] = get_file_owner_and_group(use_numeric);
+      auto [owner, group] =
+          get_file_owner_and_group(entry.full_path, use_numeric);
       info.owner = owner;
       info.author = owner;
       info.group = group;
@@ -2960,11 +2931,13 @@ auto list_file(const std::string &path,
   const std::wstring lookup_wpath = normalize_lookup_path(wpath);
   const std::wstring metadata_probe_wpath =
       normalize_metadata_probe_path(lookup_wpath);
+  const auto metadata_operand =
+      native_path::make_api_path_operand_w(metadata_probe_wpath);
   const std::wstring operand_display_name = wpath;
 
   // Extract just the filename for display
   WIN32_FIND_DATAW find_data;
-  HANDLE hFind = FindFirstFileW(metadata_probe_wpath.c_str(), &find_data);
+  HANDLE hFind = FindFirstFileW(metadata_operand.extended.c_str(), &find_data);
 
   if (hFind == INVALID_HANDLE_VALUE) {
     return std::unexpected("cannot access '" + path +
@@ -3032,7 +3005,7 @@ auto list_file(const std::string &path,
                                      ctx, size_cfg, true);
     auto mtime =
         get_time_string(display_find_data, time_mode, *time_style_selection);
-    auto [owner, group] = get_file_owner_and_group(use_numeric);
+    auto [owner, group] = get_file_owner_and_group(lookup_wpath, use_numeric);
 
     if (!inode.empty()) {
       safePrint(std::string_view(inode));
@@ -3122,6 +3095,7 @@ auto list_directory_recursive(const std::string &path,
   // Collect subdirectories for recursion
   std::wstring wpath = utf8_to_wstring(path);
   std::wstring search_path = wpath + L"\\*";
+  search_path = native_path::make_api_path_operand_w(search_path).extended;
 
   WIN32_FIND_DATAW find_data;
   HANDLE hFind = FindFirstFileW(search_path.c_str(), &find_data);
@@ -3261,6 +3235,22 @@ auto process_paths(const std::vector<std::string> &paths,
   bool success = expanded.success;
   bool printed_any = false;
   const bool multiple_operands = expanded.logical_operand_count > 1;
+
+  bool all_file_operands = !expanded_paths.empty();
+  for (const auto &path : expanded_paths) {
+    auto probe = probe_path(utf8_to_wstring(path));
+    if (!probe.attributes_valid ||
+        (probe.attributes & FILE_ATTRIBUTE_DIRECTORY) != 0) {
+      all_file_operands = false;
+      break;
+    }
+  }
+  if (all_file_operands) {
+    std::sort(expanded_paths.begin(), expanded_paths.end());
+    if (ctx.get<bool>("-r", false) || ctx.get<bool>("--reverse", false)) {
+      std::reverse(expanded_paths.begin(), expanded_paths.end());
+    }
+  }
 
   for (const auto &path : expanded_paths) {
     // Check if path exists and determine its type

--- a/src/commands/mpicalc.cpp
+++ b/src/commands/mpicalc.cpp
@@ -401,7 +401,7 @@ auto prime_check(const BigInt& value) -> BigInt {
 }
 
 auto print_help_text() -> void {
-  safePrint(R"MPICALC(+   add           [0] := [1] + [0]          {-1}
+  constexpr std::string_view help = R"MPICALC(+   add           [0] := [1] + [0]          {-1}
 -   subtract      [0] := [1] - [0]          {-1}
 *   multiply      [0] := [1] * [0]          {-1}
 /   divide        [0] := [1] / [0]          {-1}
@@ -423,7 +423,8 @@ p   print top item
 f   print the stack
 #   ignore until end of line
 ?   print this help
-)MPICALC");
+)MPICALC";
+  safePrint(winux::i18n::translate("command.mpicalc.custom_help", help));
 }
 auto process_token(const std::string& token, std::vector<BigInt>& stack)
     -> void {

--- a/src/commands/mv.cpp
+++ b/src/commands/mv.cpp
@@ -385,6 +385,12 @@ auto move_single_path(const std::string& src_path, const std::string& dest_path,
   auto backup_result = backup_existing_destination(wdest_path, ctx);
   if (!backup_result) return backup_result;
 
+  if (dest_exists) {
+    DWORD attrs = GetFileAttributesW(wdest_path.c_str());
+    if (attrs != INVALID_FILE_ATTRIBUTES && (attrs & FILE_ATTRIBUTE_READONLY))
+      SetFileAttributesW(wdest_path.c_str(), attrs & ~FILE_ATTRIBUTE_READONLY);
+  }
+
   // Try to rename first
   if (!MoveFileExW(wsrc_path.c_str(), wdest_path.c_str(),
                    MOVEFILE_REPLACE_EXISTING)) {

--- a/src/commands/numfmt.cpp
+++ b/src/commands/numfmt.cpp
@@ -51,6 +51,9 @@ auto constexpr NUMFMT_OPTIONS = std::array{
     OPTION("", "--to", "autoconvert to X", STRING_TYPE),
     OPTION("", "--round", "use METHOD for rounding", STRING_TYPE),
     OPTION("", "--padding", "pad numbers to width N", INT_TYPE),
+    OPTION("", "--pad", "pad numbers to width N", INT_TYPE),
+    OPTION("", "--suffix", "add STRING after formatted numbers", STRING_TYPE),
+    OPTION("", "--field", "replace numbers in field N", INT_TYPE),
     OPTION("-f", "--format", "use printf style floating-point FORMAT",
            STRING_TYPE),
     OPTION("", "--header", "print the first N header lines unchanged",
@@ -86,7 +89,7 @@ double apply_rounding(double value, const std::string& mode) {
 
 // Parse number with SI suffixes (K, M, G, T, P)
 bool parse_number(const std::string& s, long long& result,
-                  const std::string& round_mode = "") {
+                  const std::string& round_mode = "", std::string from = "") {
   std::string num_str;
   char suffix = 0;
 
@@ -104,21 +107,23 @@ bool parse_number(const std::string& s, long long& result,
     double num = std::stod(num_str);
 
     // Apply suffix multiplier
+    const bool si = from == "si" || from == "auto";
+    const double base = si ? 1000.0 : 1024.0;
     switch (suffix) {
       case 'K':
-        num *= 1024;
+        num *= base;
         break;
       case 'M':
-        num *= 1024 * 1024;
+        num *= base * base;
         break;
       case 'G':
-        num *= 1024 * 1024 * 1024;
+        num *= base * base * base;
         break;
       case 'T':
-        num *= 1024LL * 1024 * 1024 * 1024;
+        num *= std::pow(base, 4);
         break;
       case 'P':
-        num *= 1024LL * 1024 * 1024 * 1024 * 1024;
+        num *= std::pow(base, 5);
         break;
       case 0:
         break;
@@ -128,6 +133,37 @@ bool parse_number(const std::string& s, long long& result,
 
     // Apply rounding mode when converting from human-readable
     result = static_cast<long long>(apply_rounding(num, round_mode));
+    return true;
+  } catch (...) {
+    return false;
+  }
+}
+
+bool parse_number_value(const std::string& s, double& result,
+                        std::string from = "") {
+  std::string num_str;
+  char suffix = 0;
+  for (size_t i = 0; i < s.size(); ++i) {
+    if (std::isdigit(static_cast<unsigned char>(s[i])) || s[i] == '.' ||
+        ((s[i] == '-' || s[i] == '+') && num_str.empty())) {
+      num_str += s[i];
+    } else {
+      suffix = static_cast<char>(std::toupper(static_cast<unsigned char>(s[i])));
+      break;
+    }
+  }
+  try {
+    result = std::stod(num_str);
+    const double base = (from == "si" || from == "auto") ? 1000.0 : 1024.0;
+    switch (suffix) {
+      case 'K': result *= base; break;
+      case 'M': result *= std::pow(base, 2); break;
+      case 'G': result *= std::pow(base, 3); break;
+      case 'T': result *= std::pow(base, 4); break;
+      case 'P': result *= std::pow(base, 5); break;
+      case 0: break;
+      default: return false;
+    }
     return true;
   } catch (...) {
     return false;
@@ -160,6 +196,34 @@ std::string format_number(long long num, const std::string& unit = "") {
 
   return result;
 }
+
+std::string format_iec_i(long long num) {
+  static constexpr const char* suffixes[] = {"", "Ki", "Mi", "Gi", "Ti", "Pi"};
+  double value = static_cast<double>(num);
+  size_t index = 0;
+  while (value >= 1024.0 && index < 5) { value /= 1024.0; ++index; }
+  char buffer[64];
+  if (index == 0) sprintf_s(buffer, sizeof(buffer), "%lld", num);
+  else sprintf_s(buffer, sizeof(buffer), "%.1f", value);
+  return std::string(buffer) + suffixes[index];
+}
+
+std::string format_scaled(long long num, double base, std::string_view suffixes) {
+  double value = static_cast<double>(num);
+  size_t index = 0;
+  while (std::abs(value) >= base && index < suffixes.size()) {
+    value /= base;
+    ++index;
+  }
+  char buffer[64];
+  if (index == 0) {
+    sprintf_s(buffer, sizeof(buffer), "%lld", num);
+  } else {
+    sprintf_s(buffer, sizeof(buffer), "%.1f", value);
+  }
+  return std::string(buffer) +
+         (index == 0 ? "" : std::string(1, suffixes[index - 1]));
+}
 }  // namespace
 
 // ======================================================
@@ -185,6 +249,7 @@ REGISTER_COMMAND(
   std::string to_unit = ctx.get<std::string>("--to", "");
   bool to_si = to_unit == "si";
   bool to_iec = to_unit == "iec";
+  bool to_iec_i = to_unit == "iec-i";
   std::string from_unit = ctx.get<std::string>("--from", "");
   std::string format_str = ctx.get<std::string>("--format", "");
   if (format_str.empty()) {
@@ -199,7 +264,9 @@ REGISTER_COMMAND(
   bool grouping = ctx.get<bool>("--grouping", false);
   std::string invalid_policy = ctx.get<std::string>("--invalid", "abort");
   std::string round_mode = ctx.get<std::string>("--round", "");
-  int padding = ctx.get<int>("--padding", 0);
+  int padding = ctx.get<int>("--padding", ctx.get<int>("--pad", 0));
+  std::string suffix = ctx.get<std::string>("--suffix", "");
+  int selected_field = ctx.get<int>("--field", 0);
 
   auto add_grouping = [](const std::string& s) -> std::string {
     // Add thousands separator commas
@@ -220,7 +287,7 @@ REGISTER_COMMAND(
     if (!format_str.empty()) {
       // Simple printf-style format support
       char buf[256];
-      snprintf(buf, sizeof(buf), format_str.c_str(), num);
+      snprintf(buf, sizeof(buf), format_str.c_str(), static_cast<double>(num));
       result = buf;
     } else {
       result = std::to_string(num);
@@ -237,7 +304,7 @@ REGISTER_COMMAND(
   bool had_invalid = false;
   auto process_number = [&](const std::string& s) -> std::string {
     long long num;
-    if (!parse_number(s, num, round_mode)) {
+    if (!parse_number(s, num, round_mode, from_unit)) {
       if (invalid_policy == "warn") {
         safeErrorPrint("numfmt: invalid number: '" + s + "'\n");
       } else if (invalid_policy == "abort") {
@@ -258,10 +325,26 @@ REGISTER_COMMAND(
       }
     }
 
-    if (to_si || to_iec) {
-      return format_number(num);
+    if (to_si || to_iec || to_iec_i) {
+      std::string formatted;
+      if (to_iec_i) {
+        formatted = format_iec_i(num);
+      } else if (to_si) {
+        formatted = format_scaled(num, 1000.0, "kMGTPE");
+      } else {
+        formatted = format_number(num);
+      }
+      return formatted + suffix;
     }
-    return apply_format(num);
+    if (!format_str.empty()) {
+      double value = 0.0;
+      if (parse_number_value(s, value, from_unit)) {
+        char buf[256];
+        snprintf(buf, sizeof(buf), format_str.c_str(), value);
+        return std::string(buf) + suffix;
+      }
+    }
+    return apply_format(num) + suffix;
   };
 
   int line_num = 0;
@@ -274,12 +357,18 @@ REGISTER_COMMAND(
     if (!delimiter.empty()) {
       // Split by delimiter, process each field
       std::istringstream ss(line);
-      std::string field;
+      std::string field_text;
+      int field_number = 1;
       bool first = true;
-      while (std::getline(ss, field, delimiter[0])) {
+      while (std::getline(ss, field_text, delimiter[0])) {
         if (!first) safePrint(delimiter);
-        safePrint(process_number(field));
+        if (selected_field == 0 || selected_field == field_number) {
+          safePrint(process_number(field_text));
+        } else {
+          safePrint(field_text);
+        }
         first = false;
+        ++field_number;
       }
       safePrint("\n");
     } else {

--- a/src/commands/patch.cpp
+++ b/src/commands/patch.cpp
@@ -304,7 +304,7 @@ REGISTER_COMMAND(
       // Old file
       size_t space = line.find(' ');
       if (space != std::string::npos && space < line.length()) {
-        size_t next_space = line.find(' ', space + 1);
+        size_t next_space = line.find_first_of(" \t", space + 1);
         if (next_space != std::string::npos) {
           std::string file = line.substr(space + 1, next_space - space - 1);
           target_file = strip_path(file, strip_components);
@@ -318,7 +318,7 @@ REGISTER_COMMAND(
       // New file
       size_t space = line.find(' ');
       if (space != std::string::npos && space < line.length()) {
-        size_t next_space = line.find(' ', space + 1);
+        size_t next_space = line.find_first_of(" \t", space + 1);
         if (next_space != std::string::npos) {
           std::string file = line.substr(space + 1, next_space - space - 1);
           if (target_file.empty()) {
@@ -332,22 +332,31 @@ REGISTER_COMMAND(
           }
         }
       }
-    } else if (parse_hunk(line, current_hunk)) {
-      in_hunk = true;
-    } else if (in_hunk) {
-      if (line.empty() || line[0] == ' ' || line[0] == '+' || line[0] == '-') {
-        if (line[0] == ' ' || line[0] == '-') {
-          current_hunk.old_lines.push_back(line.substr(1));
+    } else {
+      Hunk parsed_hunk;
+      if (!parse_hunk(line, parsed_hunk)) {
+        if (in_hunk) {
+          if (line.empty() || line[0] == ' ' || line[0] == '+' ||
+              line[0] == '-') {
+            if (line[0] == ' ' || line[0] == '-') {
+              current_hunk.old_lines.push_back(line.substr(1));
+            }
+            if (line[0] == ' ' || line[0] == '+') {
+              current_hunk.new_lines.push_back(line.substr(1));
+            }
+          } else {
+            hunks.push_back(current_hunk);
+            current_hunk = Hunk();
+            in_hunk = false;
+          }
         }
-        if (line[0] == ' ' || line[0] == '+') {
-          current_hunk.new_lines.push_back(line.substr(1));
-        }
-      } else {
-        // End of hunk
-        hunks.push_back(current_hunk);
-        current_hunk = Hunk();
-        in_hunk = false;
+        continue;
       }
+      if (in_hunk) {
+        hunks.push_back(current_hunk);
+      }
+      current_hunk = std::move(parsed_hunk);
+      in_hunk = true;
     }
   }
 
@@ -378,13 +387,17 @@ REGISTER_COMMAND(
   int applied = 0;
   int failed = 0;
 
-  for (const auto& hunk : hunks) {
+  int cumulative_offset = 0;
+  for (const auto& original_hunk : hunks) {
+    Hunk hunk = original_hunk;
+    hunk.old_start += cumulative_offset;
     if (apply_hunk(lines, hunk, reverse)) {
       applied++;
+      cumulative_offset += hunk.new_count - hunk.old_count;
     } else {
       failed++;
       safeErrorPrintLn("patch: hunk FAILED at line " +
-                       std::to_string(hunk.old_start));
+                       std::to_string(original_hunk.old_start));
     }
   }
 

--- a/src/commands/pr.cpp
+++ b/src/commands/pr.cpp
@@ -294,7 +294,7 @@ auto read_lines(const std::string& filename)
       lines.push_back(line);
     }
   } else {
-    std::ifstream f(filename, std::ios::binary);
+    auto f = file_io::open_binary_file(filename);
     if (!f) {
       return std::unexpected(std::string("cannot open '") + filename +
                              "' for reading");
@@ -402,14 +402,12 @@ auto replace_spaces_with_tabs(const std::string& line, int tab_width)
 // Format a date header
 auto format_date_header(const std::string& date_format) -> std::string {
   if (date_format.empty()) {
-    // Default: "May 27 10:30 2026"
+    // GNU pr's default header uses an ISO-like local timestamp.
     SYSTEMTIME st;
     GetLocalTime(&st);
-    const char* months[] = {"Jan", "Feb", "Mar", "Apr", "May", "Jun",
-                            "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"};
     char buf[64];
-    snprintf(buf, sizeof(buf), "%s %02d %02d:%02d %04d", months[st.wMonth - 1],
-             st.wDay, st.wHour, st.wMinute, st.wYear);
+    snprintf(buf, sizeof(buf), "%04d-%02d-%02d %02d:%02d", st.wYear,
+             st.wMonth, st.wDay, st.wHour, st.wMinute);
     return buf;
   }
   // Custom format not fully implemented, return default
@@ -534,11 +532,7 @@ auto run(const Config& cfg) -> int {
   }
 
   // Apply start_page: skip lines before the start page
-  int lines_per_page =
-      cfg.page_length - 10;  // Reserve lines for header/trailer
-  if (cfg.omit_header || cfg.omit_pagination) {
-    lines_per_page = cfg.page_length;
-  }
+  int lines_per_page = std::max(1, cfg.page_length);
 
   // Process lines with all options
   std::string indent_str(cfg.indent, ' ');

--- a/src/commands/printf.cpp
+++ b/src/commands/printf.cpp
@@ -61,6 +61,8 @@ struct FormatSpec {
   bool consumes_argument = false;
   bool valid = false;
   bool left_adjust = false;
+  bool dynamic_width = false;
+  bool dynamic_precision = false;
 };
 
 struct RenderResult {
@@ -239,16 +241,22 @@ FormatSpec parse_format_spec(std::string_view format, size_t& pos) {
     }
   }
 
-  while (i < format.size() &&
-         std::isdigit(static_cast<unsigned char>(format[i]))) {
+  if (i < format.size() && format[i] == '*') {
+    spec.dynamic_width = true;
+    ++i;
+  } else while (i < format.size() &&
+                std::isdigit(static_cast<unsigned char>(format[i]))) {
     spec.width += format[i++];
   }
 
   if (i < format.size() && format[i] == '.') {
     spec.has_precision = true;
     ++i;
-    while (i < format.size() &&
-           std::isdigit(static_cast<unsigned char>(format[i]))) {
+    if (i < format.size() && format[i] == '*') {
+      spec.dynamic_precision = true;
+      ++i;
+    } else while (i < format.size() &&
+                  std::isdigit(static_cast<unsigned char>(format[i]))) {
       spec.precision += format[i++];
     }
   }
@@ -268,7 +276,7 @@ FormatSpec parse_format_spec(std::string_view format, size_t& pos) {
   spec.valid = true;
   pos = i;
   spec.consumes_argument =
-      std::string_view("bcdiuoxXfFeEgGaAs").find(spec.conversion) !=
+      std::string_view("bcdiuoxXfFeEgGaAsq").find(spec.conversion) !=
       std::string_view::npos;
   return spec;
 }
@@ -450,6 +458,19 @@ std::string render_directive(const FormatSpec& spec,
       stop_output = escaped.stop_output;
       return format_string_bytes(std::move(escaped.text), spec);
     }
+    case 'q': {
+      auto value = consume_string_argument(args, arg_index);
+      std::string quoted;
+      for (unsigned char ch : value) {
+        if (std::isalnum(ch) || ch == '_' || ch == '-' || ch == '.' || ch == '/') {
+          quoted.push_back(static_cast<char>(ch));
+        } else {
+          quoted.push_back('\\');
+          quoted.push_back(static_cast<char>(ch));
+        }
+      }
+      return format_string_bytes(std::move(quoted), spec);
+    }
     case 'c': {
       std::string arg = consume_string_argument(args, arg_index);
       int ch = arg.empty() ? 0 : static_cast<unsigned char>(arg[0]);
@@ -508,6 +529,22 @@ RenderResult render_once(std::string_view format,
     if (!spec.valid) {
       result.text += '%';
       continue;
+    }
+
+    if (spec.dynamic_width) {
+      long long width = parse_signed_argument(args, arg_index, had_error);
+      if (width < 0) { spec.left_adjust = true; width = -width; }
+      spec.width = std::to_string(width);
+    }
+    if (spec.dynamic_precision) {
+      long long precision = parse_signed_argument(args, arg_index, had_error);
+      if (precision >= 0) {
+        spec.has_precision = true;
+        spec.precision = std::to_string(precision);
+      } else {
+        spec.has_precision = false;
+        spec.precision.clear();
+      }
     }
 
     if (spec.consumes_argument) {

--- a/src/commands/ptx.cpp
+++ b/src/commands/ptx.cpp
@@ -163,7 +163,7 @@ auto read_all(const std::string& filename) -> std::optional<std::string> {
     buffer << std::cin.rdbuf();
     return buffer.str();
   }
-  std::ifstream input(filename, std::ios::binary);
+  auto input = file_io::open_binary_file(filename);
   if (!input) return std::nullopt;
   std::ostringstream buffer;
   buffer << input.rdbuf();
@@ -303,20 +303,19 @@ void collect_occurrences(const SourceText& source, size_t source_index,
                          const std::set<std::string>& only_words,
                          std::vector<Occurrence>& out) {
   const auto& text = source.text;
-  size_t context_start = 0;
-  size_t context_end = trim_right(text).size();
   size_t pos = 0;
-  while (pos < context_end) {
-    while (pos < context_end &&
+  const size_t text_end = trim_right(text).size();
+  while (pos < text_end) {
+    while (pos < text_end &&
            !is_word_char(static_cast<unsigned char>(text[pos]), breaks,
                          cfg.traditional)) {
       ++pos;
     }
-    if (pos >= context_end) break;
+    if (pos >= text_end) break;
     size_t start = pos;
-    while (pos < context_end &&
+    while (pos < text_end &&
            is_word_char(static_cast<unsigned char>(text[pos]), breaks,
-                        cfg.traditional)) {
+                         cfg.traditional)) {
       ++pos;
     }
     size_t end = pos;
@@ -324,9 +323,14 @@ void collect_occurrences(const SourceText& source, size_t source_index,
     std::string lookup = key_for(word, cfg.ignore_case);
     if (!ignore_words.empty() && ignore_words.contains(lookup)) continue;
     if (!only_words.empty() && !only_words.contains(lookup)) continue;
+    const size_t line_number = line_number_for(source, start);
+    const size_t context_start = source.line_starts[line_number - 1];
+    const size_t next_line = line_number < source.line_starts.size()
+                                 ? source.line_starts[line_number]
+                                 : text.size();
+    const size_t context_end = std::min(next_line, text_end);
     out.push_back(Occurrence{source_index, start, end, context_start,
-                             context_end, line_number_for(source, start),
-                             lookup});
+                             context_end, line_number, lookup});
   }
 }
 

--- a/src/commands/sdiff.cpp
+++ b/src/commands/sdiff.cpp
@@ -335,11 +335,6 @@ REGISTER_COMMAND(
     }
   }
 
-  // Output
-  for (const auto& line : output) {
-    safePrintLn(line);
-  }
-
   // Write to output file if specified
   if (!output_file.empty()) {
     std::wstring woutput = utf8_to_wstring(output_file);
@@ -361,6 +356,8 @@ REGISTER_COMMAND(
     WriteFile(hFile, content.data(), static_cast<DWORD>(content.size()),
               &bytesWritten, nullptr);
     CloseHandle(hFile);
+  } else {
+    for (const auto& line : output) safePrintLn(line);
   }
 
   return any_difference ? 1 : 0;

--- a/src/commands/sed.cpp
+++ b/src/commands/sed.cpp
@@ -1944,6 +1944,7 @@ auto replace_file_atomically(const std::string& path,
                              const std::string& backup_suffix,
                              const std::string& content) -> bool {
   auto original = std::filesystem::path(path);
+  DWORD original_attrs = GetFileAttributesW(utf8_to_wstring(path).c_str());
   auto suffix =
       std::string(".winuxtmp.") + std::to_string(GetCurrentProcessId());
   auto temp = std::filesystem::path(path + suffix);
@@ -1988,6 +1989,9 @@ auto replace_file_atomically(const std::string& path,
     safeErrorPrint("sed: cannot replace '" + path + "'\n");
     return false;
   }
+
+  if (original_attrs != INVALID_FILE_ATTRIBUTES)
+    SetFileAttributesW(utf8_to_wstring(path).c_str(), original_attrs);
 
   std::filesystem::remove(backup, ec);
   return true;

--- a/src/commands/seq.cpp
+++ b/src/commands/seq.cpp
@@ -405,21 +405,18 @@ auto run(const Config& cfg) -> int {
   // Generate sequence
   SmallVector<std::string, 1024> results;
   double current = cfg.first;
-  int count = 0;
-  const int MAX_COUNT = 1000000;  // Prevent infinite loops
   size_t max_width = 0;
 
   while ((increasing && current <= cfg.last) ||
          (!increasing && current >= cfg.last)) {
-    if (count >= MAX_COUNT) {
-      break;
-    }
-
     auto formatted = format_number(current, cfg);
     max_width = std::max(max_width, formatted.size());
     results.push_back(std::move(formatted));
-    current += cfg.increment;
-    count++;
+    const double next = current + cfg.increment;
+    if (!std::isfinite(next) || next == current) {
+      break;
+    }
+    current = next;
   }
 
   if (cfg.equal_width && cfg.format.empty()) {

--- a/src/commands/shred.cpp
+++ b/src/commands/shred.cpp
@@ -114,9 +114,7 @@ REGISTER_COMMAND(
 
       // Apply --size limit
       if (size_limit) {
-        if (*size_limit > 0 && *size_limit < size) {
-          size = *size_limit;
-        }
+        size = std::min(size, *size_limit);
       }
 
       // Round up to block boundary unless --exact is specified
@@ -140,26 +138,35 @@ REGISTER_COMMAND(
 
       // Overwrite file multiple times with random data
       for (int i = 0; i < passes; ++i) {
-        std::vector<char> buffer(size);
-
-        // Generate random data using CryptGenRandom
-        if (crypt_ok) {
-          CryptGenRandom(hProv, static_cast<DWORD>(size),
-                         reinterpret_cast<BYTE*>(buffer.data()));
-        } else {
-          // Fallback: use pattern (not truly random, but better than nothing)
-          for (LONGLONG j = 0; j < size; ++j) {
-            buffer[j] = static_cast<char>(
-                (i + j + static_cast<int>(std::time(nullptr))) % 256);
-          }
-        }
-
         LARGE_INTEGER li = {0};
         SetFilePointerEx(hFile, li, nullptr, FILE_BEGIN);
-
-        DWORD bytesWritten;
-        WriteFile(hFile, buffer.data(), static_cast<DWORD>(size), &bytesWritten,
-                  nullptr);
+        constexpr DWORD kBufferSize = 64 * 1024;
+        std::vector<char> buffer(kBufferSize);
+        LONGLONG remaining = size;
+        LONGLONG offset = 0;
+        while (remaining > 0) {
+          DWORD count = static_cast<DWORD>(std::min<LONGLONG>(remaining, kBufferSize));
+          if (crypt_ok) {
+            if (!CryptGenRandom(hProv, count, reinterpret_cast<BYTE*>(buffer.data()))) {
+              CloseHandle(hFile);
+              exit_code = 1;
+              break;
+            }
+          } else {
+            for (DWORD j = 0; j < count; ++j) {
+              buffer[j] = static_cast<char>((i + offset + j +
+                                             static_cast<int>(std::time(nullptr))) % 256);
+            }
+          }
+          DWORD bytes_written = 0;
+          if (!WriteFile(hFile, buffer.data(), count, &bytes_written, nullptr) ||
+              bytes_written != count) {
+            exit_code = 1;
+            break;
+          }
+          offset += count;
+          remaining -= count;
+        }
         FlushFileBuffers(hFile);
 
         if (verbose) {
@@ -170,14 +177,21 @@ REGISTER_COMMAND(
 
       // Final zero overwrite if requested
       if (zero_fill) {
-        std::vector<char> zeros(size, 0);
-
         LARGE_INTEGER li = {0};
         SetFilePointerEx(hFile, li, nullptr, FILE_BEGIN);
-
-        DWORD bytesWritten;
-        WriteFile(hFile, zeros.data(), static_cast<DWORD>(size), &bytesWritten,
-                  nullptr);
+        constexpr DWORD kBufferSize = 64 * 1024;
+        std::vector<char> zeros(kBufferSize, 0);
+        LONGLONG remaining = size;
+        while (remaining > 0) {
+          DWORD count = static_cast<DWORD>(std::min<LONGLONG>(remaining, kBufferSize));
+          DWORD bytes_written = 0;
+          if (!WriteFile(hFile, zeros.data(), count, &bytes_written, nullptr) ||
+              bytes_written != count) {
+            exit_code = 1;
+            break;
+          }
+          remaining -= count;
+        }
         FlushFileBuffers(hFile);
 
         if (verbose) {

--- a/src/commands/sleep.cpp
+++ b/src/commands/sleep.cpp
@@ -137,7 +137,11 @@ auto run(const Config& cfg) -> int {
     return 1;
   }
 
-  Sleep(static_cast<DWORD>(total_ms));
+  while (total_ms > 0) {
+    const auto chunk = std::min<int64_t>(total_ms, std::numeric_limits<DWORD>::max());
+    Sleep(static_cast<DWORD>(chunk));
+    total_ms -= chunk;
+  }
 
   return 0;
 }

--- a/src/commands/sort.cpp
+++ b/src/commands/sort.cpp
@@ -179,7 +179,7 @@ auto describe_input_open_failure(std::string_view path) -> std::string {
 auto read_source(std::string_view path) -> cp::Result<std::string> {
   if (path == "-") return read_all(std::cin);
 
-  std::ifstream in(std::string(path), std::ios::binary);
+  auto in = file_io::open_binary_file(path);
   if (!in.is_open()) {
     return std::unexpected("cannot read: " + std::string(path) + ": " +
                            describe_input_open_failure(path));
@@ -187,38 +187,12 @@ auto read_source(std::string_view path) -> cp::Result<std::string> {
   return read_all(in);
 }
 
-auto bytes_look_utf16(std::string_view bytes) -> bool {
-  if (bytes.size() >= 2) {
-    const auto b0 = static_cast<std::uint8_t>(bytes[0]);
-    const auto b1 = static_cast<std::uint8_t>(bytes[1]);
-    if ((b0 == 0xFF && b1 == 0xFE) || (b0 == 0xFE && b1 == 0xFF)) {
-      return true;
-    }
-  }
-
-  const size_t sample_size = std::min<size_t>(bytes.size(), 4096);
-  if (sample_size < 2) return false;
-
-  size_t even_nul = 0;
-  size_t odd_nul = 0;
-  for (size_t i = 0; i < sample_size; ++i) {
-    if (bytes[i] != '\0') continue;
-    if ((i & 1U) == 0U)
-      ++even_nul;
-    else
-      ++odd_nul;
-  }
-
-  const size_t threshold = sample_size / 4;
-  return (odd_nul > threshold && odd_nul > even_nul * 2) ||
-         (even_nul > threshold && even_nul > odd_nul * 2);
-}
-
 auto read_simple_lexical_source(std::string_view path)
     -> cp::Result<std::string> {
   if (path == "-") return read_source(path);
 
-  std::ifstream in(std::string(path), std::ios::binary | std::ios::ate);
+  auto in = file_io::open_binary_file(path);
+  in.seekg(0, std::ios::end);
   if (!in.is_open()) {
     return std::unexpected("cannot read: " + std::string(path) + ": " +
                            describe_input_open_failure(path));
@@ -235,8 +209,6 @@ auto read_simple_lexical_source(std::string_view path)
     bytes.resize(static_cast<size_t>(in.gcount()));
   }
 
-  if (bytes_look_utf16(bytes)) return read_source(path);
-
   if (bytes.size() >= 3 && static_cast<std::uint8_t>(bytes[0]) == 0xEF &&
       static_cast<std::uint8_t>(bytes[1]) == 0xBB &&
       static_cast<std::uint8_t>(bytes[2]) == 0xBF) {
@@ -251,7 +223,7 @@ auto read_binary_source(std::string_view path) -> cp::Result<std::string> {
                        std::istreambuf_iterator<char>{}};
   }
 
-  std::ifstream in(std::string(path), std::ios::binary);
+  auto in = file_io::open_binary_file(path);
   if (!in.is_open()) {
     return std::unexpected("cannot read: " + std::string(path) + ": " +
                            describe_input_open_failure(path));
@@ -298,21 +270,15 @@ auto split_records(std::string_view content, char delimiter)
     -> std::vector<std::string> {
   std::vector<std::string> out;
   out.reserve(content.size() / 20);  // Estimate: assume ~20 chars per record
-  const auto trim_record = [delimiter](std::string_view record) {
-    if (delimiter == '\n' && !record.empty() && record.back() == '\r') {
-      record.remove_suffix(1);
-    }
-    return std::string(record);
-  };
   size_t start = 0;
   for (size_t i = 0; i < content.size(); ++i) {
     if (content[i] == delimiter) {
-      out.emplace_back(trim_record(content.substr(start, i - start)));
+      out.emplace_back(content.substr(start, i - start));
       start = i + 1;
     }
   }
   if (start < content.size()) {
-    out.emplace_back(trim_record(content.substr(start)));
+    out.emplace_back(content.substr(start));
   }
   return out;
 }
@@ -1526,22 +1492,15 @@ auto split_record_views(std::string_view content, char delimiter)
   std::vector<std::string_view> out;
   out.reserve(content.size() / 20);
 
-  const auto trim_record = [delimiter](std::string_view record) {
-    if (delimiter == '\n' && !record.empty() && record.back() == '\r') {
-      record.remove_suffix(1);
-    }
-    return record;
-  };
-
   size_t start = 0;
   for (size_t i = 0; i < content.size(); ++i) {
     if (content[i] == delimiter) {
-      out.emplace_back(trim_record(content.substr(start, i - start)));
+      out.emplace_back(content.substr(start, i - start));
       start = i + 1;
     }
   }
   if (start < content.size()) {
-    out.emplace_back(trim_record(content.substr(start)));
+    out.emplace_back(content.substr(start));
   }
   return out;
 }
@@ -1676,12 +1635,141 @@ auto merge_record_chunks(const Config& cfg)
   return records;
 }
 
+struct ExternalRun {
+  std::filesystem::path path;
+  std::ifstream input;
+  std::string current;
+  bool has_current = false;
+};
+
+auto external_sort(const Config& cfg) -> cp::Result<int> {
+  constexpr size_t kChunkBytes = 8 * 1024 * 1024;
+  std::vector<std::filesystem::path> temporary_paths;
+  std::vector<ExternalRun> runs;
+  size_t run_number = 0;
+
+  std::filesystem::path temp_dir = cfg.temporary_directory_hint.empty()
+                                       ? std::filesystem::temp_directory_path()
+                                       : std::filesystem::path(
+                                             cfg.temporary_directory_hint);
+  auto make_run = [&](std::vector<std::string>& records) -> cp::Result<bool> {
+    if (records.empty()) return true;
+    auto before = [&](const std::string& a, const std::string& b) {
+      return is_before(a, b, cfg);
+    };
+    if (cfg.stable || cfg.unique) {
+      std::stable_sort(records.begin(), records.end(), before);
+    } else {
+      std::sort(records.begin(), records.end(), before);
+    }
+    const auto path = temp_dir / ("winuxcmd-sort-" +
+                                  std::to_string(GetCurrentProcessId()) +
+                                  "-" + std::to_string(run_number++) + ".tmp");
+    auto output = file_io::create_binary_file(path.string());
+    if (!output.is_open()) return std::unexpected("cannot create temporary file");
+    for (const auto& record : records) {
+      output.write(record.data(), static_cast<std::streamsize>(record.size()));
+      output.put(cfg.delimiter);
+    }
+    if (!output) return std::unexpected("cannot write temporary file");
+    output.close();
+    temporary_paths.push_back(path);
+    records.clear();
+    return true;
+  };
+
+  std::vector<std::string> records;
+  size_t bytes = 0;
+  auto consume = [&](std::istream& input) -> cp::Result<bool> {
+    std::string record;
+    while (std::getline(input, record, cfg.delimiter)) {
+      bytes += record.size() + 1;
+      records.push_back(std::move(record));
+      record.clear();
+      if (bytes >= kChunkBytes) {
+        auto result = make_run(records);
+        if (!result) return std::unexpected(result.error());
+        bytes = 0;
+      }
+    }
+    if (input.bad()) return std::unexpected("error reading input");
+    return true;
+  };
+
+  for (const auto& filename : cfg.files) {
+    if (filename == "-") {
+      auto stdin_content = read_source(filename);
+      if (!stdin_content) return std::unexpected(stdin_content.error());
+      std::istringstream decoded_input(*stdin_content);
+      auto result = consume(decoded_input);
+      if (!result) return std::unexpected(result.error());
+    } else {
+      auto input = file_io::open_binary_file(filename);
+      if (!input.is_open()) {
+        return std::unexpected("cannot read: " + filename + ": " +
+                              describe_input_open_failure(filename));
+      }
+      auto result = consume(input);
+      if (!result) return std::unexpected(result.error());
+    }
+  }
+  auto final_run = make_run(records);
+  if (!final_run) return std::unexpected(final_run.error());
+
+  std::ofstream output_file;
+  std::ostream* output = &std::cout;
+  int stdout_mode = -1;
+  if (!cfg.output_file.empty()) {
+    output_file = file_io::create_binary_file(cfg.output_file);
+    if (!output_file.is_open()) return std::unexpected("cannot open output file");
+    output = &output_file;
+  } else {
+    stdout_mode = _setmode(_fileno(stdout), _O_BINARY);
+  }
+
+  for (auto& path : temporary_paths) {
+    ExternalRun run{path, file_io::open_binary_file(path.string())};
+    if (!run.input.is_open()) return std::unexpected("cannot open temporary file");
+    run.has_current = static_cast<bool>(std::getline(run.input, run.current,
+                                                     cfg.delimiter));
+    runs.push_back(std::move(run));
+  }
+  auto less = [&](size_t left, size_t right) {
+    if (is_before(runs[left].current, runs[right].current, cfg)) return false;
+    if (is_before(runs[right].current, runs[left].current, cfg)) return true;
+    return left > right;
+  };
+  std::priority_queue<size_t, std::vector<size_t>, decltype(less)> queue(less);
+  for (size_t i = 0; i < runs.size(); ++i) if (runs[i].has_current) queue.push(i);
+
+  std::string previous;
+  bool have_previous = false;
+  while (!queue.empty()) {
+    const size_t index = queue.top();
+    queue.pop();
+    auto& run = runs[index];
+    const bool duplicate = have_previous &&
+        compare_records_by_sort_key(previous, run.current, cfg) == 0;
+    if (!cfg.unique || !duplicate) {
+      output->write(run.current.data(), static_cast<std::streamsize>(run.current.size()));
+      output->put(cfg.delimiter);
+      previous = run.current;
+      have_previous = true;
+    }
+    run.current.clear();
+    run.has_current = static_cast<bool>(std::getline(run.input, run.current,
+                                                     cfg.delimiter));
+    if (run.has_current) queue.push(index);
+  }
+  output->flush();
+  runs.clear();
+  for (const auto& path : temporary_paths) std::filesystem::remove(path);
+  if (stdout_mode != -1) _setmode(_fileno(stdout), stdout_mode);
+  return 0;
+}
+
 auto run(const Config& cfg) -> int {
   emit_debug_diagnostics(cfg);
-
-  if (auto fast_result = try_run_simple_lexical_block_sort(cfg)) {
-    return *fast_result;
-  }
 
   const bool simple_lexical = can_use_simple_lexical_compare(cfg);
   std::vector<std::string> records;
@@ -1716,33 +1804,13 @@ auto run(const Config& cfg) -> int {
     }
     records = std::move(*merged);
   } else {
-    auto loaded = load_records(cfg);
-    if (!loaded) {
-      cp::report_custom_error(L"sort", utf8_to_wstring(loaded.error()));
+    // External runs keep ordinary sorts bounded by a fixed memory chunk.
+    auto external = external_sort(cfg);
+    if (!external) {
+      cp::report_custom_error(L"sort", utf8_to_wstring(external.error()));
       return 2;
     }
-    records = std::move(*loaded);
-
-    if (simple_lexical) {
-      auto lexical_before = [&](const std::string& a, const std::string& b) {
-        return cfg.reverse ? a > b : a < b;
-      };
-      if (cfg.stable || cfg.unique) {
-        std::stable_sort(records.begin(), records.end(), lexical_before);
-      } else {
-        std::sort(records.begin(), records.end(), lexical_before);
-      }
-    } else {
-      if (cfg.stable || cfg.unique) {
-        std::stable_sort(
-            records.begin(), records.end(),
-            [&](const auto& a, const auto& b) { return is_before(a, b, cfg); });
-      } else {
-        std::sort(
-            records.begin(), records.end(),
-            [&](const auto& a, const auto& b) { return is_before(a, b, cfg); });
-      }
-    }
+    return *external;
   }
 
   if (cfg.unique) {

--- a/src/commands/split.cpp
+++ b/src/commands/split.cpp
@@ -567,6 +567,100 @@ auto collect_record_spans(std::string_view input, char separator)
 }
 
 auto run(const Config& cfg) -> int {
+  // Stream the common fixed-size modes. The filter and record-preserving
+  // number modes still use the existing in-memory path because their output
+  // contract requires a complete record set or a subprocess payload.
+  if (cfg.filter_command.empty() &&
+      (cfg.mode == Config::Mode::Lines || cfg.mode == Config::Mode::Bytes ||
+       cfg.mode == Config::Mode::LineBytes)) {
+    std::ifstream input;
+    if (cfg.input_file.empty() || cfg.input_file == "-") {
+      // stdin is already a stream and is handled by the same byte loop below.
+    } else {
+      auto operand = native_path::make_api_path_operand(cfg.input_file);
+      input.open(std::filesystem::path(operand.extended), std::ios::binary);
+      if (!input) {
+        std::string reason = "No such file or directory";
+        const DWORD attrs = native_path::attributes_w(operand.extended);
+        if (native_path::attributes_are_directory(attrs)) {
+          reason = "Is a directory";
+        }
+        cp::Result<int> result = std::unexpected(
+            "cannot open '" + cfg.input_file + "' for reading: " + reason);
+        cp::report_error(result, L"split");
+        return 1;
+      }
+    }
+    std::istream& source = input.is_open() ? static_cast<std::istream&>(input)
+                                           : static_cast<std::istream&>(std::cin);
+    uint64_t part_num = 0;
+    std::string chunk;
+    int64_t records = 0;
+    size_t used = 0;
+    std::array<char, 64 * 1024> buffer{};
+    auto flush = [&]() -> bool {
+      if (chunk.empty()) return true;
+      auto result = write_chunk(cfg, part_num, chunk);
+      if (!result) {
+        cp::report_error(result, L"split");
+        return false;
+      }
+      if (*result) ++part_num;
+      chunk.clear();
+      used = 0;
+      records = 0;
+      return true;
+    };
+    if (cfg.mode == Config::Mode::Bytes) {
+      while (source) {
+        source.read(buffer.data(), static_cast<std::streamsize>(buffer.size()));
+        const auto got = source.gcount();
+        for (std::streamsize i = 0; i < got; ++i) {
+          chunk.push_back(buffer[static_cast<size_t>(i)]);
+          if (chunk.size() == static_cast<size_t>(cfg.chunk_size) && !flush()) return 1;
+        }
+      }
+    } else {
+      std::string record;
+      char c = 0;
+      while (source.get(c)) {
+        record.push_back(c);
+        if (c != cfg.separator) continue;
+
+        if (cfg.mode == Config::Mode::Lines) {
+          chunk += record;
+          record.clear();
+          ++records;
+          if (records >= cfg.chunk_lines && !flush()) return 1;
+        } else {
+          const auto limit = static_cast<size_t>(cfg.chunk_size);
+          if (!chunk.empty() && chunk.size() + record.size() > limit &&
+              !flush()) {
+            return 1;
+          }
+          chunk += record;
+          record.clear();
+        }
+      }
+      if (!record.empty()) {
+        if (cfg.mode == Config::Mode::LineBytes && !chunk.empty() &&
+            chunk.size() + record.size() > static_cast<size_t>(cfg.chunk_size) &&
+            !flush()) {
+          return 1;
+        }
+        chunk += record;
+      }
+      if (!chunk.empty() && !flush()) return 1;
+    }
+    if (!chunk.empty() && !flush()) return 1;
+    if (source.bad()) {
+      cp::Result<int> result = std::unexpected("error reading from file");
+      cp::report_error(result, L"split");
+      return 1;
+    }
+    return 0;
+  }
+
   // Read input
   std::string input;
   auto split_input_open_error = [](std::string_view path) -> std::string {
@@ -577,8 +671,13 @@ auto run(const Config& cfg) -> int {
              "' for reading: Is a directory";
     }
 
+    auto operand = native_path::make_api_path_operand(path);
+    const DWORD attrs = native_path::attributes_w(operand.extended);
+    const std::string reason = native_path::attributes_are_directory(attrs)
+                                   ? "Is a directory"
+                                   : "No such file or directory";
     return std::string("cannot open '") + std::string(path) +
-           "' for reading: No such file or directory";
+           "' for reading: " + reason;
   };
 
   if (cfg.input_file.empty() || cfg.input_file == "-") {
@@ -674,11 +773,6 @@ auto run(const Config& cfg) -> int {
           end = input.size();
         } else {
           end = static_cast<size_t>((i + 1) * chunk_size);
-          // Try to find a newline boundary
-          size_t nl = input.find(cfg.separator, end);
-          if (nl != std::string::npos && nl < end + chunk_size / 10) {
-            end = nl + 1;
-          }
         }
         if (start >= input.size()) break;
 

--- a/src/commands/stat.cpp
+++ b/src/commands/stat.cpp
@@ -74,6 +74,10 @@ struct FileStatData {
   uint64_t volume_serial = 0;
   uint32_t hard_links = 1;
   uint32_t io_block_size = 4096;
+  std::string owner_name;
+  std::string owner_id;
+  std::string group_name;
+  std::string group_id;
 };
 
 struct FileSystemStatData {
@@ -147,6 +151,8 @@ auto build_config(const CommandContext<STAT_OPTIONS.size()>& ctx)
 }
 
 auto format_timestamp(FILETIME ft) -> std::string {
+  FILETIME local{};
+  if (FileTimeToLocalFileTime(&ft, &local)) ft = local;
   SYSTEMTIME st;
   FileTimeToSystemTime(&ft, &st);
 
@@ -182,17 +188,11 @@ auto format_size(uint64_t size) -> std::string {
 }
 
 auto format_permissions(DWORD attrs) -> std::string {
-  std::string perm;
-  perm += (attrs & FILE_ATTRIBUTE_DIRECTORY) ? 'd' : '-';
-  perm += (attrs & FILE_ATTRIBUTE_READONLY) ? 'r' : 'r';
-  perm += (attrs & FILE_ATTRIBUTE_READONLY) ? '-' : 'w';
-  perm += '-';
-  perm += (attrs & FILE_ATTRIBUTE_READONLY) ? 'r' : 'r';
-  perm += (attrs & FILE_ATTRIBUTE_READONLY) ? '-' : 'w';
-  perm += '-';
-  perm += (attrs & FILE_ATTRIBUTE_READONLY) ? 'r' : 'r';
-  perm += (attrs & FILE_ATTRIBUTE_READONLY) ? '-' : 'w';
-  perm += '-';
+  const bool directory = (attrs & FILE_ATTRIBUTE_DIRECTORY) != 0;
+  const bool writable = (attrs & FILE_ATTRIBUTE_READONLY) == 0;
+  std::string perm = directory ? "d" : "-";
+  perm += writable ? (directory ? "rwxr-xr-x" : "rw-r--r--")
+                   : (directory ? "r-xr-xr-x" : "r--r--r--");
   return perm;
 }
 
@@ -204,9 +204,9 @@ auto file_type_name(DWORD attrs) -> std::string {
 
 auto format_mode_octal(DWORD attrs) -> std::string {
   if (attrs & FILE_ATTRIBUTE_DIRECTORY) {
-    return (attrs & FILE_ATTRIBUTE_READONLY) ? "555" : "777";
+    return (attrs & FILE_ATTRIBUTE_READONLY) ? "555" : "755";
   }
-  return (attrs & FILE_ATTRIBUTE_READONLY) ? "444" : "666";
+  return (attrs & FILE_ATTRIBUTE_READONLY) ? "444" : "644";
 }
 
 auto io_block_size_for(const std::filesystem::path& p) -> uint32_t {
@@ -215,8 +215,10 @@ auto io_block_size_for(const std::filesystem::path& p) -> uint32_t {
   auto absolute = std::filesystem::absolute(dir, ec);
   auto wdir = ec ? dir.wstring() : absolute.wstring();
 
-  wchar_t root[MAX_PATH];
-  if (!GetVolumePathNameW(wdir.c_str(), root, MAX_PATH)) return 4096;
+  auto operand = native_path::make_api_path_operand_w(wdir);
+  wchar_t root[32768];
+  if (!GetVolumePathNameW(operand.extended.c_str(), root,
+                          static_cast<DWORD>(std::size(root)))) return 4096;
 
   DWORD sectors_per_cluster = 0;
   DWORD bytes_per_sector = 0;
@@ -238,16 +240,24 @@ auto io_block_size_for(const std::filesystem::path& p) -> uint32_t {
 auto load_file_stat(const std::filesystem::path& p)
     -> cp::Result<FileStatData> {
   FileStatData stat;
-  if (!GetFileAttributesExW(p.c_str(), GetFileExInfoStandard, &stat.attrs)) {
+  auto operand = native_path::make_api_path_operand_w(p.wstring());
+  if (!GetFileAttributesExW(operand.extended.c_str(), GetFileExInfoStandard,
+                            &stat.attrs)) {
     return std::unexpected("Access denied");
   }
+
+  auto accounts = win32_file_accounts(operand.extended);
+  stat.owner_name = accounts.owner.name;
+  stat.owner_id = accounts.owner.id;
+  stat.group_name = accounts.group.name;
+  stat.group_id = accounts.group.id;
 
   stat.size = stat.attrs.nFileSizeLow +
               (static_cast<uint64_t>(stat.attrs.nFileSizeHigh) << 32);
   stat.io_block_size = io_block_size_for(p);
 
   HANDLE h =
-      CreateFileW(p.c_str(), FILE_READ_ATTRIBUTES,
+      CreateFileW(operand.extended.c_str(), FILE_READ_ATTRIBUTES,
                   FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
                   nullptr, OPEN_EXISTING, FILE_FLAG_BACKUP_SEMANTICS, nullptr);
   if (h != INVALID_HANDLE_VALUE) {
@@ -331,13 +341,16 @@ auto load_file_system_stat(const std::string& filename)
   auto absolute = std::filesystem::absolute(fs_path, ec);
   std::wstring path = ec ? utf8_to_wstring(filename) : absolute.wstring();
 
-  wchar_t root[MAX_PATH];
-  if (!GetVolumePathNameW(path.c_str(), root, MAX_PATH)) {
+  auto path_operand = native_path::make_api_path_operand_w(path);
+  std::array<wchar_t, 32768> root{};
+  if (!GetVolumePathNameW(path_operand.extended.c_str(), root.data(),
+                          static_cast<DWORD>(root.size()))) {
     return std::unexpected("cannot read file system");
   }
 
   ULARGE_INTEGER free_available{}, total_bytes{}, total_free{};
-  if (!GetDiskFreeSpaceExW(root, &free_available, &total_bytes, &total_free)) {
+  if (!GetDiskFreeSpaceExW(root.data(), &free_available, &total_bytes,
+                           &total_free)) {
     return std::unexpected("cannot read file system");
   }
 
@@ -346,7 +359,7 @@ auto load_file_system_stat(const std::string& filename)
   DWORD free_clusters = 0;
   DWORD total_clusters = 0;
   uint32_t block_size = 4096;
-  if (GetDiskFreeSpaceW(root, &sectors_per_cluster, &bytes_per_sector,
+  if (GetDiskFreeSpaceW(root.data(), &sectors_per_cluster, &bytes_per_sector,
                         &free_clusters, &total_clusters)) {
     uint64_t computed =
         static_cast<uint64_t>(sectors_per_cluster) * bytes_per_sector;
@@ -355,12 +368,13 @@ auto load_file_system_stat(const std::string& filename)
     }
   }
 
-  wchar_t fs_name[MAX_PATH] = L"";
+  std::array<wchar_t, 32768> fs_name{};
   DWORD serial = 0;
   DWORD max_component = 0;
   DWORD flags = 0;
-  GetVolumeInformationW(root, nullptr, 0, &serial, &max_component, &flags,
-                        fs_name, MAX_PATH);
+  GetVolumeInformationW(root.data(), nullptr, 0, &serial, &max_component,
+                        &flags, fs_name.data(),
+                        static_cast<DWORD>(fs_name.size()));
 
   return FileSystemStatData{
       .free_available = static_cast<uint64_t>(free_available.QuadPart),
@@ -369,7 +383,7 @@ auto load_file_system_stat(const std::string& filename)
       .block_size = block_size,
       .max_component = max_component,
       .serial = serial,
-      .fs_name = wstring_to_utf8(fs_name)};
+      .fs_name = wstring_to_utf8(fs_name.data())};
 }
 
 auto render_format(std::string_view format, const std::string& filename,
@@ -434,12 +448,16 @@ auto render_format(std::string_view format, const std::string& filename,
         out += std::to_string(stat.io_block_size);
         break;
       case 'u':
+        out += stat.owner_id.empty() ? "0" : stat.owner_id;
+        break;
       case 'g':
-        out += "0";
+        out += stat.group_id.empty() ? "0" : stat.group_id;
         break;
       case 'U':
+        out += stat.owner_name.empty() ? "UNKNOWN" : stat.owner_name;
+        break;
       case 'G':
-        out += "UNKNOWN";
+        out += stat.group_name.empty() ? "UNKNOWN" : stat.group_name;
         break;
       case 'x':
         out += format_timestamp(stat.attrs.ftLastAccessTime);
@@ -471,10 +489,11 @@ auto render_format(std::string_view format, const std::string& filename,
         break;
       case 'm': {
         // Mount point
-        wchar_t volume[MAX_PATH];
-        std::wstring wfilename = utf8_to_wstring(filename);
-        if (GetVolumePathNameW(wfilename.c_str(), volume, MAX_PATH)) {
-          out += wstring_to_utf8(volume);
+        std::array<wchar_t, 32768> volume{};
+        auto operand = native_path::make_api_path_operand(filename);
+        if (GetVolumePathNameW(operand.extended.c_str(), volume.data(),
+                               static_cast<DWORD>(volume.size()))) {
+          out += wstring_to_utf8(volume.data());
         } else {
           out += "/";
         }

--- a/src/commands/stdbuf.cpp
+++ b/src/commands/stdbuf.cpp
@@ -140,7 +140,7 @@ auto validate_buffer_mode(std::string_view stream_name, const std::string& mode)
     -> bool {
   if (mode.empty()) return true;
   if (mode == "0") return true;
-  if (mode == "L") return stream_name != "standard input";
+  if (mode == "L") return true;
   auto size = parse_buffer_size(mode);
   return size.has_value() && *size > 0;
 }
@@ -185,6 +185,21 @@ auto stdbuf_windows_error_text(DWORD error) -> std::string {
 auto build_stdbuf_command_line(std::span<const std::string_view> args)
     -> std::wstring {
   return build_windows_command_line(args);
+}
+
+auto set_child_buffer_mode(const char* name, const std::string& mode)
+    -> std::optional<std::string> {
+  const char* old = std::getenv(name);
+  std::optional<std::string> previous;
+  if (old != nullptr) previous = old;
+  _putenv_s(name, mode.c_str());
+  return previous;
+}
+
+auto restore_child_buffer_mode(const char* name,
+                               const std::optional<std::string>& previous)
+    -> void {
+  _putenv_s(name, previous.has_value() ? previous->c_str() : "");
 }
 }  // namespace
 
@@ -233,7 +248,7 @@ REGISTER_COMMAND(
 
   // For Windows, we'll just execute the command directly
   // and set the parent process buffering
-  if (!set_stream_buffering(stdin, input_mode)) {
+  if (input_mode != "L" && !set_stream_buffering(stdin, input_mode)) {
     safeErrorPrintLn("stdbuf: invalid mode for standard input: " + input_mode);
     return kStdbufUsageErrorExitCode;
   }
@@ -247,6 +262,17 @@ REGISTER_COMMAND(
     return kStdbufUsageErrorExitCode;
   }
 
+  // WinuxCmd children apply these inherited settings at their common entry
+  // point. Store resolved byte sizes so the child does not duplicate the
+  // suffix parser; line mode remains the explicit L marker.
+  auto resolve_mode = [](const std::string& mode) {
+    if (mode == "L" || mode == "0" || mode.empty()) return mode;
+    return std::to_string(*parse_buffer_size(mode));
+  };
+  auto old_i = set_child_buffer_mode("WINUX_STDBUF_I", resolve_mode(input_mode));
+  auto old_o = set_child_buffer_mode("WINUX_STDBUF_O", resolve_mode(output_mode));
+  auto old_e = set_child_buffer_mode("WINUX_STDBUF_E", resolve_mode(error_mode));
+
   // Execute command
   STARTUPINFOW si = {sizeof(si)};
   PROCESS_INFORMATION pi;
@@ -254,6 +280,9 @@ REGISTER_COMMAND(
 
   if (!CreateProcessW(nullptr, cmd_line.data(), nullptr, nullptr, TRUE, 0,
                       nullptr, nullptr, &si, &pi)) {
+    restore_child_buffer_mode("WINUX_STDBUF_I", old_i);
+    restore_child_buffer_mode("WINUX_STDBUF_O", old_o);
+    restore_child_buffer_mode("WINUX_STDBUF_E", old_e);
     DWORD error = GetLastError();
     safeErrorPrintLn("stdbuf: failed to run command '" +
                      std::string(ctx.positionals[0]) +
@@ -269,6 +298,10 @@ REGISTER_COMMAND(
 
   CloseHandle(pi.hProcess);
   CloseHandle(pi.hThread);
+
+  restore_child_buffer_mode("WINUX_STDBUF_I", old_i);
+  restore_child_buffer_mode("WINUX_STDBUF_O", old_o);
+  restore_child_buffer_mode("WINUX_STDBUF_E", old_e);
 
   return static_cast<int>(exit_code);
 }

--- a/src/commands/tac.cpp
+++ b/src/commands/tac.cpp
@@ -189,10 +189,6 @@ auto run(const Config& cfg) -> int {
       return 1;
     }
 
-    if (!cfg.regex && cfg.separator == "\n") {
-      *content = normalize_newline_delimited_text(*content);
-    }
-
     cp::Result<std::vector<std::string>> records =
         cfg.regex ? split_regex_records(*content, cfg.separator, cfg.before)
                   : cp::Result<std::vector<std::string>>{split_literal_records(

--- a/src/commands/tail.cpp
+++ b/src/commands/tail.cpp
@@ -584,13 +584,12 @@ auto output_tail(std::istream& in, const TailConfig& config) -> void {
 }
 
 auto open_input_file(const std::string& file) -> std::ifstream {
-  return std::ifstream(std::filesystem::path(utf8_to_wstring(file)),
-                       std::ios::binary);
+  return file_io::open_binary_file(file);
 }
 
 auto describe_open_failure(const std::string& file) -> std::string {
   std::wstring wfile = utf8_to_wstring(file);
-  DWORD attrs = GetFileAttributesW(wfile.c_str());
+  DWORD attrs = native_path::attributes_w(utf8_to_wstring(file));
   if (attrs == INVALID_FILE_ATTRIBUTES) {
     return "No such file or directory";
   }

--- a/src/commands/tee.cpp
+++ b/src/commands/tee.cpp
@@ -163,7 +163,10 @@ REGISTER_COMMAND(
     if (got == 0) break;
 
     if (!write_stdout_copy(buffer.data(), got)) {
-      if (handle_write_error()) return 1;
+      handle_write_error();
+      // A closed downstream pipe cannot recover. Continuing would repeatedly
+      // hit the same error while consuming stdin indefinitely.
+      return 1;
     }
 
     for (auto& file : file_streams) {

--- a/src/commands/test.cpp
+++ b/src/commands/test.cpp
@@ -176,7 +176,8 @@ bool is_unary_operator(const std::string& op) {
 bool is_binary_operator(const std::string& op) {
   static const std::unordered_set<std::string> ops = {
       "=",   "==",  "!=",  "<",   "<=", ">",    ">=", "-eq", "-ne",
-      "-lt", "-le", "-gt", "-ge", "-a", "-and", "-o", "-or"};
+      "-lt", "-le", "-gt", "-ge", "-a", "-and", "-o", "-or", "-nt",
+      "-ot", "-ef"};
   return ops.contains(op);
 }
 
@@ -241,6 +242,34 @@ int evaluate_binary(const std::string& a, const std::string& op,
     return compare_integers(op, va, vb) ? 0 : 1;
   }
 
+  if (op == "-nt" || op == "-ot" || op == "-ef") {
+    WIN32_FILE_ATTRIBUTE_DATA left{}, right{};
+    const auto left_path = utf8_to_wstring(a);
+    const auto right_path = utf8_to_wstring(b);
+    if (!GetFileAttributesExW(left_path.c_str(), GetFileExInfoStandard,
+                              &left) ||
+        !GetFileAttributesExW(right_path.c_str(), GetFileExInfoStandard,
+                              &right)) {
+      return 1;
+    }
+    if (op == "-ef") {
+      wchar_t left_full[MAX_PATH * 4]{}, right_full[MAX_PATH * 4]{};
+      if (!GetFullPathNameW(left_path.c_str(), std::size(left_full), left_full,
+                            nullptr) ||
+          !GetFullPathNameW(right_path.c_str(), std::size(right_full),
+                            right_full, nullptr)) {
+        return 1;
+      }
+      return _wcsicmp(left_full, right_full) == 0 ? 0 : 1;
+    }
+    ULARGE_INTEGER left_time{left.ftLastWriteTime.dwLowDateTime,
+                             left.ftLastWriteTime.dwHighDateTime};
+    ULARGE_INTEGER right_time{right.ftLastWriteTime.dwLowDateTime,
+                              right.ftLastWriteTime.dwHighDateTime};
+    return op == "-nt" ? (left_time.QuadPart > right_time.QuadPart ? 0 : 1)
+                       : (left_time.QuadPart < right_time.QuadPart ? 0 : 1);
+  }
+
   if (op == "-a" || op == "-and") return (!a.empty() && !b.empty()) ? 0 : 1;
   if (op == "-o" || op == "-or") return (!a.empty() || !b.empty()) ? 0 : 1;
   return 2;
@@ -252,32 +281,58 @@ int invert_test_status(int status) {
   return status;
 }
 
+class TestExpressionParser {
+ public:
+  explicit TestExpressionParser(std::span<const std::string> args) : args_(args) {}
+  int parse() {
+    if (args_.empty()) return 1;
+    int result = parse_or();
+    return error_ || pos_ != args_.size() ? 2 : result;
+  }
+ private:
+  int parse_or() {
+    int result = parse_and();
+    while (peek("-o") || peek("-or")) { ++pos_; int right = parse_and(); result = combine_or(result, right); }
+    return result;
+  }
+  int parse_and() {
+    int result = parse_not();
+    while (peek("-a") || peek("-and")) { ++pos_; int right = parse_not(); result = combine_and(result, right); }
+    return result;
+  }
+  int parse_not() {
+    if (peek("!")) { ++pos_; return invert_test_status(parse_not()); }
+    if (peek("(")) {
+      ++pos_; int result = parse_or();
+      if (!peek(")")) { error_ = true; return 2; }
+      ++pos_; return result;
+    }
+    return parse_primary();
+  }
+  int parse_primary() {
+    if (pos_ >= args_.size()) { error_ = true; return 2; }
+    if (pos_ + 1 < args_.size() && is_unary_operator(std::string(args_[pos_]))) {
+      auto op = std::string(args_[pos_++]);
+      return evaluate_unary(op, std::string(args_[pos_++]));
+    }
+    if (pos_ + 2 < args_.size() && is_binary_operator(std::string(args_[pos_ + 1]))) {
+      auto left = std::string(args_[pos_++]);
+      auto op = std::string(args_[pos_++]);
+      auto right = std::string(args_[pos_++]);
+      return evaluate_binary(left, op, right);
+    }
+    return args_[pos_++].empty() ? 1 : 0;
+  }
+  static int combine_or(int left, int right) { return left == 0 || right == 0 ? 0 : (left == 2 || right == 2 ? 2 : 1); }
+  static int combine_and(int left, int right) { return left == 0 && right == 0 ? 0 : (left == 2 || right == 2 ? 2 : 1); }
+  bool peek(std::string_view token) const { return pos_ < args_.size() && args_[pos_] == token; }
+  std::span<const std::string> args_;
+  size_t pos_ = 0;
+  bool error_ = false;
+};
+
 int evaluate_test_expression(std::span<const std::string> args) {
-  // GNU test.c's term() treats operators as expression tokens, not command
-  // options.  Keep this parser token-based so constructs like
-  // `test 123 -gt 45` survive the generic Winux option scanner.
-  if (args.empty()) return 1;
-
-  if (args.front() == "!") {
-    return invert_test_status(evaluate_test_expression(args.subspan(1)));
-  }
-
-  if (args.size() == 1) return args[0].empty() ? 1 : 0;
-
-  if (args.size() == 2 && is_unary_operator(args[0])) {
-    return evaluate_unary(args[0], args[1]);
-  }
-
-  if (args.size() == 3 && is_binary_operator(args[1])) {
-    return evaluate_binary(args[0], args[1], args[2]);
-  }
-
-  if (args.size() == 4 && args[1] == "!" &&
-      (args[2] == "=" || args[2] == "==" || args[2] == "!=")) {
-    return invert_test_status(evaluate_binary(args[0], args[2], args[3]));
-  }
-
-  return 2;
+  return TestExpressionParser(args).parse();
 }
 }  // namespace
 

--- a/src/commands/test_bracket.cpp
+++ b/src/commands/test_bracket.cpp
@@ -139,7 +139,8 @@ auto is_unary_operator(const std::string& op) -> bool {
 auto is_binary_operator(const std::string& op) -> bool {
   static const std::unordered_set<std::string> ops = {
       "=",   "==",  "!=",  "<",   "<=", ">",    ">=", "-eq", "-ne",
-      "-lt", "-le", "-gt", "-ge", "-a", "-and", "-o", "-or"};
+      "-lt", "-le", "-gt", "-ge", "-a", "-and", "-o", "-or", "-nt",
+      "-ot", "-ef"};
   return ops.contains(op);
 }
 
@@ -229,10 +230,10 @@ auto invert_test_status(int status) -> int {
   return status;
 }
 
-auto evaluate_bracket_expression(std::span<const std::string> args) -> int {
+auto evaluate_bracket_expression_legacy(std::span<const std::string> args) -> int {
   if (args.empty()) return 1;
   if (args.front() == "!") {
-    return invert_test_status(evaluate_bracket_expression(args.subspan(1)));
+    return invert_test_status(evaluate_bracket_expression_legacy(args.subspan(1)));
   }
   if (args.size() == 1) return args[0].empty() ? 1 : 0;
   if (args.size() == 2 && is_unary_operator(args[0])) {
@@ -246,6 +247,44 @@ auto evaluate_bracket_expression(std::span<const std::string> args) -> int {
     return invert_test_status(evaluate_binary(args[0], args[2], args[3]));
   }
   return 2;
+}
+
+class BracketExpressionParser {
+ public:
+  explicit BracketExpressionParser(std::span<const std::string> args) : args_(args) {}
+  int parse() {
+    if (args_.empty()) return 1;
+    int result = parse_or();
+    return error_ || pos_ != args_.size() ? 2 : result;
+  }
+ private:
+  int parse_or() {
+    int result = parse_and();
+    while (peek("-o") || peek("-or")) { ++pos_; int right = parse_and(); result = result == 0 || right == 0 ? 0 : 1; }
+    return result;
+  }
+  int parse_and() {
+    int result = parse_not();
+    while (peek("-a") || peek("-and")) { ++pos_; int right = parse_not(); result = result == 0 && right == 0 ? 0 : 1; }
+    return result;
+  }
+  int parse_not() {
+    if (peek("!")) { ++pos_; return invert_test_status(parse_not()); }
+    if (peek("(")) { ++pos_; int result = parse_or(); if (!peek(")")) { error_ = true; return 2; } ++pos_; return result; }
+    return parse_primary();
+  }
+  int parse_primary() {
+    if (pos_ >= args_.size()) { error_ = true; return 2; }
+    if (pos_ + 1 < args_.size() && is_unary_operator(std::string(args_[pos_]))) { auto op = std::string(args_[pos_++]); return evaluate_unary(op, std::string(args_[pos_++])); }
+    if (pos_ + 2 < args_.size() && is_binary_operator(std::string(args_[pos_ + 1]))) { auto left = std::string(args_[pos_++]); auto op = std::string(args_[pos_++]); auto right = std::string(args_[pos_++]); return evaluate_binary(left, op, right); }
+    return args_[pos_++].empty() ? 1 : 0;
+  }
+  bool peek(std::string_view token) const { return pos_ < args_.size() && args_[pos_] == token; }
+  std::span<const std::string> args_; size_t pos_ = 0; bool error_ = false;
+};
+
+auto evaluate_bracket_expression(std::span<const std::string> args) -> int {
+  return BracketExpressionParser(args).parse();
 }
 }  // namespace bracket_command
 

--- a/src/commands/top.cpp
+++ b/src/commands/top.cpp
@@ -861,14 +861,16 @@ auto parse_config(const CommandContext<TOP_OPTIONS.size()>& ctx)
 auto check_help_version(const CommandContext<TOP_OPTIONS.size()>& ctx)
     -> cp::Result<bool> {
   if (ctx.get<bool>("--help", false)) {
-    safePrint("Usage: top [options]\n");
-    safePrint("  -b, --batch        Batch mode\n");
-    safePrint("  -d, --delay DELAY  Update interval (default: 3s)\n");
-    safePrint("  -n, --iterations N Exit after N iterations\n");
-    safePrint("  -o, --field-sort F Sort by CPU|MEM|TIME|PID|NAME\n");
-    safePrint("      --rows N       Limit number of displayed processes\n");
-    safePrint("      --help         Show help\n");
-    safePrint("  -v, --version      Show version\n");
+    const std::string help =
+        "Usage: top [options]\n"
+        "  -b, --batch        Batch mode\n"
+        "  -d, --delay DELAY  Update interval (default: 3s)\n"
+        "  -n, --iterations N Exit after N iterations\n"
+        "  -o, --field-sort F Sort by CPU|MEM|TIME|PID|NAME\n"
+        "      --rows N       Limit number of displayed processes\n"
+        "      --help         Show help\n"
+        "  -v, --version      Show version\n";
+    safePrint(winux::i18n::translate("command.top.custom_help", help));
     return true;  // Should exit
   }
 

--- a/src/commands/tsort.cpp
+++ b/src/commands/tsort.cpp
@@ -69,8 +69,23 @@ REGISTER_COMMAND(tsort,
     }
   }
 
-  for (const auto& n : nodes) {
-    safePrintLn(n);
+  std::map<std::string, int> remaining;
+  for (const auto& n : nodes) remaining[n] = 0;
+  for (const auto& [node, deps] : graph)
+    for (const auto& dependency : deps) ++remaining[dependency];
+  std::set<std::string> ready;
+  for (const auto& [node, degree] : remaining)
+    if (degree == 0) ready.insert(node);
+  size_t emitted = 0;
+  while (!ready.empty()) {
+    auto node = *ready.begin(); ready.erase(ready.begin());
+    safePrintLn(node); ++emitted;
+    for (const auto& dependency : graph[node])
+      if (--remaining[dependency] == 0) ready.insert(dependency);
+  }
+  if (emitted != nodes.size()) {
+    safeErrorPrintLn("tsort: input contains a loop");
+    return 1;
   }
 
   return 0;

--- a/src/commands/tzset.cpp
+++ b/src/commands/tzset.cpp
@@ -22,27 +22,18 @@ auto constexpr TZSET_OPTIONS = std::array{
 namespace {
 
 void print_usage_stdout() {
-  safePrintLn("Usage: tzset [OPTION]");
-  safePrintLn("");
-  safePrintLn(
-      "Print POSIX-compatible timezone ID from current Windows timezone "
-      "setting");
-  safePrintLn("");
-  safePrintLn("Options:");
-  safePrintLn("      --help               output usage information and exit.");
-  safePrintLn(
-      "  -V, --version            output version information and exit.");
-  safePrintLn("");
-  safePrintLn(
-      "Use tzset to set your TZ variable. In POSIX-compatible shells like "
-      "bash,");
-  safePrintLn("dash, mksh, or zsh:");
-  safePrintLn("");
-  safePrintLn("      export TZ=$(tzset)");
-  safePrintLn("");
-  safePrintLn("In csh-compatible shells like tcsh:");
-  safePrintLn("");
-  safePrintLn("      setenv TZ `tzset`");
+  constexpr std::string_view help =
+      "Usage: tzset [OPTION]\n\n"
+      "Print POSIX-compatible timezone ID from current Windows timezone setting\n\n"
+      "Options:\n"
+      "      --help               output usage information and exit.\n"
+      "  -V, --version            output version information and exit.\n\n"
+      "Use tzset to set your TZ variable. In POSIX-compatible shells like bash,\n"
+      "dash, mksh, or zsh:\n\n"
+      "      export TZ=$(tzset)\n\n"
+      "In csh-compatible shells like tcsh:\n\n"
+      "      setenv TZ `tzset`\n";
+  safePrint(winux::i18n::translate("command.tzset.custom_help", help));
 }
 
 void print_usage_stderr() {

--- a/src/commands/uniq.cpp
+++ b/src/commands/uniq.cpp
@@ -129,21 +129,15 @@ auto read_source(std::string_view path) -> cp::Result<std::string> {
 auto split_records(std::string_view content, char delimiter)
     -> std::vector<std::string> {
   SmallVector<std::string, 4096> out;
-  const auto trim_record = [delimiter](std::string_view record) {
-    if (delimiter == '\n' && !record.empty() && record.back() == '\r') {
-      record.remove_suffix(1);
-    }
-    return std::string(record);
-  };
   size_t start = 0;
   for (size_t i = 0; i < content.size(); ++i) {
     if (content[i] == delimiter) {
-      out.emplace_back(trim_record(content.substr(start, i - start)));
+      out.emplace_back(content.substr(start, i - start));
       start = i + 1;
     }
   }
   if (start < content.size()) {
-    out.emplace_back(trim_record(content.substr(start)));
+    out.emplace_back(content.substr(start));
   }
   return std::vector<std::string>(out.begin(), out.end());
 }
@@ -295,36 +289,50 @@ auto emit_group_separator(std::ostream& out, const Config& cfg) -> void {
 }
 
 auto run(const Config& cfg) -> int {
-  auto content = read_source(cfg.input);
-  if (!content) {
-    cp::report_error(content, L"uniq");
-    return 1;
+  std::ifstream input_file;
+  std::istream* input = &std::cin;
+  if (cfg.input != "-") {
+    auto input_operand = native_path::make_api_path_operand(cfg.input);
+    if (input_operand.had_trailing_separator &&
+        native_path::attributes_are_regular_file(
+            native_path::attributes_w(input_operand.extended))) {
+      cp::report_custom_error(
+          L"uniq", utf8_to_wstring(cfg.input + ": Not a directory"));
+      return 1;
+    }
+    input_file = file_io::open_binary_file(cfg.input);
+    if (!input_file.is_open()) {
+      auto content = read_source(cfg.input);
+      if (!content) {
+        cp::report_error(content, L"uniq");
+        return 1;
+      }
+      cp::report_custom_error(L"uniq", L"cannot open input");
+      return 1;
+    }
+    input = &input_file;
   }
 
-  auto records = split_records(*content, cfg.delimiter);
   std::ostream* out = &std::cout;
   std::ofstream file_out;
+  int stdout_mode = -1;
   if (cfg.output != "-") {
-    file_out.open(cfg.output, std::ios::binary | std::ios::trunc);
+    file_out = file_io::create_binary_file(cfg.output);
     if (!file_out.is_open()) {
       cp::report_custom_error(L"uniq", L"cannot open output file");
       return 1;
     }
     out = &file_out;
+  } else {
+    // Keep record bytes unchanged when stdout is a Windows pipe.
+    stdout_mode = _setmode(_fileno(stdout), _O_BINARY);
   }
 
-  if (records.empty()) return 0;
-
-  size_t i = 0;
   bool first_emitted_group = false;
-  while (i < records.size()) {
-    size_t j = i + 1;
-    const auto key = comparison_key(records[i], cfg);
-    while (j < records.size() && comparison_key(records[j], cfg) == key) {
-      ++j;
-    }
-
-    const size_t count = j - i;
+  std::vector<std::string> group;
+  std::string key;
+  auto emit_group = [&](const std::vector<std::string>& records) {
+    const size_t count = records.size();
     if (should_emit(count, cfg)) {
       if (cfg.group_mode == GroupMode::separate && first_emitted_group) {
         emit_group_separator(*out, cfg);
@@ -335,17 +343,17 @@ auto run(const Config& cfg) -> int {
       }
 
       if (cfg.group_all) {
-        for (size_t k = i; k < j; ++k) {
-          emit_one(*out, records[k], count, cfg, true);
+        for (const auto& record : records) {
+          emit_one(*out, record, count, cfg, true);
         }
       } else if (count == 1) {
-        emit_one(*out, records[i], count, cfg);
+        emit_one(*out, records.front(), count, cfg);
       } else {
         if (cfg.output_first_repeated) {
-          emit_one(*out, records[i], count, cfg);
+          emit_one(*out, records.front(), count, cfg);
         }
         if (cfg.output_later_repeated) {
-          for (size_t k = i + 1; k < j; ++k) {
+          for (size_t k = 1; k < records.size(); ++k) {
             emit_one(*out, records[k], count, cfg, true);
           }
         }
@@ -357,10 +365,28 @@ auto run(const Config& cfg) -> int {
       }
       first_emitted_group = true;
     }
-    i = j;
+  };
+
+  std::string line;
+  while (std::getline(*input, line, cfg.delimiter)) {
+    auto line_key = comparison_key(line, cfg);
+    if (!group.empty() && line_key != key) {
+      emit_group(group);
+      group.clear();
+    }
+    if (group.empty()) key = std::move(line_key);
+    group.push_back(std::move(line));
+    line.clear();
   }
+  if (input->bad()) {
+    cp::report_custom_error(L"uniq", L"error reading input");
+    if (stdout_mode != -1) _setmode(_fileno(stdout), stdout_mode);
+    return 1;
+  }
+  if (!group.empty()) emit_group(group);
 
   out->flush();
+  if (stdout_mode != -1) _setmode(_fileno(stdout), stdout_mode);
   return 0;
 }
 

--- a/src/commands/unix2dos.cpp
+++ b/src/commands/unix2dos.cpp
@@ -118,18 +118,11 @@ REGISTER_COMMAND(unix2dos,
   };
 
   if (ctx.positionals.empty()) {
-    // Read from stdin, write to stdout
-    std::string line;
-    bool first = true;
-    while (std::getline(std::cin, line)) {
-      if (!first) {
-        safePrint("\r\n");
-      }
-      safePrint(line);
-      first = false;
-    }
-    if (!first) {
-      safePrint("\r\n");
+    std::string content((std::istreambuf_iterator<char>(std::cin)), {});
+    for (size_t i = 0; i < content.size(); ++i) {
+      if (content[i] == '\n' && (i == 0 || content[i - 1] != '\r'))
+        safePrint("\r");
+      safePrint(content.substr(i, 1));
     }
   } else {
     // Process each file in place

--- a/src/commands/wpm.cpp
+++ b/src/commands/wpm.cpp
@@ -2242,42 +2242,29 @@ auto show_info(const Options& opts, std::string_view name) -> int {
 }
 
 auto print_usage() -> int {
-  safePrintLn("Winux Package Manager " + std::string(kVersion));
-  safePrintLn("Usage: wpm <command> [args] [options]");
-  safePrintLn("");
-  safePrintLn("Commands:");
-  safePrintLn("  links list|rebuild|remove     manage WinuxCmd hardlinks");
-  safePrintLn("  index status|update           inspect or refresh local index");
-  safePrintLn("  source list|use|add           manage index sources");
-  safePrintLn(
-      "  list                          list indexed packages and install "
-      "state");
-  safePrintLn(
-      "  search <query>                search names, commands, categories, "
-      "licenses");
-  safePrintLn("  info <package>                show package metadata");
-  safePrintLn(
-      "  install <package>             install package from local index");
-  safePrintLn(
-      "  installed                     list packages present in this root");
-  safePrintLn(
-      "  update winuxcmd               update WinuxCmd from local index");
-  safePrintLn("");
-  safePrintLn("Options:");
-  safePrintLn(
-      "  -r, --root <dir>              manage a specific WinuxCmd root");
-  safePrintLn("  -s, --source <name>           use a specific index source");
-  safePrintLn(
-      "  -a, --all                     show index-only packages in list "
-      "output");
-  safePrintLn(
-      "  -f, --force                   overwrite existing files when safe");
-  safePrintLn(
-      "  -n, --dry-run                 show planned changes without writing");
-  safePrintLn("  -v, --verbose                 print detailed progress");
-  safePrintLn("      --help                    display this help and exit");
-  safePrintLn(
-      "  -V, --version                 output version information and exit");
+  const std::string help =
+      "Winux Package Manager " + std::string(kVersion) + "\n"
+      "Usage: wpm <command> [args] [options]\n\n"
+      "Commands:\n"
+      "  links list|rebuild|remove     manage WinuxCmd hardlinks\n"
+      "  index status|update           inspect or refresh local index\n"
+      "  source list|use|add           manage index sources\n"
+      "  list                          list indexed packages and install state\n"
+      "  search <query>                search names, commands, categories, licenses\n"
+      "  info <package>                show package metadata\n"
+      "  install <package>             install package from local index\n"
+      "  installed                     list packages present in this root\n"
+      "  update winuxcmd               update WinuxCmd from local index\n\n"
+      "Options:\n"
+      "  -r, --root <dir>              manage a specific WinuxCmd root\n"
+      "  -s, --source <name>           use a specific index source\n"
+      "  -a, --all                     show index-only packages in list output\n"
+      "  -f, --force                   overwrite existing files when safe\n"
+      "  -n, --dry-run                 show planned changes without writing\n"
+      "  -v, --verbose                 print detailed progress\n"
+      "      --help                    display this help and exit\n"
+      "  -V, --version                 output version information and exit\n";
+  safePrint(winux::i18n::translate("command.wpm.custom_help", help));
   return 0;
 }
 

--- a/src/commands/xargs.cpp
+++ b/src/commands/xargs.cpp
@@ -1193,6 +1193,9 @@ REGISTER_COMMAND(
   if (max_procs == 1) max_procs = ctx.get<int>("-P", 1);
   int max_chars = ctx.get<int>("--max-chars", 0);
   if (max_chars == 0) max_chars = ctx.get<int>("-s", 0);
+  // Windows CreateProcess has a finite command-line limit.  GNU xargs
+  // batches by default, so an omitted -s must still enforce that limit.
+  if (max_chars == 0) max_chars = kWindowsCommandLineLimit;
   bool exit_if_exceeded =
       ctx.get<bool>("--exit", false) || ctx.get<bool>("-x", false);
   bool show_limits = ctx.get<bool>("--show-limits", false);

--- a/src/commands/xxd.cpp
+++ b/src/commands/xxd.cpp
@@ -62,6 +62,53 @@ std::string offset_hex(size_t offset) {
   return std::string(buf);
 }
 
+std::optional<unsigned char> parse_hex_byte(char high, char low) {
+  auto digit = [](char c) -> int {
+    if (c >= '0' && c <= '9') return c - '0';
+    if (c >= 'a' && c <= 'f') return c - 'a' + 10;
+    if (c >= 'A' && c <= 'F') return c - 'A' + 10;
+    return -1;
+  };
+  int h = digit(high), l = digit(low);
+  if (h < 0 || l < 0) return std::nullopt;
+  return static_cast<unsigned char>((h << 4) | l);
+}
+
+std::optional<std::vector<unsigned char>> reverse_xxd(
+    const std::vector<unsigned char>& input) {
+  std::string text(input.begin(), input.end());
+  std::vector<unsigned char> output;
+  size_t line_start = 0;
+  while (line_start <= text.size()) {
+    size_t line_end = text.find('\n', line_start);
+    if (line_end == std::string::npos) line_end = text.size();
+    std::string_view line(text.data() + line_start, line_end - line_start);
+    size_t colon = line.find(':');
+    if (colon != std::string_view::npos) line.remove_prefix(colon + 1);
+    size_t pos = 0;
+    while (pos < line.size()) {
+      while (pos < line.size() && std::isspace(static_cast<unsigned char>(line[pos]))) ++pos;
+      size_t token_start = pos;
+      while (pos < line.size() && !std::isspace(static_cast<unsigned char>(line[pos]))) ++pos;
+      auto token = line.substr(token_start, pos - token_start);
+      if (token.empty()) continue;
+      if (token.size() % 2 != 0) break;
+      std::vector<unsigned char> token_bytes;
+      bool valid = true;
+      for (size_t i = 0; i < token.size(); i += 2) {
+        auto byte = parse_hex_byte(token[i], token[i + 1]);
+        if (!byte) { valid = false; break; }
+        token_bytes.push_back(*byte);
+      }
+      if (!valid) break;
+      output.insert(output.end(), token_bytes.begin(), token_bytes.end());
+    }
+    if (line_end == text.size()) break;
+    line_start = line_end + 1;
+  }
+  return output;
+}
+
 void print_default_xxd(const std::vector<unsigned char>& data) {
   constexpr size_t kColumns = 16;
   for (size_t offset = 0; offset < data.size(); offset += kColumns) {
@@ -102,8 +149,23 @@ REGISTER_COMMAND(xxd,
       ctx.get<bool>("-r", false) || ctx.get<bool>("--reverse", false);
 
   if (reverse) {
-    safeErrorPrintLn("xxd: reverse mode not fully implemented");
-    return 1;
+    std::string filename = ctx.positionals.empty() ? "-" : std::string(ctx.positionals[0]);
+    std::vector<unsigned char> input;
+    if (filename == "-") input = read_stdin_bytes();
+    else {
+      auto file_data = read_file_bytes(filename);
+      if (!file_data) { safeErrorPrintLn("xxd: cannot open " + filename); return 1; }
+      input = std::move(*file_data);
+    }
+    auto decoded = reverse_xxd(input);
+    if (!decoded) { safeErrorPrintLn("xxd: invalid hex dump"); return 1; }
+    HANDLE out = GetStdHandle(STD_OUTPUT_HANDLE);
+    if (!decoded->empty()) {
+      DWORD written = 0;
+      if (!WriteFile(out, decoded->data(), static_cast<DWORD>(decoded->size()),
+                     &written, nullptr) || written != decoded->size()) return 1;
+    }
+    return 0;
   }
 
   std::string filename =

--- a/src/core/cmd_meta.cppm
+++ b/src/core/cmd_meta.cppm
@@ -86,6 +86,28 @@ auto trim_right_ascii(std::string_view value) -> std::string_view {
   return value;
 }
 
+// Help text is UTF-8, so a byte-based fallback wrap must not split a
+// multi-byte code point. The normal space-based break is already safe.
+auto utf8_boundary_at_or_before(std::string_view value, size_t position)
+    -> size_t {
+  position = std::min(position, value.size());
+  size_t boundary = 0;
+  while (boundary < position) {
+    const auto lead = static_cast<unsigned char>(value[boundary]);
+    size_t length = 1;
+    if ((lead & 0xE0) == 0xC0) {
+      length = 2;
+    } else if ((lead & 0xF0) == 0xE0) {
+      length = 3;
+    } else if ((lead & 0xF8) == 0xF0) {
+      length = 4;
+    }
+    if (boundary + length > position) return boundary;
+    boundary += length;
+  }
+  return boundary;
+}
+
 auto append_wrapped_line(std::string& out, std::string_view line,
                          size_t continuation_indent, size_t text_width,
                          bool indent_first_line) -> void {
@@ -98,6 +120,13 @@ auto append_wrapped_line(std::string& out, std::string_view line,
     if (break_pos == std::string_view::npos || break_pos == 0) {
       break_pos = text_width;
       broke_on_space = false;
+    }
+    if (!broke_on_space) {
+      break_pos = utf8_boundary_at_or_before(line, break_pos);
+      if (break_pos == 0) {
+        // Keep progress guaranteed for an unusually small width.
+        break_pos = std::min(text_width, line.size());
+      }
     }
 
     if (!first_output || indent_first_line) {
@@ -226,15 +255,19 @@ auto format_help_text(std::string_view name, std::string_view synopsis,
   }
   result += "\n\n";
 
-  if (!description.empty()) {
-    result.append(description.data(), description.size());
+  const auto translated_description =
+      winux::i18n::translate("command." + std::string(name) + ".description",
+                             description);
+  if (!translated_description.empty()) {
+    result.append(translated_description.data(), translated_description.size());
     result += "\n\n";
   }
 
   std::vector<OptionMeta> display_options;
   display_options.reserve(options.size() + 2);
   for (const auto& opt : options) {
-    display_options.push_back(opt);
+    // Empty descriptions are parser sentinels, not user-facing options.
+    if (!opt.description.empty()) display_options.push_back(opt);
   }
   if (!has_option(options, "--help")) {
     display_options.emplace_back("", "--help", "display this help and exit",
@@ -257,16 +290,26 @@ auto format_help_text(std::string_view name, std::string_view synopsis,
     result += "\n";
     for (const auto& opt : display_options) {
       std::string option_str = format_option_names(opt);
+      const auto option_key =
+          (opt.long_name == "--help" || opt.long_name == "--version")
+              ? "common.option." +
+                    std::string(opt.long_name == "--help" ? "help" : "version")
+              : "command." + std::string(name) + ".option." +
+                    (opt.long_name.empty()
+                         ? std::string(opt.short_name.substr(1))
+                         : std::string(opt.long_name.substr(2)));
+      const auto translated_option =
+          winux::i18n::translate(option_key, opt.description);
 
       append_styled(result, option_str, option_style, color);
-      if (opt.description.empty()) {
+      if (translated_option.empty()) {
         result += "\n";
       } else {
         size_t padding = max_option_width + 2 - option_str.size();
         if (padding > 0) {
           result.append(padding, ' ');
         }
-        append_wrapped_description(result, opt.description,
+        append_wrapped_description(result, translated_option,
                                    max_option_width + 2, terminal_width);
       }
     }
@@ -522,6 +565,8 @@ export class CommandMetaBase {
   virtual ~CommandMetaBase() = default;
 
   virtual std::string_view name() const = 0;
+  virtual std::string_view synopsis() const = 0;
+  virtual std::string_view description() const = 0;
 
   virtual std::string get_help() const = 0;
 
@@ -540,6 +585,8 @@ class CommandMetaWrapper : public CommandMetaBase {
   CommandMetaWrapper(const CommandMeta<N>& meta) : m_meta(meta) {}
 
   std::string_view name() const override { return m_meta.name(); }
+  std::string_view synopsis() const override { return m_meta.synopsis(); }
+  std::string_view description() const override { return m_meta.description(); }
   std::string get_help() const override { return m_meta.get_help(); }
   std::string get_man() const override { return m_meta.get_man(); }
   std::string_view brief_desc() const override { return m_meta.brief_desc(); }
@@ -561,6 +608,8 @@ export class CommandMetaHandle {
       : m_ptr(std::make_unique<CommandMetaWrapper<N> >(meta)) {}
 
   std::string_view name() const { return m_ptr->name(); }
+  std::string_view synopsis() const { return m_ptr->synopsis(); }
+  std::string_view description() const { return m_ptr->description(); }
   std::string get_help() const { return m_ptr->get_help(); }
   std::string get_man() const { return m_ptr->get_man(); }
   std::string_view brief_desc() const { return m_ptr->brief_desc(); }

--- a/src/core/command_context.cppm
+++ b/src/core/command_context.cppm
@@ -26,6 +26,15 @@
 export module core:command_context;
 import :opt;
 
+export auto option_policy_for_command(std::string_view command)
+    -> OptionParsePolicy {
+  OptionParsePolicy policy;
+  policy.allow_unknown_short_options_as_positionals =
+      command == "printf" || command == "expr" || command == "test" ||
+      command == "[";
+  return policy;
+}
+
 export struct StringOptionOccurrence {
   std::string_view short_name;
   std::string_view long_name;

--- a/src/core/command_macros.h
+++ b/src/core/command_macros.h
@@ -102,7 +102,8 @@
     inline int invoke(std::span<std::string_view> args) noexcept {             \
       constexpr size_t N = option_count;                                       \
       bool ok = true;                                                          \
-      auto ctx = make_context<N>(args, meta.options(), ok);                    \
+      auto ctx = make_context<N>(args, meta.options(), ok,                  \
+                                 option_policy_for_command(cmd_name));      \
       if (!ok) {                                                               \
         if (!ctx.parse_error.empty()) {                                        \
           safeErrorPrintLn(std::string(command_name) + ": " +                  \

--- a/src/core/dispatcher.cppm
+++ b/src/core/dispatcher.cppm
@@ -737,6 +737,11 @@ auto default_standard_interception_enabled(std::span<std::string_view>)
   return true;
 }
 
+auto command_owned_help_interception_disabled(std::span<std::string_view>)
+    -> bool {
+  return false;
+}
+
 auto dispatch_wpm_help_version(const CommandEntryErased &entry,
                                std::span<std::string_view> args)
     -> std::optional<int> {
@@ -795,6 +800,13 @@ auto behavior_for(std::string_view name) -> CommandBehavior {
     behavior.standard_interception_enabled = echo_standard_interception_enabled;
   } else if (name == "wpm") {
     behavior.special_dispatch = dispatch_wpm_help_version;
+  }
+
+  // These commands own structured help output and translate it themselves.
+  // Let their handlers receive --help instead of the generic metadata path.
+  if (name == "top" || name == "mpicalc" || name == "tzset") {
+    behavior.standard_interception_enabled =
+        command_owned_help_interception_disabled;
   }
 
   return behavior;
@@ -989,4 +1001,5 @@ export class CommandRegistry {
   static std::string getManPage(std::string_view cmdName) noexcept {
     return getImpl().man(cmdName);
   }
+
 };

--- a/src/core/opt.cppm
+++ b/src/core/opt.cppm
@@ -119,6 +119,9 @@ export struct OptionParsePolicy {
   bool allow_short_option_clusters = true;
   bool allow_short_attached_values = true;
   bool allow_optional_short_attached_values = true;
+  // Some utilities accept operands such as -5 or -n after their syntax
+  // establishes that the remaining arguments are operands.
+  bool allow_unknown_short_options_as_positionals = false;
 };
 
 export ParseResultRuntime parse_command_runtime(
@@ -392,6 +395,20 @@ export ParseResultRuntime parse_command_runtime(
         }
 
         continue;
+      }
+
+      if (policy.allow_unknown_short_options_as_positionals) {
+        bool has_registered_short_name = false;
+        for (const auto& m : metas) {
+          if (m.short_name == arg) {
+            has_registered_short_name = true;
+            break;
+          }
+        }
+        if (!has_registered_short_name) {
+          result.positionals.push_back(arg);
+          continue;
+        }
       }
 
       if (policy.allow_numeric_short_options && arg.size() > 1 &&

--- a/src/utils/file_io.cppm
+++ b/src/utils/file_io.cppm
@@ -67,6 +67,18 @@ auto read_handle_to_string(HANDLE file, std::string_view path)
 
 export namespace file_io {
 
+export auto open_binary_file(std::string_view filename) -> std::ifstream {
+  auto operand = native_path::make_api_path_operand(filename);
+  return std::ifstream(std::filesystem::path(operand.extended),
+                       std::ios::binary);
+}
+
+export auto create_binary_file(std::string_view filename) -> std::ofstream {
+  auto operand = native_path::make_api_path_operand(filename);
+  return std::ofstream(std::filesystem::path(operand.extended),
+                       std::ios::binary | std::ios::trunc);
+}
+
 auto read_all_stdin() -> std::expected<std::string, std::string> {
   std::string content;
   std::array<char, kReadChunkSize> buffer{};

--- a/src/utils/i18n.cppm
+++ b/src/utils/i18n.cppm
@@ -1,0 +1,97 @@
+module;
+
+#include <windows.h>
+
+export module utils:i18n;
+
+import std;
+import :json;
+
+namespace winux::i18n {
+
+namespace {
+std::filesystem::path executable_root() {
+  std::wstring buffer(MAX_PATH, L'\0');
+  DWORD size = GetModuleFileNameW(nullptr, buffer.data(),
+                                  static_cast<DWORD>(buffer.size()));
+  while (size == buffer.size()) {
+    buffer.resize(buffer.size() * 2, L'\0');
+    size = GetModuleFileNameW(nullptr, buffer.data(),
+                              static_cast<DWORD>(buffer.size()));
+  }
+  buffer.resize(size);
+  auto path = std::filesystem::path(buffer);
+  return path.has_parent_path() ? path.parent_path() : std::filesystem::current_path();
+}
+
+std::string environment_value(const char* name) {
+  const char* value = std::getenv(name);
+  return value ? std::string(value) : std::string{};
+}
+
+std::string normalize_locale(std::string locale) {
+  for (char& ch : locale) {
+    if (ch == '_') ch = '-';
+  }
+  return locale;
+}
+
+std::optional<nlohmann::json> read_catalog(const std::filesystem::path& path) {
+  std::ifstream input(path, std::ios::binary);
+  if (!input.is_open()) return std::nullopt;
+  std::string text{std::istreambuf_iterator<char>(input),
+                   std::istreambuf_iterator<char>{}};
+  try {
+    auto catalog = nlohmann::json::parse(text);
+    if (!catalog.is_object() || !catalog.value("messages", nlohmann::json::object()).is_object()) {
+      return std::nullopt;
+    }
+    return catalog;
+  } catch (const std::exception&) {
+    return std::nullopt;
+  }
+}
+
+struct Catalog {
+  bool enabled = false;
+  std::string locale;
+  nlohmann::json messages = nlohmann::json::object();
+};
+
+const Catalog& catalog() {
+  static const Catalog loaded = [] {
+    Catalog result;
+    result.locale = normalize_locale(environment_value("WINUX_LANG"));
+    if (result.locale.empty() || result.locale == "off" ||
+        result.locale == "none" || result.locale == "C") {
+      result.locale.clear();
+      return result;
+    }
+    result.enabled = true;
+
+    auto root = executable_root() / ".wpm" / "i18n";
+    auto path = root / result.locale / "catalog.json";
+    auto parsed = read_catalog(path);
+    if (!parsed && result.locale.find('-') != std::string::npos) {
+      auto language = result.locale.substr(0, result.locale.find('-'));
+      parsed = read_catalog(root / language / "catalog.json");
+    }
+    if (parsed) result.messages = std::move(*parsed)["messages"];
+    return result;
+  }();
+  return loaded;
+}
+}  // namespace
+
+export std::string locale() { return catalog().locale; }
+
+export std::string translate(std::string_view key, std::string_view fallback) {
+  const auto& messages = catalog().messages;
+  auto it = messages.find(std::string(key));
+  if (it == messages.end() || !it->is_string()) return std::string(fallback);
+  return it->get<std::string>();
+}
+
+export bool has_catalog() { return !catalog().messages.empty(); }
+
+}  // namespace winux::i18n

--- a/src/utils/native_path.cppm
+++ b/src/utils/native_path.cppm
@@ -168,7 +168,11 @@ export auto make_api_path_operand(std::string_view path) -> ApiPathOperand {
 }
 
 export auto attributes_w(std::wstring_view path) -> DWORD {
-  std::wstring native(path);
+  // Keep all attribute probes on the same extended-path API boundary as
+  // file_io. This avoids MAX_PATH failures for otherwise valid paths.
+  const std::wstring native =
+      path.starts_with(L"\\\\?\\") ? std::wstring(path)
+                                      : to_extended_path(path);
   return GetFileAttributesW(native.c_str());
 }
 

--- a/src/utils/text_io.cppm
+++ b/src/utils/text_io.cppm
@@ -31,28 +31,6 @@ import :utf8;
 namespace {
 enum class EncodingHint { Utf8, Utf16Le, Utf16Be };
 
-auto guess_utf16_from_nuls(std::string_view bytes)
-    -> std::optional<EncodingHint> {
-  if (bytes.size() < 2) return std::nullopt;
-
-  size_t even_nul = 0;
-  size_t odd_nul = 0;
-  for (size_t i = 0; i < bytes.size(); ++i) {
-    if (bytes[i] != '\0') continue;
-    if ((i & 1U) == 0U)
-      ++even_nul;
-    else
-      ++odd_nul;
-  }
-
-  const size_t threshold = bytes.size() / 4;
-  if (odd_nul > threshold && odd_nul > even_nul * 2)
-    return EncodingHint::Utf16Le;
-  if (even_nul > threshold && even_nul > odd_nul * 2)
-    return EncodingHint::Utf16Be;
-  return std::nullopt;
-}
-
 auto decode_utf16(std::string_view bytes, bool little_endian) -> std::string {
   std::wstring wide;
   wide.reserve(bytes.size() / 2);
@@ -90,8 +68,6 @@ export auto read_text_stream(std::istream& in) -> std::string {
   } else if (bytes.size() >= 2 && static_cast<std::uint8_t>(bytes[0]) == 0xFE &&
              static_cast<std::uint8_t>(bytes[1]) == 0xFF) {
     encoding = EncodingHint::Utf16Be;
-  } else if (auto guessed = guess_utf16_from_nuls(bytes); guessed.has_value()) {
-    encoding = *guessed;
   }
 
   if (encoding == EncodingHint::Utf16Le) return decode_utf16(bytes, true);

--- a/src/utils/utils.cppm
+++ b/src/utils/utils.cppm
@@ -33,6 +33,7 @@ export import :wildcard;
 export import :path;
 export import :native_path;
 export import :json;
+export import :i18n;
 export import :file_io;
 export import :cppbar;
 export import :encoding;

--- a/src/utils/win32.cppm
+++ b/src/utils/win32.cppm
@@ -14,6 +14,7 @@
 module;
 
 #include "pch/pch.h"
+#include <aclapi.h>
 
 export module utils:win32;
 
@@ -299,6 +300,28 @@ export auto win32_account_from_sid(PSID sid) -> Win32AccountInfo {
                            .name = win32_account_name_from_sid(sid)};
   if (account.id.empty()) account.id = "0";
   return account;
+}
+
+export struct Win32FileAccounts {
+  Win32AccountInfo owner;
+  Win32AccountInfo group;
+};
+
+export auto win32_file_accounts(std::wstring_view path) -> Win32FileAccounts {
+  PSID owner_sid = nullptr;
+  PSID group_sid = nullptr;
+  PSECURITY_DESCRIPTOR descriptor = nullptr;
+  const auto status = GetNamedSecurityInfoW(
+      const_cast<wchar_t*>(path.data()), SE_FILE_OBJECT,
+      OWNER_SECURITY_INFORMATION | GROUP_SECURITY_INFORMATION, &owner_sid,
+      &group_sid, nullptr, nullptr, &descriptor);
+  if (status != ERROR_SUCCESS) return {};
+
+  Win32FileAccounts accounts;
+  if (owner_sid) accounts.owner = win32_account_from_sid(owner_sid);
+  if (group_sid) accounts.group = win32_account_from_sid(group_sid);
+  if (descriptor) LocalFree(descriptor);
+  return accounts;
 }
 
 export auto win32_lookup_account(std::wstring_view name)

--- a/tests/differential/README.md
+++ b/tests/differential/README.md
@@ -1,0 +1,7 @@
+# GNU differential regression tests
+
+This directory contains independent cases for comparing WinuxCmd with a GNU
+coreutils oracle. Set `WINUXCMD_BIN` and `GNU_BIN` when they are not on PATH.
+
+Each case supports `cmd`, `args`, `stdin`, `setup`, `timeout`, `source`, and
+`tags`. `stdin` and `setup` use a following block indented by two spaces.

--- a/tests/differential/baseline.json
+++ b/tests/differential/baseline.json
@@ -1,0 +1,5 @@
+{
+  "oracle": "",
+  "generated_at": "",
+  "cases": {}
+}

--- a/tests/differential/corpus/cat/basic.case
+++ b/tests/differential/corpus/cat/basic.case
@@ -1,0 +1,6 @@
+cmd: cat
+args: input.txt
+setup: |
+  printf 'alpha\nbeta\n' > input.txt
+source: tests/differential/corpus/cat/basic.case:1
+tags: literal

--- a/tests/differential/corpus/head/positive-offset.case
+++ b/tests/differential/corpus/head/positive-offset.case
@@ -1,0 +1,6 @@
+cmd: head
+args: -n +2 input.txt
+setup: |
+  printf 'one\ntwo\nthree\n' > input.txt
+source: tests/differential/corpus/head/positive-offset.case:1
+tags: regression

--- a/tests/differential/corpus/split/no-overlap.case
+++ b/tests/differential/corpus/split/no-overlap.case
@@ -1,0 +1,6 @@
+cmd: split
+args: -n 2 input.txt part
+setup: |
+  printf 'one\ntwo\nthree\nfour\n' > input.txt
+source: tests/differential/corpus/split/no-overlap.case:1
+tags: regression

--- a/tests/differential/runner.sh
+++ b/tests/differential/runner.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+set -u
+
+ROOT=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+CORPUS="$ROOT/corpus"
+ONLY=""
+REPORT="$ROOT/report.md"
+WINUXCMD_BIN="${WINUXCMD_BIN:-}"
+WINUXCMD_EXE="${WINUXCMD_EXE:-winuxcmd.exe}"
+GNU_BIN="${GNU_BIN:-}"
+
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --corpus) CORPUS=$2; shift 2 ;;
+    --report) REPORT=$2; shift 2 ;;
+    --only) ONLY=$2; shift 2 ;;
+    -h|--help) printf '%s\n' 'runner.sh [--corpus DIR] [--report FILE] [--only CMD]'; exit 0 ;;
+    *) exit 2 ;;
+  esac
+done
+
+find_oracle() {
+  if [ -n "$GNU_BIN" ] && [ -x "$GNU_BIN/$1" ]; then printf '%s/%s' "$GNU_BIN" "$1"; else command -v "$1" 2>/dev/null || true; fi
+}
+
+run_case() {
+  local case_file=$1 work line block cmd args timeout setup stdin
+  work=$(mktemp -d) || return 2
+  cmd=""; args=""; timeout=10; setup=""; stdin=""; block=""
+  while IFS= read -r line || [ -n "$line" ]; do
+    if [ -n "$block" ]; then
+      if [[ "$line" == "  "* ]]; then
+        if [ "$block" = setup ]; then setup+="${line#  }\n"; else stdin+="${line#  }\n"; fi
+        continue
+      fi
+      block=""
+    fi
+    case "$line" in
+      cmd:*) cmd=${line#cmd: };;
+      args:*) args=${line#args: };;
+      timeout:*) timeout=${line#timeout: };;
+      setup:\ \|) block=setup;;
+      stdin:\ \|) block=stdin;;
+    esac
+  done < "$case_file"
+  if [ -z "$cmd" ]; then rm -rf "$work"; echo "SKIP missing cmd: $case_file"; return 0; fi
+  [ -z "$setup" ] || (cd "$work" && printf '%b' "$setup" | sh)
+  local wout="$work/w.out" gout="$work/g.out" wrc grc wcmd gcmd bucket
+  wcmd="$WINUXCMD_EXE"; [ -n "$WINUXCMD_BIN" ] && wcmd="$WINUXCMD_BIN/$WINUXCMD_EXE"
+  gcmd=$(find_oracle "$cmd")
+  if [ ! -x "$gcmd" ]; then rm -rf "$work"; echo "SKIP no GNU oracle for $cmd"; return 0; fi
+  printf '%b' "$stdin" | MSYS2_ARG_CONV_EXCL='*' MSYS_NO_PATHCONV=1 timeout "$timeout" "$wcmd" $args >"$wout" 2>/dev/null; wrc=$?
+  printf '%b' "$stdin" | MSYS2_ARG_CONV_EXCL='*' MSYS_NO_PATHCONV=1 timeout "$timeout" "$gcmd" $args >"$gout" 2>/dev/null; grc=$?
+  if [ "$wrc" -ne "$grc" ]; then bucket=EXIT_DIFF; elif cmp -s "$wout" "$gout"; then bucket=PASS; elif [ "$(tr -d '\r' < "$wout")" = "$(tr -d '\r' < "$gout")" ]; then bucket=CRLF_DIFF; else bucket=OUT_DIFF; fi
+  printf '%s\t%s\n' "${case_file#$ROOT/}" "$bucket"
+  rm -rf "$work"
+}
+
+oracle=$({ find_oracle coreutils --version || true; } | head -1 | tr -d '\r')
+printf '# Differential report\n\nOracle: `%s`\n\n| Case | Result |\n|---|---|\n' "$oracle" > "$REPORT"
+results=$(mktemp)
+find "$CORPUS" -type f -name '*.case' | sort | while IFS= read -r file; do
+  [ -n "$ONLY" ] && [ "$(basename "$(dirname "$file")")" != "$ONLY" ] && continue
+  run_case "$file"
+done | tee "$results" >> "$REPORT"
+printf '\n## Summary\n\n' >> "$REPORT"
+awk -F '\t' '{ total++; count[$2]++ } END { for (k in count) printf "- %s: %d/%d\n", k, count[k], total }' "$results" >> "$REPORT"
+rm -f "$results"

--- a/tests/differential/whitelist.txt
+++ b/tests/differential/whitelist.txt
@@ -1,0 +1,1 @@
+# case path<TAB>reason

--- a/tests/unit/cp/cp_unit_test.cpp
+++ b/tests/unit/cp/cp_unit_test.cpp
@@ -49,6 +49,34 @@ TEST(cp, cp_basic_copy) {
   EXPECT_EQ(dest_content, "hello world");
 }
 
+TEST(cp, cp_empty_file_succeeds) {
+  TempDir tmp;
+  tmp.write("empty.txt", "");
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"cp.exe", {L"empty.txt", L"copy.txt"});
+
+  auto r = p.run();
+
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_TRUE(std::filesystem::exists(tmp.path / "copy.txt"));
+  EXPECT_EQ(tmp.read("copy.txt"), "");
+}
+
+TEST(cp, cp_link_creates_hard_link) {
+  TempDir tmp;
+  tmp.write("source.txt", "payload");
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"cp.exe", {L"-l", L"source.txt", L"dest.txt"});
+  auto r = p.run();
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_EQ(tmp.read("dest.txt"), "payload");
+  tmp.write("source.txt", "changed");
+  EXPECT_EQ(tmp.read("dest.txt"), "changed");
+}
+
 TEST(cp, cp_copy_multiple_files) {
   TempDir tmp;
   tmp.write("file1.txt", "content1");

--- a/tests/unit/cut/cut_unit_test.cpp
+++ b/tests/unit/cut/cut_unit_test.cpp
@@ -13,6 +13,17 @@ TEST(cut, cut_basic_fields_default_tab) {
   EXPECT_EQ_TEXT(r.stdout_text, "a\tc\n1\t3\n");
 }
 
+TEST(cut, cut_undelimited_record_is_emitted_once) {
+  TempDir tmp;
+  tmp.write("a.txt", "a\tb\nnodelim\n");
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"cut.exe", {L"-f1-2", L"a.txt"});
+  auto r = p.run();
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_EQ_TEXT(r.stdout_text, "a\tb\nnodelim\n");
+}
+
 TEST(cut, cut_with_delimiter_and_range) {
   TempDir tmp;
   tmp.write("a.txt", "x,y,z\nm,n,o\n");

--- a/tests/unit/date/date_unit_test.cpp
+++ b/tests/unit/date/date_unit_test.cpp
@@ -43,6 +43,14 @@ TEST(date, date_basic) {
   EXPECT_FALSE(r.stdout_text.empty());
 }
 
+TEST(date, date_relative_day_is_accepted) {
+  Pipeline p;
+  p.add(L"date.exe", {L"-u", L"--date", L"+1 day", L"+%s"});
+  auto r = p.run();
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_FALSE(r.stdout_text.empty());
+}
+
 TEST(date, date_format) {
   TempDir tmp;
 

--- a/tests/unit/diff/diff_unit_test.cpp
+++ b/tests/unit/diff/diff_unit_test.cpp
@@ -45,6 +45,17 @@ TEST(diff, diff_identical) {
   EXPECT_TRUE(r.stdout_text.empty());
 }
 
+TEST(diff, diff_distinguishes_crlf_and_lf_without_ignore_space) {
+  TempDir tmp;
+  tmp.write_bytes("crlf.txt", {'a', '\r', '\n'});
+  tmp.write_bytes("lf.txt", {'a', '\n'});
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"diff.exe", {L"crlf.txt", L"lf.txt"});
+  auto r = p.run();
+  EXPECT_EQ(r.exit_code, 1);
+}
+
 TEST(diff, diff_different) {
   TempDir tmp;
   tmp.write("file1.txt", "hello\nworld\n");
@@ -102,6 +113,22 @@ TEST(diff, diff_unified) {
   TEST_LOG("diff unified output", r.stdout_text);
 
   EXPECT_EQ(r.exit_code, 1);
+  EXPECT_TRUE(r.stdout_text.find("@@") != std::string::npos);
+}
+
+TEST(diff, diff_unified_pure_insertion_has_valid_header) {
+  TempDir tmp;
+  tmp.write("old.txt", "one\ntwo\n");
+  tmp.write("new.txt", "one\ninserted\ntwo\n");
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"diff.exe", {L"-u", L"old.txt", L"new.txt"});
+
+  auto r = p.run();
+
+  EXPECT_EQ(r.exit_code, 1);
+  EXPECT_TRUE(r.stdout_text.find("184467") == std::string::npos);
   EXPECT_TRUE(r.stdout_text.find("@@") != std::string::npos);
 }
 

--- a/tests/unit/dos2unix/dos2unix_unit_test.cpp
+++ b/tests/unit/dos2unix/dos2unix_unit_test.cpp
@@ -18,3 +18,12 @@ TEST(dos2unix, dos2unix_from_stdin) {
   EXPECT_EQ(r.exit_code, 0);
   EXPECT_EQ_TEXT(r.stdout_text, "line1\nline2\n");
 }
+
+TEST(dos2unix, dos2unix_stdin_preserves_missing_final_newline) {
+  Pipeline p;
+  p.set_stdin("x");
+  p.add(L"dos2unix.exe", {});
+  auto r = p.run();
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_EQ(r.stdout_text, "x");
+}

--- a/tests/unit/fmt/fmt_unit_test.cpp
+++ b/tests/unit/fmt/fmt_unit_test.cpp
@@ -45,6 +45,15 @@ TEST(fmt, fmt_basic) {
   EXPECT_FALSE(r.stdout_text.empty());
 }
 
+TEST(fmt, fmt_width_is_not_exceeded_by_word_combinations) {
+  auto r = run_command(fmt_exe(), {L"-w", L"20"},
+                       "alpha beta gamma one two three\n");
+  EXPECT_EQ(r.exit_code, 0);
+  std::istringstream lines(r.stdout_text);
+  std::string line;
+  while (std::getline(lines, line)) EXPECT_LE(line.size(), 20u);
+}
+
 TEST(fmt, fmt_stdin) {
   Pipeline p;
   p.set_stdin("This is a long line that should be formatted.\n");

--- a/tests/unit/head/head_unit_test.cpp
+++ b/tests/unit/head/head_unit_test.cpp
@@ -62,6 +62,17 @@ TEST(head, head_n_and_c_options) {
   EXPECT_EQ_TEXT(r2.stdout_text, "alpha");
 }
 
+TEST(head, head_plus_count_starts_at_requested_line) {
+  TempDir tmp;
+  tmp.write("a.txt", "one\ntwo\nthree\nfour\n");
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"head.exe", {L"-n", L"+3", L"a.txt"});
+  auto r = p.run();
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_EQ_TEXT(r.stdout_text, "three\nfour\n");
+}
+
 TEST(head, head_last_count_option_wins) {
   TempDir tmp;
   tmp.write("a.txt", "alpha\nbeta\ngamma\n");

--- a/tests/unit/locale/locale_unit_test.cpp
+++ b/tests/unit/locale/locale_unit_test.cpp
@@ -72,3 +72,18 @@ TEST(locale, locale_charmaps) {
   EXPECT_FALSE(r.stdout_text.empty());
   EXPECT_TRUE(r.stdout_text.find("UTF-8") != std::string::npos);
 }
+
+TEST(locale, locale_keyword_values_are_not_full_environment_dump) {
+  Pipeline p;
+  p.add(L"locale.exe", {L"charmap"});
+  auto r = p.run();
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_EQ_TEXT(r.stdout_text, "UTF-8\n");
+
+  Pipeline days;
+  days.add(L"locale.exe", {L"abday"});
+  auto days_result = days.run();
+  EXPECT_EQ(days_result.exit_code, 0);
+  EXPECT_TRUE(days_result.stdout_text.find("Sun") != std::string::npos);
+  EXPECT_TRUE(days_result.stdout_text.find("LANG=") == std::string::npos);
+}

--- a/tests/unit/ls/ls_unit_test.cpp
+++ b/tests/unit/ls/ls_unit_test.cpp
@@ -1139,6 +1139,19 @@ TEST(ls, ls_multiple_file_operands_do_not_print_headers) {
   EXPECT_TRUE(r.stdout_text.find("\n\n") == std::string::npos);
 }
 
+TEST(ls, ls_explicit_file_operands_are_sorted) {
+  TempDir tmp;
+  tmp.write("base.txt", "base\n");
+  tmp.write("od.txt", "od\n");
+  tmp.write("cm.txt", "cm\n");
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"ls.exe", {L"-1", L"base.txt", L"od.txt", L"cm.txt"});
+  auto r = p.run();
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_EQ_TEXT(r.stdout_text, "base.txt\ncm.txt\nod.txt\n");
+}
+
 TEST(ls, ls_mixed_file_and_directory_prints_directory_header) {
   TempDir tmp;
   tmp.write("top.txt", "top");

--- a/tests/unit/numfmt/numfmt_unit_test.cpp
+++ b/tests/unit/numfmt/numfmt_unit_test.cpp
@@ -29,6 +29,15 @@ TEST(numfmt, numfmt_from_iec) {
   EXPECT_TRUE(r.stdout_text.find("2097152") != std::string::npos);
 }
 
+TEST(numfmt, numfmt_auto_uses_decimal_for_large_suffixes) {
+  Pipeline p;
+  p.set_stdin("1T\n");
+  p.add(L"numfmt.exe", {L"--from=auto"});
+  auto r = p.run();
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_TRUE(r.stdout_text.find("1000000000000") != std::string::npos);
+}
+
 TEST(numfmt, numfmt_to_iec) {
   Pipeline p;
   p.set_stdin("1536\n2097152\n");
@@ -38,6 +47,33 @@ TEST(numfmt, numfmt_to_iec) {
   EXPECT_EQ(r.exit_code, 0);
   EXPECT_TRUE(r.stdout_text.find("1.5K") != std::string::npos);
   EXPECT_TRUE(r.stdout_text.find("2.0M") != std::string::npos);
+}
+
+TEST(numfmt, numfmt_to_iec_i_and_selected_field) {
+  Pipeline p;
+  p.set_stdin("value 1500\n");
+  p.add(L"numfmt.exe", {L"--to=iec-i", L"--delimiter= ", L"--field=2"});
+  auto r = p.run();
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_EQ_TEXT(r.stdout_text, "value 1.5Ki\n");
+}
+
+TEST(numfmt, numfmt_to_si_uses_decimal_scaling) {
+  Pipeline p;
+  p.set_stdin("1500\n");
+  p.add(L"numfmt.exe", {L"--to=si"});
+  auto r = p.run();
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_EQ(r.stdout_text, "1.5k\n");
+}
+
+TEST(numfmt, numfmt_format_preserves_numeric_value) {
+  Pipeline p;
+  p.set_stdin("42\n");
+  p.add(L"numfmt.exe", {L"--format=%05.1f"});
+  auto r = p.run();
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_EQ(r.stdout_text, "042.0\n");
 }
 
 TEST(numfmt, numfmt_round_up) {

--- a/tests/unit/patch/patch_unit_test.cpp
+++ b/tests/unit/patch/patch_unit_test.cpp
@@ -25,3 +25,26 @@ TEST(patch, patch_basic) {
   EXPECT_EQ(r.exit_code, 0);
   EXPECT_EQ_TEXT(tmp.read("file.txt"), "world\n");
 }
+
+TEST(patch, patch_multiple_hunks_use_cumulative_offsets) {
+  TempDir tmp;
+  tmp.write("file.txt", "a\nb\nc\nd\n");
+  std::string patch_data =
+      "--- file.txt\t2026-08-13 00:00:00\n"
+      "+++ file.txt\t2026-08-13 00:00:01\n"
+      "@@ -1,1 +1,2 @@\n"
+      " a\n"
+      "+x\n"
+      "@@ -3,1 +4,1 @@\n"
+      "-c\n"
+      "+z\n";
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.set_stdin(patch_data);
+  p.add(L"patch.exe", {});
+  auto r = p.run();
+  TEST_LOG("patch multi stdout", r.stdout_text);
+  TEST_LOG("patch multi stderr", r.stderr_text);
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_EQ_TEXT(tmp.read("file.txt"), "a\nx\nb\nz\nd\n");
+}

--- a/tests/unit/printf/printf_unit_test.cpp
+++ b/tests/unit/printf/printf_unit_test.cpp
@@ -114,3 +114,11 @@ TEST(printf, printf_warns_for_invalid_numeric_conversion) {
   EXPECT_NE(r.stderr_text.find("value not completely converted"),
             std::string::npos);
 }
+
+TEST(printf, printf_dynamic_width_precision_and_shell_quote) {
+  Pipeline p;
+  p.add(L"printf.exe", {L"|%*d|%.*f|%q|", L"5", L"42", L"2", L"3.14159", L"a b"});
+  auto r = p.run();
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_EQ_TEXT(r.stdout_text, "|   42|3.14|a\\ b|");
+}

--- a/tests/unit/ptx/ptx_unit_test.cpp
+++ b/tests/unit/ptx/ptx_unit_test.cpp
@@ -60,6 +60,20 @@ TEST(ptx, ptx_file_input) {
   EXPECT_EQ(r.exit_code, 0);
 }
 
+TEST(ptx, ptx_context_does_not_cross_line_boundaries) {
+  TempDir tmp;
+  tmp.write("a.txt", "alpha one\nbeta two\n");
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"ptx.exe", {L"-w", L"80", L"a.txt"});
+  auto r = p.run();
+
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_TRUE(r.stdout_text.find("alpha one beta") == std::string::npos);
+  EXPECT_TRUE(r.stdout_text.find("beta two alpha") == std::string::npos);
+}
+
 TEST(ptx, ptx_auto_reference) {
   TempDir tmp;
   tmp.write("a.txt", "hello world\nfoo bar\n");

--- a/tests/unit/shred/shred_unit_test.cpp
+++ b/tests/unit/shred/shred_unit_test.cpp
@@ -102,3 +102,17 @@ TEST(shred, shred_nonexistent_file) {
 
   EXPECT_NE(r.exit_code, 0);
 }
+
+TEST(shred, shred_zero_size_does_not_modify_file) {
+  TempDir tmp;
+  tmp.write("data.txt", "must remain intact");
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"shred.exe", {L"-s", L"0", L"-n", L"1", L"data.txt"});
+
+  auto r = p.run();
+
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_EQ(tmp.read("data.txt"), "must remain intact");
+}

--- a/tests/unit/sort/sort_unit_test.cpp
+++ b/tests/unit/sort/sort_unit_test.cpp
@@ -54,7 +54,7 @@ TEST(sort, sort_missing_file_reports_gnu_shaped_read_error) {
       std::string::npos);
 }
 
-TEST(sort, sort_strips_cr_from_crlf_input_records) {
+TEST(sort, sort_preserves_crlf_input_records) {
   TempDir tmp;
   tmp.write_bytes("a.txt",
                   {'p',  'e',  'a', 'r', '\r', '\n', 'a', 'p', 'p',  'l', 'e',
@@ -66,7 +66,8 @@ TEST(sort, sort_strips_cr_from_crlf_input_records) {
   auto r = p.run();
 
   EXPECT_EQ(r.exit_code, 0);
-  EXPECT_EQ_TEXT(r.stdout_text, "apple\nbanana\npear\n");
+  EXPECT_EQ(r.stdout_text,
+            std::string("apple\r\nbanana\r\npear\r\n", 21));
 }
 
 TEST(sort, sort_numeric_reverse_unique) {
@@ -835,6 +836,19 @@ TEST(sort, sort_uniq_pipeline_accepts_utf16le_stdin_with_bom) {
   EXPECT_EQ(r.exit_code, 0);
   EXPECT_TRUE(r.stdout_text.find("1 cat") != std::string::npos);
   EXPECT_TRUE(r.stdout_text.find("2 dog") != std::string::npos);
+}
+
+TEST(sort, sort_preserves_nul_dense_input_without_encoding_bom) {
+  TempDir tmp;
+  tmp.write_bytes("binary.dat", {'b', '\0', 'x', '\n', 'a', '\0', 'y', '\n'});
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"sort.exe", {L"binary.dat"});
+  auto r = p.run();
+
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_EQ(r.stdout_text, std::string("a\0y\nb\0x\n", 8));
 }
 
 TEST(sort, sort_wildcard) {

--- a/tests/unit/split/split_unit_test.cpp
+++ b/tests/unit/split/split_unit_test.cpp
@@ -122,6 +122,25 @@ TEST(split, split_number_line_mode_preserves_crlf_records) {
   EXPECT_EQ_TEXT(tmp.read("partab"), "b\r\nc\r\n");
 }
 
+TEST(split, split_number_mode_reassembles_without_overlap) {
+  TempDir tmp;
+  const std::string input = "line01\nline02\nline03\nline04\nline05\n";
+  tmp.write("input.txt", input);
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"split.exe", {L"-n", L"4", L"input.txt", L"part"});
+
+  auto r = p.run();
+
+  EXPECT_EQ(r.exit_code, 0);
+  std::string rebuilt;
+  for (const char *suffix : {"aa", "ab", "ac", "ad"}) {
+    rebuilt += tmp.read(std::string("part") + suffix);
+  }
+  EXPECT_EQ(rebuilt, input);
+}
+
 TEST(split, split_number_k_of_n_mode_is_rejected) {
   TempDir tmp;
   tmp.write("input.txt", "line1\nline2\n");

--- a/tests/unit/stat/stat_unit_test.cpp
+++ b/tests/unit/stat/stat_unit_test.cpp
@@ -158,7 +158,7 @@ TEST(stat, stat_format_common_fields) {
   TEST_LOG("stat common fields output", r.stdout_text);
 
   EXPECT_EQ(r.exit_code, 0);
-  EXPECT_TRUE(r.stdout_text.starts_with("regular file|666|-rw-rw-rw-|"));
+  EXPECT_TRUE(r.stdout_text.starts_with("regular file|644|-rw-r--r--|"));
   EXPECT_TRUE(r.stdout_text.ends_with("\n"));
 
   auto last_separator = r.stdout_text.find_last_of('|');

--- a/tests/unit/stdbuf/stdbuf_unit_test.cpp
+++ b/tests/unit/stdbuf/stdbuf_unit_test.cpp
@@ -82,7 +82,7 @@ TEST(stdbuf, stdbuf_accepts_bare_binary_suffix) {
   EXPECT_EQ(r.exit_code, 0);
 }
 
-TEST(stdbuf, stdbuf_rejects_line_buffered_stdin) {
+TEST(stdbuf, stdbuf_accepts_line_buffered_stdin) {
   Pipeline p;
   p.add(L"stdbuf.exe", {L"-iL", L"echo.exe", L"test"});
 
@@ -93,8 +93,8 @@ TEST(stdbuf, stdbuf_rejects_line_buffered_stdin) {
   TEST_LOG_EXIT_CODE(r);
   TEST_LOG("stdbuf stderr", r.stderr_text);
 
-  EXPECT_EQ(r.exit_code, 125);
-  EXPECT_FALSE(r.stderr_text.empty());
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_EQ_TEXT(r.stdout_text, "test\n");
 }
 
 TEST(stdbuf, stdbuf_rejects_zero_sized_buffer_mode) {

--- a/tests/unit/tac/tac_unit_test.cpp
+++ b/tests/unit/tac/tac_unit_test.cpp
@@ -154,7 +154,7 @@ TEST(tac, tac_single_line) {
   EXPECT_EQ_TEXT(r.stdout_text, "only one line\n");
 }
 
-TEST(tac, tac_newline_mode_trims_trailing_cr_from_crlf_records) {
+TEST(tac, tac_newline_mode_preserves_crlf_records) {
   TempDir tmp;
   tmp.write_bytes("crlf.txt",
                   {'l', 'i',  'n',  'e', '1', '\r', '\n', 'l', 'i',  'n', 'e',
@@ -167,7 +167,7 @@ TEST(tac, tac_newline_mode_trims_trailing_cr_from_crlf_records) {
   auto r = p.run();
 
   EXPECT_EQ(r.exit_code, 0);
-  EXPECT_EQ_TEXT(r.stdout_text, "line3\nline2\nline1\n");
+  EXPECT_EQ_TEXT(r.stdout_text, "line3\r\nline2\r\nline1\r\n");
 }
 
 TEST(tac, tac_missing_input_reports_no_such_file) {

--- a/tests/unit/test/test_unit_test.cpp
+++ b/tests/unit/test/test_unit_test.cpp
@@ -34,3 +34,37 @@ TEST(test, test_file_not_exists) {
 
   EXPECT_EQ(r.exit_code, 1);
 }
+
+TEST(test, test_file_time_and_identity_operators) {
+  TempDir tmp;
+  tmp.write("old.txt", "old");
+  tmp.write("new.txt", "new");
+  std::error_code ec;
+  auto old_time = std::filesystem::last_write_time(tmp.path / "old.txt", ec);
+  std::filesystem::last_write_time(tmp.path / "new.txt", old_time + std::chrono::seconds(2), ec);
+
+  Pipeline newer;
+  newer.set_cwd(tmp.wpath());
+  newer.add(L"test.exe", {L"new.txt", L"-nt", L"old.txt"});
+  EXPECT_EQ(newer.run().exit_code, 0);
+
+  Pipeline older;
+  older.set_cwd(tmp.wpath());
+  older.add(L"test.exe", {L"old.txt", L"-ot", L"new.txt"});
+  EXPECT_EQ(older.run().exit_code, 0);
+
+  Pipeline same;
+  same.set_cwd(tmp.wpath());
+  same.add(L"test.exe", {L"old.txt", L"-ef", L"old.txt"});
+  EXPECT_EQ(same.run().exit_code, 0);
+}
+
+TEST(test, test_logical_precedence_and_parentheses) {
+  Pipeline p;
+  p.add(L"test.exe", {L"1", L"-eq", L"2", L"-o", L"3", L"-eq", L"3", L"-a", L"4", L"-eq", L"4"});
+  EXPECT_EQ(p.run().exit_code, 0);
+
+  Pipeline grouped;
+  grouped.add(L"test.exe", {L"(", L"1", L"-eq", L"2", L"-o", L"3", L"-eq", L"3", L")", L"-a", L"4", L"-eq", L"4"});
+  EXPECT_EQ(grouped.run().exit_code, 0);
+}

--- a/tests/unit/test_bracket/test_bracket_unit_test.cpp
+++ b/tests/unit/test_bracket/test_bracket_unit_test.cpp
@@ -28,3 +28,9 @@ TEST(test_bracket, test_bracket_numeric_false_expression) {
 
   EXPECT_EQ(r.exit_code, 1);
 }
+
+TEST(test_bracket, test_bracket_logical_precedence_and_negation) {
+  Pipeline p;
+  p.add(L"[.exe", {L"!", L"(", L"1", L"-eq", L"2", L")", L"-a", L"3", L"-eq", L"3", L"]"});
+  EXPECT_EQ(p.run().exit_code, 0);
+}

--- a/tests/unit/tsort/tsort_unit_test.cpp
+++ b/tests/unit/tsort/tsort_unit_test.cpp
@@ -17,3 +17,12 @@ TEST(tsort, tsort_basic) {
 
   EXPECT_EQ(r.exit_code, 0);
 }
+
+TEST(tsort, tsort_respects_dependency_edges) {
+  Pipeline p;
+  p.set_stdin("c b\nb a\n");
+  p.add(L"tsort.exe", {});
+  auto r = p.run();
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_EQ_TEXT(r.stdout_text, "c\nb\na\n");
+}

--- a/tests/unit/uniq/uniq_unit_test.cpp
+++ b/tests/unit/uniq/uniq_unit_test.cpp
@@ -55,7 +55,8 @@ TEST(uniq, uniq_reads_utf8_filename) {
   EXPECT_EQ_TEXT(r.stdout_text, "x\ny\n");
 }
 
-TEST(uniq, uniq_strips_cr_from_crlf_input_records) {
+TEST(uniq, uniq_preserves_crlf_input_records) {
+  // GNU uniq preserves carriage returns as input bytes.
   TempDir tmp;
   tmp.write_bytes("a.txt", {'a', '\r', '\n', 'a', '\r', '\n', 'b', '\r', '\n',
                             'a', '\r', '\n'});
@@ -66,7 +67,7 @@ TEST(uniq, uniq_strips_cr_from_crlf_input_records) {
   auto r = p.run();
 
   EXPECT_EQ(r.exit_code, 0);
-  EXPECT_EQ_TEXT(r.stdout_text, "a\nb\na\n");
+  EXPECT_EQ(r.stdout_text, "a\r\nb\r\na\r\n");
 }
 
 TEST(uniq, uniq_count) {

--- a/tests/unit/xxd/xxd_unit_test.cpp
+++ b/tests/unit/xxd/xxd_unit_test.cpp
@@ -37,3 +37,16 @@ TEST(xxd, xxd_full_line_has_no_extra_padding_or_blank_line) {
       r.stdout_text,
       "00000000: 3031 3233 3435 3637 3839 6162 6364 6566  0123456789abcdef\n");
 }
+
+TEST(xxd, xxd_reverse_decodes_hex_dump) {
+  TempDir tmp;
+  tmp.write("dump.txt", "00000000: 6865 6c6c 6f                             hello\n");
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"xxd.exe", {L"-r", L"dump.txt"});
+  auto r = p.run();
+
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_EQ(r.stdout_text, "hello");
+}


### PR DESCRIPTION
Completes the current issue-140 roundup fixes and regression coverage, including streaming/binary-safe processing, option parity, path handling, locale and buffering behavior. Includes the existing i18n foundation and differential regression scaffolding. Local validation: 2301/2301 CTest tests passed.