### PR TITLE
fix: harden wpm self update replacement

### DIFF
--- a/src/commands/wpm.cpp
+++ b/src/commands/wpm.cpp
@@ -1969,6 +1969,19 @@ auto parse_hidden_value(std::span<const std::string_view> args,
   return {};
 }
 
+auto unique_update_backup_path(const fs::path& root) -> fs::path {
+  fs::path dir = backup_dir(root);
+  std::string stem =
+      "winuxcmd-before-update-" + std::to_string(GetCurrentProcessId());
+  fs::path candidate = dir / (stem + ".exe");
+  std::error_code ec;
+  for (int suffix = 1; fs::exists(candidate, ec); ++suffix) {
+    candidate = dir / (stem + "-" + std::to_string(suffix) + ".exe");
+    ec.clear();
+  }
+  return candidate;
+}
+
 auto apply_update(std::span<const std::string_view> args) -> int {
   fs::path root = parse_hidden_value(args, "--root");
   fs::path payload = parse_hidden_value(args, "--payload");
@@ -1988,22 +2001,15 @@ auto apply_update(std::span<const std::string_view> args) -> int {
   std::error_code ec;
   fs::create_directories(backup_dir(root), ec);
   fs::path target = root / "winuxcmd.exe";
-  fs::path backup =
-      backup_dir(root) /
-      ("winuxcmd-" + std::string(WinuxCmd::VERSION_STRING) + ".exe");
+  fs::path backup = unique_update_backup_path(root);
   if (fs::exists(target, ec)) {
-    fs::copy_file(target, backup, fs::copy_options::overwrite_existing, ec);
+    fs::copy_file(target, backup, fs::copy_options::none, ec);
     if (ec) {
       safeErrorPrintLn("wpm: failed to backup winuxcmd.exe: " + ec.message());
       return 1;
     }
   }
 
-  if (remove_links(root, false) != 0) {
-    safeErrorPrintLn("wpm: failed to remove existing command links");
-    rebuild_links(root, true, false, false);
-    return 1;
-  }
   fs::copy_file(payload, target, fs::copy_options::overwrite_existing, ec);
   if (ec) {
     safeErrorPrintLn("wpm: failed to replace winuxcmd.exe: " + ec.message());

--- a/tests/unit/wpm/wpm_unit_test.cpp
+++ b/tests/unit/wpm/wpm_unit_test.cpp
@@ -483,6 +483,31 @@ TEST(wpm, wpm_links_rebuild_removes_legacy_jq_hardlink) {
   EXPECT_TRUE(std::filesystem::exists(tmp.path / L"wpm.exe"));
 }
 
+TEST(wpm, wpm_apply_update_replaces_root_and_rebuilds_links) {
+  TempDir tmp;
+  auto root_exe = tmp.path / L"winuxcmd.exe";
+  auto wpm_exe = tmp.path / L"wpm.exe";
+  auto old_payload = tmp.path / L"old-winuxcmd.exe";
+
+  tmp.write("old-winuxcmd.exe", "old exe\n");
+  std::filesystem::copy_file(old_payload, root_exe,
+                             std::filesystem::copy_options::overwrite_existing);
+  bool linked = CreateHardLinkW(wpm_exe.wstring().c_str(),
+                                root_exe.wstring().c_str(), nullptr) != 0;
+  EXPECT_TRUE(linked);
+  if (!linked) return;
+
+  auto result = run_command(
+      build_winuxcmd_path().wstring(),
+      {L"wpm", L"--", L"__apply-update", L"--root", tmp.wpath(), L"--payload",
+       build_winuxcmd_path().wstring(), L"--parent", L"0"});
+
+  EXPECT_EQ(result.exit_code, 0);
+  EXPECT_EQ(run_command(root_exe.wstring(), {L"--version"}).exit_code, 0);
+  EXPECT_TRUE(std::filesystem::exists(tmp.path / L".wpm" / L"backup"));
+  EXPECT_TRUE(same_file(root_exe, wpm_exe));
+}
+
 TEST(wpm, wpm_index_update_uses_local_file_source) {
   TempDir tmp;
   const auto index_path = tmp.path / L"fixture-index.json";


### PR DESCRIPTION
## Summary
- make self-update backups use unique pre-update filenames
- replace root winuxcmd.exe directly before rebuilding command hardlinks
- add regression coverage for hidden __apply-update replacing root and relinking wpm.exe

## Validation
- ./scripts/format.sh
- powershell.exe -NoProfile -Command "& './scripts/build-with-vs.ps1' -BuildDir winuxcmd-build-vs-codex4 -Target winuxcmd-tests -Configuration Release"
- ./winuxcmd-build-vs-codex4/tests/winuxcmd-tests.exe --gtest_filter=wpm.*