### PR TITLE
feat: expand GNU and upstream command compatibility

### DIFF
--- a/src/commands/cal.cpp
+++ b/src/commands/cal.cpp
@@ -11,7 +11,7 @@ import utils;
 import container;
 
 auto constexpr CAL_OPTIONS =
-    std::array{OPTION("", "", "display calendar", STRING_TYPE)};
+    std::array{OPTION("-m", "--monday", "start week on Monday", BOOL_TYPE)};
 
 namespace {
 constexpr int kMonthWidth = 20;
@@ -53,6 +53,10 @@ int weekdaySundayZero(int year, int month, int day) {
          7;
 }
 
+int weekdayMondayZero(int year, int month, int day) {
+  return (weekdaySundayZero(year, month, day) + 6) % 7;
+}
+
 std::string blanks(size_t count) { return std::string(count, char(32)); }
 
 std::string center(std::string_view text, size_t width) {
@@ -71,14 +75,15 @@ std::string rightAlignedDay(int day, int width) {
   return blanks(static_cast<size_t>(width) - text.size()) + text;
 }
 
-std::array<std::string, 8> monthLines(int year, int month) {
+std::array<std::string, 8> monthLines(int year, int month, bool monday_first) {
   std::array<std::string, 8> lines{};
   lines[0] = center(
       std::format("{} {:04d}", kMonthNames[static_cast<size_t>(month)], year),
       kMonthWidth);
-  lines[1] = "Su Mo Tu We Th Fr Sa";
+  lines[1] = monday_first ? "Mo Tu We Th Fr Sa Su" : "Su Mo Tu We Th Fr Sa";
 
-  int start = weekdaySundayZero(year, month, 1);
+  int start = monday_first ? weekdayMondayZero(year, month, 1)
+                            : weekdaySundayZero(year, month, 1);
   int last = daysInMonth(year, month);
   int day = 1;
   for (int week = 0; week < 6; ++week) {
@@ -99,17 +104,18 @@ void printLine(std::string_view line) {
   safePrint("\n");
 }
 
-void printMonth(int year, int month) {
-  for (const auto& line : monthLines(year, month)) printLine(line);
+void printMonth(int year, int month, bool monday_first) {
+  for (const auto& line : monthLines(year, month, monday_first)) printLine(line);
 }
 
-void printYear(int year) {
+void printYear(int year, bool monday_first) {
   printLine(center(std::format("{:04d}", year), kYearWidth));
   safePrint("\n");
   for (int first_month = 1; first_month <= 12; first_month += kYearColumns) {
     std::array<std::array<std::string, 8>, kYearColumns> months = {
-        monthLines(year, first_month), monthLines(year, first_month + 1),
-        monthLines(year, first_month + 2)};
+        monthLines(year, first_month, monday_first),
+        monthLines(year, first_month + 1, monday_first),
+        monthLines(year, first_month + 2, monday_first)};
     for (size_t line = 0; line < months[0].size(); ++line) {
       for (size_t col = 0; col < months.size(); ++col) {
         safePrint(months[col][line]);
@@ -188,10 +194,12 @@ REGISTER_COMMAND(cal,
     return 1;
   }
 
+  bool monday_first = ctx.get<bool>("--monday", false) || ctx.get<bool>("-m", false);
+
   if (whole_year) {
-    printYear(year);
+    printYear(year, monday_first);
   } else {
-    printMonth(year, month);
+    printMonth(year, month, monday_first);
   }
 
   return 0;

--- a/src/commands/cp.cpp
+++ b/src/commands/cp.cpp
@@ -361,8 +361,46 @@ auto preserve_metadata(const std::string& srcPath, const std::string& destPath)
   return true;
 }
 
+enum class BackupControl { none, simple, numbered, existing };
+
+auto backup_control_name(std::string control) -> std::string {
+  std::ranges::transform(control, control.begin(), [](unsigned char ch) {
+    return static_cast<char>(std::tolower(ch));
+  });
+  return control;
+}
+
+auto parse_backup_control(std::string control) -> cp::Result<BackupControl> {
+  control = backup_control_name(std::move(control));
+  if (control.empty() || control == "existing" || control == "nil") {
+    return BackupControl::existing;
+  }
+  if (control == "none" || control == "off") {
+    return BackupControl::none;
+  }
+  if (control == "simple" || control == "never") {
+    return BackupControl::simple;
+  }
+  if (control == "numbered" || control == "t") {
+    return BackupControl::numbered;
+  }
+  return std::unexpected("invalid backup type");
+}
+
+auto requested_backup_control(const CommandContext<CP_OPTIONS.size()>& ctx)
+    -> cp::Result<BackupControl> {
+  if (ctx.get<bool>("-b", false)) {
+    return BackupControl::existing;
+  }
+  if (ctx.has("--backup")) {
+    return parse_backup_control(ctx.get<std::string>("--backup", ""));
+  }
+  return BackupControl::none;
+}
+
 auto backup_enabled(const CommandContext<CP_OPTIONS.size()>& ctx) -> bool {
-  return ctx.get<bool>("-b", false) || ctx.has("--backup");
+  auto control = requested_backup_control(ctx);
+  return control && *control != BackupControl::none;
 }
 
 auto backup_suffix(const CommandContext<CP_OPTIONS.size()>& ctx)
@@ -372,9 +410,53 @@ auto backup_suffix(const CommandContext<CP_OPTIONS.size()>& ctx)
     suffix = ctx.get<std::string>("-S", "");
   }
   if (suffix.empty()) {
-    suffix = cp_constants::DEFAULT_BACKUP_SUFFIX;
+    if (const char* env_suffix = std::getenv("SIMPLE_BACKUP_SUFFIX");
+        env_suffix != nullptr && *env_suffix != '\0') {
+      suffix = env_suffix;
+    } else {
+      suffix = cp_constants::DEFAULT_BACKUP_SUFFIX;
+    }
   }
   return suffix;
+}
+
+auto numbered_backup_path(const std::wstring& dest_path) -> std::wstring {
+  for (int version = 1;; ++version) {
+    std::wstring candidate = dest_path + L".~" + std::to_wstring(version) + L"~";
+    if (!native_path::valid_attributes(native_path::attributes_w(candidate))) {
+      return candidate;
+    }
+  }
+}
+
+auto simple_backup_path(const std::wstring& dest_path,
+                        const CommandContext<CP_OPTIONS.size()>& ctx)
+    -> std::wstring {
+  return dest_path + utf8_to_wstring(backup_suffix(ctx));
+}
+
+auto select_backup_path(const std::wstring& dest_path,
+                        const CommandContext<CP_OPTIONS.size()>& ctx)
+    -> cp::Result<std::optional<std::wstring>> {
+  auto control = requested_backup_control(ctx);
+  if (!control) return std::unexpected(control.error());
+
+  switch (*control) {
+    case BackupControl::none:
+      return std::optional<std::wstring>{};
+    case BackupControl::simple:
+      return std::optional<std::wstring>{simple_backup_path(dest_path, ctx)};
+    case BackupControl::numbered:
+      return std::optional<std::wstring>{numbered_backup_path(dest_path)};
+    case BackupControl::existing: {
+      std::wstring first_numbered = dest_path + L".~1~";
+      if (native_path::valid_attributes(native_path::attributes_w(first_numbered))) {
+        return std::optional<std::wstring>{numbered_backup_path(dest_path)};
+      }
+      return std::optional<std::wstring>{simple_backup_path(dest_path, ctx)};
+    }
+  }
+  return std::unexpected("invalid backup type");
 }
 
 auto verbose_enabled(const CommandContext<CP_OPTIONS.size()>& ctx) -> bool {
@@ -395,9 +477,14 @@ auto backup_existing_destination(const std::string& destPath,
     return true;
   }
 
-  std::wstring backup_path =
-      dest_operand.extended + utf8_to_wstring(backup_suffix(ctx));
-  if (!MoveFileExW(dest_operand.extended.c_str(), backup_path.c_str(),
+  auto backup_path = select_backup_path(dest_operand.extended, ctx);
+  if (!backup_path) {
+    return std::unexpected(backup_path.error());
+  }
+  if (!*backup_path) {
+    return true;
+  }
+  if (!MoveFileExW(dest_operand.extended.c_str(), (*backup_path)->c_str(),
                    MOVEFILE_REPLACE_EXISTING)) {
     return std::unexpected("cannot create backup for destination");
   }
@@ -413,8 +500,14 @@ auto copy_self_with_backup(const std::string& path,
   }
 
   std::wstring wpath = utf8_to_wstring(path);
-  std::wstring backup_path = wpath + utf8_to_wstring(backup_suffix(ctx));
-  if (!CopyFileW(wpath.c_str(), backup_path.c_str(), FALSE)) {
+  auto backup_path = select_backup_path(wpath, ctx);
+  if (!backup_path) {
+    return std::unexpected(backup_path.error());
+  }
+  if (!*backup_path) {
+    return true;
+  }
+  if (!CopyFileW(wpath.c_str(), (*backup_path)->c_str(), FALSE)) {
     return std::unexpected("cannot create backup for destination");
   }
   return true;

--- a/src/commands/date.cpp
+++ b/src/commands/date.cpp
@@ -56,6 +56,8 @@ using cmd::meta::OptionType;
  * - @a -R, @a --rfc-2822: Output RFC 2822 compliant date string [IMPLEMENTED]
  * - @a -I, @a --iso-8601: Output ISO 8601 date/time [IMPLEMENTED]
  * - @a --rfc-3339: Output RFC 3339 date/time [IMPLEMENTED]
+ * - @a -r, @a --reference: Display the last modification time of FILE
+ * [IMPLEMENTED]
  * - @a +FORMAT: Output formatted date string [IMPLEMENTED]
  */
 auto constexpr DATE_OPTIONS = std::array{
@@ -67,6 +69,8 @@ auto constexpr DATE_OPTIONS = std::array{
     OPTION("-I", "--iso-8601", "output ISO 8601 date/time",
            OPTIONAL_STRING_TYPE),
     OPTION("", "--rfc-3339", "output RFC 3339 date/time", STRING_TYPE),
+    OPTION("-r", "--reference", "display the last modification time of FILE",
+           STRING_TYPE),
     OPTION("-f", "--file", "display date strings from DATEFILE, one per line",
            STRING_TYPE),
     OPTION("", "--universal", "alias for --utc")};
@@ -543,6 +547,15 @@ auto current_time_value(bool use_utc) -> TimeValue {
   return make_time_value(utc, use_utc).value();
 }
 
+auto read_reference_time(std::string_view path) -> std::optional<FILETIME> {
+  WIN32_FILE_ATTRIBUTE_DATA attributes{};
+  if (!GetFileAttributesExW(utf8_to_wstring(std::string(path)).c_str(),
+                            GetFileExInfoStandard, &attributes)) {
+    return std::nullopt;
+  }
+  return attributes.ftLastWriteTime;
+}
+
 auto parse_date_argument(const std::string &arg) -> std::optional<FILETIME> {
   std::string value = trim_copy(arg);
   std::string lower = lower_copy(value);
@@ -626,6 +639,7 @@ REGISTER_COMMAND(
     "  date +'%H:%M:%S'        Display time in HH:MM:SS format\n"
     "  date -u                 Display UTC time\n"
     "  date -R                 Display RFC email format\n"
+    "  date -r FILE            Display FILE modification time\n"
     "  date -Iseconds          Display ISO 8601 format",
     "cal(1)", "caomengxuan666", "Copyright © 2026 WinuxCmd", DATE_OPTIONS) {
   using namespace date_pipeline;
@@ -636,6 +650,19 @@ REGISTER_COMMAND(
                  ctx.get<bool>("--rfc-2822", false);
 
   FILETIME selected_time{};
+  std::string reference_path = ctx.get<std::string>("--reference", "");
+  if (reference_path.empty()) reference_path = ctx.get<std::string>("-r", "");
+  if (!reference_path.empty()) {
+    auto reference_time = read_reference_time(reference_path);
+    if (!reference_time) {
+      safeErrorPrint("date: failed to get modification time of '");
+      safeErrorPrint(reference_path);
+      safeErrorPrint("'\n");
+      return 1;
+    }
+    selected_time = *reference_time;
+  }
+
   std::string date_arg = ctx.get<std::string>("--date", "");
   if (date_arg.empty()) date_arg = ctx.get<std::string>("-d", "");
   if (!date_arg.empty()) {
@@ -647,7 +674,7 @@ REGISTER_COMMAND(
       return 1;
     }
     selected_time = *parsed;
-  } else {
+  } else if (reference_path.empty()) {
     GetSystemTimeAsFileTime(&selected_time);
   }
 

--- a/src/commands/diff.cpp
+++ b/src/commands/diff.cpp
@@ -62,7 +62,15 @@ using cmd::meta::OptionType;
 auto constexpr DIFF_OPTIONS =
     std::array{OPTION("-q", "--brief", "report only when files differ"),
                OPTION("-u", "--unified",
-                      "output NUM (default 3) lines of unified context"),
+                      "output NUM (default 3) lines of unified context",
+                      OPTIONAL_INT_TYPE),
+               OPTION("-U", "", "output NUM lines of unified context", INT_TYPE),
+               OPTION("-c", "--context",
+                      "output NUM (default 3) lines of copied context",
+                      OPTIONAL_INT_TYPE),
+               OPTION("-C", "", "output NUM lines of copied context", INT_TYPE),
+               OPTION("", "--label", "use LABEL instead of file name",
+                      STRING_TYPE),
                OPTION("-y", "--side-by-side", "output in two columns"),
                OPTION("-w", "--ignore-all-space", "ignore all white space"),
                OPTION("-B", "--ignore-blank-lines",
@@ -395,6 +403,117 @@ auto format_unified_range(size_t start_line, size_t count) -> std::string {
   return out;
 }
 
+auto format_context_range(size_t start_line, size_t count) -> std::string {
+  if (count == 1) return std::to_string(start_line);
+  if (count == 0) return std::to_string(start_line) + ",0";
+  return std::to_string(start_line) + "," +
+         std::to_string(start_line + count - 1);
+}
+
+struct DiffHunk {
+  size_t edit_start = 0;
+  size_t edit_end = 0;
+  size_t file1_start = 0;
+  size_t file1_end = 0;
+  size_t file2_start = 0;
+  size_t file2_end = 0;
+};
+
+auto build_diff_hunks(const std::vector<Edit> &edits, size_t line1_count,
+                      size_t line2_count, int context)
+    -> std::vector<DiffHunk> {
+  std::vector<DiffHunk> hunks;
+  if (edits.empty()) return hunks;
+
+  auto context_lines = static_cast<size_t>(std::max(context, 0));
+  std::vector<std::pair<size_t, size_t>> groups;
+  size_t hunk_start = 0;
+  for (size_t i = 1; i < edits.size(); ++i) {
+    size_t prev_line1 = edits[i - 1].line1_index;
+    size_t curr_line1 = edits[i].line1_index;
+    size_t prev_line2 = edits[i - 1].line2_index;
+    size_t curr_line2 = edits[i].line2_index;
+
+    size_t distance =
+        std::max((curr_line1 > prev_line1 + context_lines)
+                     ? curr_line1 - prev_line1 - context_lines
+                     : 0,
+                 (curr_line2 > prev_line2 + context_lines)
+                     ? curr_line2 - prev_line2 - context_lines
+                     : 0);
+
+    if (distance > context_lines * 2) {
+      groups.push_back({hunk_start, i});
+      hunk_start = i;
+    }
+  }
+  groups.push_back({hunk_start, edits.size()});
+
+  for (auto [group_start, group_end] : groups) {
+    DiffHunk hunk;
+    hunk.edit_start = group_start;
+    hunk.edit_end = group_end;
+    hunk.file1_start = line1_count;
+    hunk.file1_end = 0;
+    hunk.file2_start = line2_count;
+    hunk.file2_end = 0;
+
+    for (size_t i = group_start; i < group_end; ++i) {
+      const auto &edit = edits[i];
+      if (edit.type == EditType::DEL) {
+        hunk.file1_start = std::min(hunk.file1_start, edit.line1_index);
+        hunk.file1_end = std::max(hunk.file1_end, edit.line1_index + 1);
+      } else if (edit.type == EditType::INS) {
+        hunk.file2_start = std::min(hunk.file2_start, edit.line2_index);
+        hunk.file2_end = std::max(hunk.file2_end, edit.line2_index + 1);
+      }
+    }
+
+    if (hunk.file1_start == line1_count) {
+      hunk.file1_start = edits[group_start].line1_index;
+      hunk.file1_end = hunk.file1_start;
+    }
+    if (hunk.file2_start == line2_count) {
+      hunk.file2_start = edits[group_start].line2_index;
+      hunk.file2_end = hunk.file2_start;
+    }
+
+    hunk.file1_start = static_cast<size_t>(std::max(
+        static_cast<ptrdiff_t>(hunk.file1_start) -
+            static_cast<ptrdiff_t>(context_lines),
+        static_cast<ptrdiff_t>(0)));
+    hunk.file1_end = std::min(hunk.file1_end + context_lines, line1_count);
+    hunk.file2_start = static_cast<size_t>(std::max(
+        static_cast<ptrdiff_t>(hunk.file2_start) -
+            static_cast<ptrdiff_t>(context_lines),
+        static_cast<ptrdiff_t>(0)));
+    hunk.file2_end = std::min(hunk.file2_end + context_lines, line2_count);
+
+    hunks.push_back(hunk);
+  }
+
+  return hunks;
+}
+
+struct DiffLabel {
+  std::string text;
+  bool custom = false;
+};
+
+void output_diff_file_header(std::string_view prefix, const DiffLabel &label,
+                             const std::string &path) {
+  safePrint(std::string(prefix));
+  safePrint(label.text);
+  if (!label.custom) {
+    auto timestamp = format_unified_timestamp(path);
+    if (!timestamp.empty()) {
+      safePrint("\t");
+      safePrint(timestamp);
+    }
+  }
+  safePrint("\n");
+}
+
 /**
  * @brief Output unified diff format using LCS
  * @param path1 First file path
@@ -407,129 +526,38 @@ auto output_unified_diff(const std::string &path1, const std::string &path2,
                          const std::vector<std::string> &compare_lines1,
                          const std::vector<std::string> &compare_lines2,
                          const std::vector<std::string> &lines1,
-                         const std::vector<std::string> &lines2, int context)
+                         const std::vector<std::string> &lines2, int context,
+                         const DiffLabel &label1, const DiffLabel &label2)
     -> void {
   auto edits = compute_diff(compare_lines1, compare_lines2);
+  auto hunks = build_diff_hunks(edits, lines1.size(), lines2.size(), context);
+  if (hunks.empty()) return;
 
-  // Group edits into hunks
-  std::vector<std::pair<size_t, size_t>> hunks;  // (start_index, end_index)
-  if (!edits.empty()) {
-    size_t hunk_start = 0;
-    for (size_t i = 1; i < edits.size(); ++i) {
-      size_t distance = 0;
+  output_diff_file_header("--- ", label1, path1);
+  output_diff_file_header("+++ ", label2, path2);
 
-      // Calculate distance in terms of line numbers
-      size_t prev_line1 = (edits[i - 1].type != EditType::INS)
-                              ? edits[i - 1].line1_index
-                              : (edits[i - 1].line1_index);
-      size_t curr_line1 = (edits[i].type != EditType::INS)
-                              ? edits[i].line1_index
-                              : (edits[i].line1_index);
-      size_t prev_line2 = (edits[i - 1].type != EditType::DEL)
-                              ? edits[i - 1].line2_index
-                              : (edits[i - 1].line2_index);
-      size_t curr_line2 = (edits[i].type != EditType::DEL)
-                              ? edits[i].line2_index
-                              : (edits[i].line2_index);
-
-      distance = std::max((curr_line1 > prev_line1 + context)
-                              ? curr_line1 - prev_line1 - context
-                              : 0,
-                          (curr_line2 > prev_line2 + context)
-                              ? curr_line2 - prev_line2 - context
-                              : 0);
-
-      if (distance > context * 2) {
-        hunks.push_back({hunk_start, i});
-        hunk_start = i;
-      }
-    }
-    hunks.push_back({hunk_start, edits.size()});
-  }
-
-  if (hunks.empty()) {
-    return;  // Files are identical
-  }
-
-  // Output header
-  safePrint("--- ");
-  safePrint(path1);
-  auto timestamp1 = format_unified_timestamp(path1);
-  if (!timestamp1.empty()) {
-    safePrint("\t");
-    safePrint(timestamp1);
-  }
-  safePrint("\n");
-  safePrint("+++ ");
-  safePrint(path2);
-  auto timestamp2 = format_unified_timestamp(path2);
-  if (!timestamp2.empty()) {
-    safePrint("\t");
-    safePrint(timestamp2);
-  }
-  safePrint("\n");
-
-  // Output each hunk
-  for (auto [hunk_start, hunk_end] : hunks) {
-    // Find the range of lines in both files
-    size_t file1_start = lines1.size();
-    size_t file1_end = 0;
-    size_t file2_start = lines2.size();
-    size_t file2_end = 0;
-    size_t context_start = lines1.size();
-    size_t context_end = 0;
-
-    for (size_t i = hunk_start; i < hunk_end; ++i) {
-      const auto &edit = edits[i];
-
-      if (edit.type == EditType::KEEP) {
-        context_start = std::min(context_start, edit.line1_index);
-        context_end = std::max(context_end, edit.line1_index + 1);
-      } else if (edit.type == EditType::DEL) {
-        file1_start = std::min(file1_start, edit.line1_index);
-        file1_end = std::max(file1_end, edit.line1_index + 1);
-      } else {  // INS
-        file2_start = std::min(file2_start, edit.line2_index);
-        file2_end = std::max(file2_end, edit.line2_index + 1);
-      }
-    }
-
-    // A pure insertion or deletion has no changed line on the other side.
-    // Use the edit's anchor position so the zero-length range does not
-    // underflow when its unified header is formatted.
-    if (file1_start == lines1.size()) {
-      file1_start = edits[hunk_start].line1_index;
-      file1_end = file1_start;
-    }
-    if (file2_start == lines2.size()) {
-      file2_start = edits[hunk_start].line2_index;
-      file2_end = file2_start;
-    }
-
-    // Add context lines
-    file1_start =
-        std::max((ptrdiff_t)file1_start - (ptrdiff_t)context, (ptrdiff_t)0);
-    file1_end = std::min(file1_end + context, lines1.size());
-    file2_start =
-        std::max((ptrdiff_t)file2_start - (ptrdiff_t)context, (ptrdiff_t)0);
-    file2_end = std::min(file2_end + context, lines2.size());
-
-    // Output hunk header
+  for (const auto &hunk : hunks) {
     safePrint("@@ -");
-    safePrint(format_unified_range(file1_start + 1, file1_end - file1_start));
+    safePrint(format_unified_range(hunk.file1_start + 1,
+                                   hunk.file1_end - hunk.file1_start));
     safePrint(" +");
-    safePrint(format_unified_range(file2_start + 1, file2_end - file2_start));
+    safePrint(format_unified_range(hunk.file2_start + 1,
+                                   hunk.file2_end - hunk.file2_start));
     safePrint(" @@\n");
 
-    // Output hunk content
-    size_t i1 = file1_start;
-    size_t i2 = file2_start;
-
-    for (size_t i = hunk_start; i < hunk_end; ++i) {
+    size_t i1 = hunk.file1_start;
+    size_t i2 = hunk.file2_start;
+    for (size_t i = hunk.edit_start; i < hunk.edit_end; ++i) {
       const auto &edit = edits[i];
 
       if (edit.type == EditType::KEEP) {
-        while (i1 < edit.line1_index && i1 < file1_end) {
+        if (edit.line1_index < hunk.file1_start ||
+            edit.line1_index >= hunk.file1_end ||
+            edit.line2_index < hunk.file2_start ||
+            edit.line2_index >= hunk.file2_end) {
+          continue;
+        }
+        while (i1 < edit.line1_index && i1 < hunk.file1_end) {
           safePrint(" ");
           safePrint(lines1[i1]);
           safePrint("\n");
@@ -542,7 +570,11 @@ auto output_unified_diff(const std::string &path1, const std::string &path2,
         ++i1;
         ++i2;
       } else if (edit.type == EditType::DEL) {
-        while (i1 < edit.line1_index && i1 < file1_end) {
+        if (edit.line1_index < hunk.file1_start ||
+            edit.line1_index >= hunk.file1_end) {
+          continue;
+        }
+        while (i1 < edit.line1_index && i1 < hunk.file1_end) {
           safePrint(" ");
           safePrint(lines1[i1]);
           safePrint("\n");
@@ -553,8 +585,12 @@ auto output_unified_diff(const std::string &path1, const std::string &path2,
         safePrint(lines1[edit.line1_index]);
         safePrint("\n");
         ++i1;
-      } else {  // INS
-        while (i2 < edit.line2_index && i2 < file2_end) {
+      } else {
+        if (edit.line2_index < hunk.file2_start ||
+            edit.line2_index >= hunk.file2_end) {
+          continue;
+        }
+        while (i2 < edit.line2_index && i2 < hunk.file2_end) {
           safePrint(" ");
           safePrint(lines2[i2]);
           safePrint("\n");
@@ -568,14 +604,144 @@ auto output_unified_diff(const std::string &path1, const std::string &path2,
       }
     }
 
-    // Output remaining context lines
-    while (i1 < file1_end && i2 < file2_end) {
+    while (i1 < hunk.file1_end && i2 < hunk.file2_end) {
       safePrint(" ");
       safePrint(lines1[i1]);
       safePrint("\n");
       ++i1;
       ++i2;
     }
+  }
+}
+
+void output_context_old_section(const std::vector<Edit> &edits,
+                                const std::vector<std::string> &lines1,
+                                const DiffHunk &hunk, bool mixed_change) {
+  size_t i1 = hunk.file1_start;
+  for (size_t i = hunk.edit_start; i < hunk.edit_end; ++i) {
+    const auto &edit = edits[i];
+    if (edit.type == EditType::INS) continue;
+    if (edit.type == EditType::KEEP) {
+      if (edit.line1_index < hunk.file1_start ||
+          edit.line1_index >= hunk.file1_end) {
+        continue;
+      }
+      while (i1 < edit.line1_index && i1 < hunk.file1_end) {
+        safePrint("  ");
+        safePrint(lines1[i1]);
+        safePrint("\n");
+        ++i1;
+      }
+      safePrint("  ");
+      safePrint(lines1[edit.line1_index]);
+      safePrint("\n");
+      ++i1;
+      continue;
+    }
+    if (edit.line1_index < hunk.file1_start ||
+        edit.line1_index >= hunk.file1_end) {
+      continue;
+    }
+    while (i1 < edit.line1_index && i1 < hunk.file1_end) {
+      safePrint("  ");
+      safePrint(lines1[i1]);
+      safePrint("\n");
+      ++i1;
+    }
+    safePrint(mixed_change ? "! " : "- ");
+    safePrint(lines1[edit.line1_index]);
+    safePrint("\n");
+    ++i1;
+  }
+  while (i1 < hunk.file1_end) {
+    safePrint("  ");
+    safePrint(lines1[i1]);
+    safePrint("\n");
+    ++i1;
+  }
+}
+
+void output_context_new_section(const std::vector<Edit> &edits,
+                                const std::vector<std::string> &lines2,
+                                const DiffHunk &hunk, bool mixed_change) {
+  size_t i2 = hunk.file2_start;
+  for (size_t i = hunk.edit_start; i < hunk.edit_end; ++i) {
+    const auto &edit = edits[i];
+    if (edit.type == EditType::DEL) continue;
+    if (edit.type == EditType::KEEP) {
+      if (edit.line2_index < hunk.file2_start ||
+          edit.line2_index >= hunk.file2_end) {
+        continue;
+      }
+      while (i2 < edit.line2_index && i2 < hunk.file2_end) {
+        safePrint("  ");
+        safePrint(lines2[i2]);
+        safePrint("\n");
+        ++i2;
+      }
+      safePrint("  ");
+      safePrint(lines2[edit.line2_index]);
+      safePrint("\n");
+      ++i2;
+      continue;
+    }
+    if (edit.line2_index < hunk.file2_start ||
+        edit.line2_index >= hunk.file2_end) {
+      continue;
+    }
+    while (i2 < edit.line2_index && i2 < hunk.file2_end) {
+      safePrint("  ");
+      safePrint(lines2[i2]);
+      safePrint("\n");
+      ++i2;
+    }
+    safePrint(mixed_change ? "! " : "+ ");
+    safePrint(lines2[edit.line2_index]);
+    safePrint("\n");
+    ++i2;
+  }
+  while (i2 < hunk.file2_end) {
+    safePrint("  ");
+    safePrint(lines2[i2]);
+    safePrint("\n");
+    ++i2;
+  }
+}
+
+auto output_context_diff(const std::string &path1, const std::string &path2,
+                         const std::vector<std::string> &compare_lines1,
+                         const std::vector<std::string> &compare_lines2,
+                         const std::vector<std::string> &lines1,
+                         const std::vector<std::string> &lines2, int context,
+                         const DiffLabel &label1, const DiffLabel &label2)
+    -> void {
+  auto edits = compute_diff(compare_lines1, compare_lines2);
+  auto hunks = build_diff_hunks(edits, lines1.size(), lines2.size(), context);
+  if (hunks.empty()) return;
+
+  output_diff_file_header("*** ", label1, path1);
+  output_diff_file_header("--- ", label2, path2);
+
+  for (const auto &hunk : hunks) {
+    bool has_delete = false;
+    bool has_insert = false;
+    for (size_t i = hunk.edit_start; i < hunk.edit_end; ++i) {
+      has_delete = has_delete || edits[i].type == EditType::DEL;
+      has_insert = has_insert || edits[i].type == EditType::INS;
+    }
+    const bool mixed_change = has_delete && has_insert;
+
+    safePrint("***************\n");
+    safePrint("*** ");
+    safePrint(format_context_range(hunk.file1_start + 1,
+                                   hunk.file1_end - hunk.file1_start));
+    safePrint(" ****\n");
+    output_context_old_section(edits, lines1, hunk, mixed_change);
+    safePrint("--- ");
+    safePrint(format_context_range(hunk.file2_start + 1,
+                                   hunk.file2_end - hunk.file2_start));
+    safePrint(" ----\n");
+    output_context_new_section(edits, lines2, hunk, mixed_change);
   }
 }
 
@@ -673,13 +839,53 @@ REGISTER_COMMAND(
   using namespace diff_pipeline;
 
   bool brief = ctx.get<bool>("-q", false) || ctx.get<bool>("--brief", false);
-  bool unified =
-      ctx.get<bool>("-u", false) || ctx.get<bool>("--unified", false);
-  bool side_by_side =
-      ctx.get<bool>("-y", false) || ctx.get<bool>("--side-by-side", false);
   bool ignore_all_space =
       ctx.get<bool>("-w", false) || ctx.get<bool>("--ignore-all-space", false);
-  int context = 3;  // Default context lines for unified diff
+
+  enum class OutputMode { Normal, Unified, Context, SideBySide };
+  OutputMode output_mode = OutputMode::Normal;
+  int context = 3;
+
+  auto set_context = [&](int value, std::string_view option,
+                         bool optional_value) -> bool {
+    if (value < 0) {
+      if (optional_value && value == -1) {
+        context = 3;
+        return true;
+      }
+      safeErrorPrint("diff: invalid context length '");
+      safeErrorPrint(std::to_string(value));
+      safeErrorPrint("'\n");
+      safeErrorPrint("Try 'diff --help' for more information.\n");
+      return false;
+    }
+    context = value;
+    return true;
+  };
+
+  for (const auto &occurrence : ctx.options.occurrences()) {
+    if (!ctx.metas || occurrence.index >= ctx.metas->size()) continue;
+    const auto &meta = (*ctx.metas)[occurrence.index];
+    if (meta.short_name == "-u" || meta.long_name == "--unified") {
+      output_mode = OutputMode::Unified;
+      auto value = std::get_if<int>(&occurrence.value);
+      if (value && !set_context(*value, "--unified", true)) return 1;
+    } else if (meta.short_name == "-U") {
+      output_mode = OutputMode::Unified;
+      auto value = std::get_if<int>(&occurrence.value);
+      if (value && !set_context(*value, "-U", false)) return 1;
+    } else if (meta.short_name == "-c" || meta.long_name == "--context") {
+      output_mode = OutputMode::Context;
+      auto value = std::get_if<int>(&occurrence.value);
+      if (value && !set_context(*value, "--context", true)) return 1;
+    } else if (meta.short_name == "-C") {
+      output_mode = OutputMode::Context;
+      auto value = std::get_if<int>(&occurrence.value);
+      if (value && !set_context(*value, "-C", false)) return 1;
+    } else if (meta.short_name == "-y" || meta.long_name == "--side-by-side") {
+      output_mode = OutputMode::SideBySide;
+    }
+  }
 
   auto files_result = resolve_files(ctx);
   if (!files_result) {
@@ -691,6 +897,12 @@ REGISTER_COMMAND(
 
   std::string file1 = (*files_result)[0];
   std::string file2 = (*files_result)[1];
+
+  DiffLabel label1{file1, false};
+  DiffLabel label2{file2, false};
+  auto labels = ctx.string_occurrences({"--label"});
+  if (!labels.empty()) label1 = DiffLabel{labels[0].value, true};
+  if (labels.size() > 1) label2 = DiffLabel{labels[1].value, true};
 
   if (brief) {
     auto result = compare_files(file1, file2, true, ignore_all_space);
@@ -729,10 +941,13 @@ REGISTER_COMMAND(
     return 0;
   }
 
-  if (unified) {
+  if (output_mode == OutputMode::Unified) {
     output_unified_diff(file1, file2, compare_lines1, compare_lines2, lines1,
-                        lines2, context);
-  } else if (side_by_side) {
+                        lines2, context, label1, label2);
+  } else if (output_mode == OutputMode::Context) {
+    output_context_diff(file1, file2, compare_lines1, compare_lines2, lines1,
+                        lines2, context, label1, label2);
+  } else if (output_mode == OutputMode::SideBySide) {
     output_side_by_side(file1, file2, compare_lines1, compare_lines2, lines1,
                         lines2);
   } else {

--- a/src/commands/diff3.cpp
+++ b/src/commands/diff3.cpp
@@ -174,6 +174,18 @@ void output_default_block(const Diff3Block& block) {
   print_default_section(3, block.start, block.yours, true);
 }
 
+void output_ed_script_block(const Diff3Block& block) {
+  const bool mine_eq_older = diff3_same_lines(block.mine, block.older);
+  const bool yours_eq_older = diff3_same_lines(block.yours, block.older);
+
+  // GNU -e applies only non-overlapping OLDER-to-YOURS changes to MINE.
+  if (mine_eq_older && !yours_eq_older) {
+    safePrintLn(change_spec(block.start, block.mine.size()));
+    diff3_print_lines(block.yours);
+    safePrintLn(".");
+  }
+}
+
 bool output_merge_block(const Diff3Block& block, const std::string& mine_file,
                         const std::string& older_file,
                         const std::string& yours_file) {
@@ -314,9 +326,14 @@ auto run(const Config& cfg) -> int {
                : 0;
   }
 
-  if (cfg.ed_script || cfg.bracketed_conflicts || cfg.overwrite_overlapping) {
-    // Compatibility placeholder: these GNU ed-script modes are still modeled
-    // as default reports until the edit-script engine is implemented.
+  if (cfg.ed_script) {
+    if (block) output_ed_script_block(*block);
+    return 0;
+  }
+
+  if (cfg.bracketed_conflicts || cfg.overwrite_overlapping) {
+    // Compatibility placeholder: these GNU modes are still modeled as default
+    // reports until their specialized output is implemented.
   }
 
   if (block) output_default_block(*block);

--- a/src/commands/file.cpp
+++ b/src/commands/file.cpp
@@ -221,9 +221,7 @@ auto classify_by_magic(const std::vector<unsigned char>& header)
     return FileClassification{"PDF document", "application/pdf; charset=binary"};
   }
   if (has_prefix(header, {static_cast<unsigned char>(0x89), 'P', 'N', 'G',
-                          '', '
-', static_cast<unsigned char>(0x1A), '
-'})) {
+                          '\r', '\n', static_cast<unsigned char>(0x1A), '\n'})) {
     return FileClassification{"PNG image data", "image/png; charset=binary"};
   }
   if (has_prefix(header, {static_cast<unsigned char>(0xFF),

--- a/src/commands/file.cpp
+++ b/src/commands/file.cpp
@@ -54,7 +54,7 @@ using namespace std::string_view_literals;
  * @par Options:
  * - @a -b, @a --brief: do not append filename [IMPLEMENTED]
  * - @a -h, @a --no-dereference: don't follow symlinks [IMPLEMENTED]
- * - @a -i, @a --mime: output MIME type strings [TODO]
+ * - @a -i, @a --mime: output MIME type strings [IMPLEMENTED]
  * - @a -L, @a --dereference: follow symlinks [IMPLEMENTED]
  */
 auto constexpr FILE_OPTIONS = std::array{
@@ -286,9 +286,10 @@ auto classify_by_extension(const std::wstring& filename) -> FileClassification {
  * @param path File path
  * @param brief Brief mode (no filename prefix)
  * @param symlink Follow symlinks
+ * @param mime Output MIME type instead of description
  * @return File type description
  */
-auto process_file(const std::string& path, bool brief, bool symlink)
+auto process_file(const std::string& path, bool brief, bool symlink, bool mime)
     -> std::optional<std::string> {
   std::wstring wpath = utf8_to_wstring(path);
 
@@ -301,11 +302,11 @@ auto process_file(const std::string& path, bool brief, bool symlink)
 
   // Check if it's a directory
   if (attrs & FILE_ATTRIBUTE_DIRECTORY) {
-    type = "directory";
+    type = mime ? "inode/directory; charset=binary" : "directory";
   }
   // Check if it's a reparse point (symlink or junction)
   else if (attrs & FILE_ATTRIBUTE_REPARSE_POINT) {
-    type = "symbolic link";
+    type = mime ? "inode/symlink; charset=binary" : "symbolic link";
   }
   // Regular file
   else {
@@ -314,7 +315,9 @@ auto process_file(const std::string& path, bool brief, bool symlink)
     std::wstring filename =
         (last_sep != std::wstring::npos) ? wpath.substr(last_sep + 1) : wpath;
 
-    type = classify_by_extension(filename).description;
+    auto classification = classify_by_magic(read_file_header(wpath))
+                              .value_or(classify_by_extension(filename));
+    type = mime ? classification.mime : classification.description;
   }
 
   if (brief) {
@@ -357,12 +360,13 @@ auto process_files(const CommandContext<FILE_OPTIONS.size()>& ctx)
       ctx.get<bool>("--dereference", false) || ctx.get<bool>("-L", false);
   bool no_deref =
       ctx.get<bool>("--no-dereference", false) || ctx.get<bool>("-h", false);
+  bool mime = ctx.get<bool>("--mime", false) || ctx.get<bool>("-i", false);
 
   bool all_ok = true;
 
   for (size_t i = 0; i < paths.size(); ++i) {
     const auto& path = paths[i];
-    auto result = process_file(path, brief, symlink && !no_deref);
+    auto result = process_file(path, brief, symlink && !no_deref, mime);
 
     if (result) {
       safePrintLn(utf8_to_wstring(*result));

--- a/src/commands/file.cpp
+++ b/src/commands/file.cpp
@@ -60,7 +60,7 @@ using namespace std::string_view_literals;
 auto constexpr FILE_OPTIONS = std::array{
     OPTION("-b", "--brief", "do not prepend filenames to output lines"),
     OPTION("-h", "--no-dereference", "don't follow symlinks"),
-    OPTION("-i", "--mime", "output MIME type strings [TODO]"),
+    OPTION("-i", "--mime", "output MIME type strings"),
     OPTION("-L", "--dereference", "follow symlinks")};
 
 // ======================================================
@@ -158,6 +158,31 @@ constexpr auto extension_map = make_constexpr_map(
         {".so"sv, "ELF shared object"sv},
         {".dylib"sv, "Mach-O dynamically linked shared library"sv},
     }));
+
+constexpr auto extension_mime_map = make_constexpr_map(
+    std::to_array<std::pair<std::string_view, std::string_view>>({
+        {".txt"sv, "text/plain; charset=us-ascii"sv},
+        {".md"sv, "text/markdown; charset=utf-8"sv},
+        {".json"sv, "application/json; charset=us-ascii"sv},
+        {".xml"sv, "text/xml; charset=us-ascii"sv},
+        {".html"sv, "text/html; charset=us-ascii"sv},
+        {".htm"sv, "text/html; charset=us-ascii"sv},
+        {".css"sv, "text/css; charset=us-ascii"sv},
+        {".js"sv, "text/javascript; charset=us-ascii"sv},
+        {".ts"sv, "text/plain; charset=us-ascii"sv},
+        {".py"sv, "text/x-python; charset=us-ascii"sv},
+        {".sh"sv, "text/x-shellscript; charset=us-ascii"sv},
+        {".pdf"sv, "application/pdf; charset=binary"sv},
+        {".zip"sv, "application/zip; charset=binary"sv},
+        {".gz"sv, "application/gzip; charset=binary"sv},
+        {".png"sv, "image/png; charset=binary"sv},
+        {".jpg"sv, "image/jpeg; charset=binary"sv},
+        {".jpeg"sv, "image/jpeg; charset=binary"sv},
+        {".gif"sv, "image/gif; charset=binary"sv},
+        {".bmp"sv, "image/bmp; charset=binary"sv},
+        {".exe"sv, "application/x-dosexec; charset=binary"sv},
+        {".dll"sv, "application/x-dosexec; charset=binary"sv},
+    }));
 }  // namespace file_constants
 
 // ======================================================
@@ -166,31 +191,89 @@ constexpr auto extension_map = make_constexpr_map(
 namespace file_pipeline {
 namespace cp = core::pipeline;
 
-/**
- * @brief Detect file type from extension
- * @param filename Filename to check
- * @return Detected file type
- */
-auto detect_file_type(const std::wstring& filename) -> std::string {
-  // Get extension
+struct FileClassification {
+  std::string description;
+  std::string mime;
+};
+
+auto has_prefix(const std::vector<unsigned char>& data,
+                std::initializer_list<unsigned char> prefix) -> bool {
+  return data.size() >= prefix.size() &&
+         std::equal(prefix.begin(), prefix.end(), data.begin());
+}
+
+auto read_file_header(const std::wstring& path) -> std::vector<unsigned char> {
+  std::ifstream file(std::filesystem::path(path), std::ios::binary);
+  if (!file) {
+    return {};
+  }
+
+  std::array<unsigned char, 64> buffer{};
+  file.read(reinterpret_cast<char*>(buffer.data()),
+            static_cast<std::streamsize>(buffer.size()));
+  const auto count = static_cast<size_t>(std::max<std::streamsize>(0, file.gcount()));
+  return {buffer.begin(), buffer.begin() + count};
+}
+
+auto classify_by_magic(const std::vector<unsigned char>& header)
+    -> std::optional<FileClassification> {
+  if (has_prefix(header, {'%', 'P', 'D', 'F', '-'})) {
+    return FileClassification{"PDF document", "application/pdf; charset=binary"};
+  }
+  if (has_prefix(header, {static_cast<unsigned char>(0x89), 'P', 'N', 'G',
+                          '', '
+', static_cast<unsigned char>(0x1A), '
+'})) {
+    return FileClassification{"PNG image data", "image/png; charset=binary"};
+  }
+  if (has_prefix(header, {static_cast<unsigned char>(0xFF),
+                          static_cast<unsigned char>(0xD8),
+                          static_cast<unsigned char>(0xFF)})) {
+    return FileClassification{"JPEG image data", "image/jpeg; charset=binary"};
+  }
+  if (has_prefix(header, {'G', 'I', 'F', '8', '7', 'a'}) ||
+      has_prefix(header, {'G', 'I', 'F', '8', '9', 'a'})) {
+    return FileClassification{"GIF image data", "image/gif; charset=binary"};
+  }
+  if (header.size() >= 4 && header[0] == 'P' && header[1] == 'K' &&
+      ((header[2] == 3 && header[3] == 4) ||
+       (header[2] == 5 && header[3] == 6) ||
+       (header[2] == 7 && header[3] == 8))) {
+    return FileClassification{"Zip archive data", "application/zip; charset=binary"};
+  }
+  if (has_prefix(header, {static_cast<unsigned char>(0x1F),
+                          static_cast<unsigned char>(0x8B)})) {
+    return FileClassification{"gzip compressed data", "application/gzip; charset=binary"};
+  }
+  if (has_prefix(header, {'B', 'M'})) {
+    return FileClassification{"PC bitmap image data", "image/bmp; charset=binary"};
+  }
+  if (has_prefix(header, {static_cast<unsigned char>(0x7F), 'E', 'L', 'F'})) {
+    return FileClassification{"ELF executable", "application/x-executable; charset=binary"};
+  }
+  if (has_prefix(header, {'M', 'Z'})) {
+    return FileClassification{"MS-DOS executable", "application/x-dosexec; charset=binary"};
+  }
+
+  return std::nullopt;
+}
+
+auto classify_by_extension(const std::wstring& filename) -> FileClassification {
   size_t dot_pos = filename.find_last_of(L'.');
   if (dot_pos == std::wstring::npos) {
-    // No extension, assume text file
-    return "ASCII text";
+    return {"ASCII text", "text/plain; charset=us-ascii"};
   }
 
   std::wstring ext = filename.substr(dot_pos);
   std::string ext_lower = wstring_to_utf8(ext);
-
-  // Convert to lowercase
   std::transform(ext_lower.begin(), ext_lower.end(), ext_lower.begin(),
                  ::tolower);
 
-  // Lookup in extension map using ConstexprMap
   std::string_view ext_sv(ext_lower);
-  auto result = file_constants::extension_map.get_or(ext_sv, "data"sv);
-
-  return std::string(result);
+  auto description = file_constants::extension_map.get_or(ext_sv, "data"sv);
+  auto mime = file_constants::extension_mime_map.get_or(
+      ext_sv, "application/octet-stream; charset=binary"sv);
+  return {std::string(description), std::string(mime)};
 }
 
 /**

--- a/src/commands/file.cpp
+++ b/src/commands/file.cpp
@@ -211,17 +211,19 @@ auto read_file_header(const std::wstring& path) -> std::vector<unsigned char> {
   std::array<unsigned char, 64> buffer{};
   file.read(reinterpret_cast<char*>(buffer.data()),
             static_cast<std::streamsize>(buffer.size()));
-  const auto count = static_cast<size_t>(std::max<std::streamsize>(0, file.gcount()));
+  const auto count =
+      static_cast<size_t>(std::max<std::streamsize>(0, file.gcount()));
   return {buffer.begin(), buffer.begin() + count};
 }
 
 auto classify_by_magic(const std::vector<unsigned char>& header)
     -> std::optional<FileClassification> {
   if (has_prefix(header, {'%', 'P', 'D', 'F', '-'})) {
-    return FileClassification{"PDF document", "application/pdf; charset=binary"};
+    return FileClassification{"PDF document",
+                              "application/pdf; charset=binary"};
   }
-  if (has_prefix(header, {static_cast<unsigned char>(0x89), 'P', 'N', 'G',
-                          '\r', '\n', static_cast<unsigned char>(0x1A), '\n'})) {
+  if (has_prefix(header, {static_cast<unsigned char>(0x89), 'P', 'N', 'G', '\r',
+                          '\n', static_cast<unsigned char>(0x1A), '\n'})) {
     return FileClassification{"PNG image data", "image/png; charset=binary"};
   }
   if (has_prefix(header, {static_cast<unsigned char>(0xFF),
@@ -237,20 +239,25 @@ auto classify_by_magic(const std::vector<unsigned char>& header)
       ((header[2] == 3 && header[3] == 4) ||
        (header[2] == 5 && header[3] == 6) ||
        (header[2] == 7 && header[3] == 8))) {
-    return FileClassification{"Zip archive data", "application/zip; charset=binary"};
+    return FileClassification{"Zip archive data",
+                              "application/zip; charset=binary"};
   }
   if (has_prefix(header, {static_cast<unsigned char>(0x1F),
                           static_cast<unsigned char>(0x8B)})) {
-    return FileClassification{"gzip compressed data", "application/gzip; charset=binary"};
+    return FileClassification{"gzip compressed data",
+                              "application/gzip; charset=binary"};
   }
   if (has_prefix(header, {'B', 'M'})) {
-    return FileClassification{"PC bitmap image data", "image/bmp; charset=binary"};
+    return FileClassification{"PC bitmap image data",
+                              "image/bmp; charset=binary"};
   }
   if (has_prefix(header, {static_cast<unsigned char>(0x7F), 'E', 'L', 'F'})) {
-    return FileClassification{"ELF executable", "application/x-executable; charset=binary"};
+    return FileClassification{"ELF executable",
+                              "application/x-executable; charset=binary"};
   }
   if (has_prefix(header, {'M', 'Z'})) {
-    return FileClassification{"MS-DOS executable", "application/x-dosexec; charset=binary"};
+    return FileClassification{"MS-DOS executable",
+                              "application/x-dosexec; charset=binary"};
   }
 
   return std::nullopt;
@@ -307,7 +314,7 @@ auto process_file(const std::string& path, bool brief, bool symlink)
     std::wstring filename =
         (last_sep != std::wstring::npos) ? wpath.substr(last_sep + 1) : wpath;
 
-    type = detect_file_type(filename);
+    type = classify_by_extension(filename).description;
   }
 
   if (brief) {

--- a/src/commands/find.cpp
+++ b/src/commands/find.cpp
@@ -149,8 +149,7 @@ auto constexpr FIND_OPTIONS = std::array{
     OPTION("-empty", "",
            "file is empty and is either a regular file or a directory"),
     OPTION("-amin", "", "file was last accessed n minutes ago", STRING_TYPE),
-    OPTION("-atime", "", "file was last accessed n*24 hours ago",
-           STRING_TYPE),
+    OPTION("-atime", "", "file was last accessed n*24 hours ago", STRING_TYPE),
     OPTION("-cmin", "", "file status was last changed n minutes ago",
            STRING_TYPE),
     OPTION("-ctime", "", "file status was last changed n*24 hours ago",
@@ -1156,15 +1155,14 @@ class ExpressionParser {
            token == "-gid" || token == "-size" || token == "-empty" ||
            token == "-amin" || token == "-atime" || token == "-cmin" ||
            token == "-ctime" || token == "-mtime" || token == "-mmin" ||
-           token == "-newer" ||
-           is_newerxy_option(token) || token == "-samefile" ||
-           token == "-files0-from" || token == "-mindepth" ||
-           token == "-maxdepth" || token == "-print" || token == "-print0" ||
-           token == "-fprint" || token == "-fprint0" || token == "-printf" ||
-           token == "-prune" || token == "-quit" || token == "-true" ||
-           token == "-false" || token == "-depth" || token == "-d" ||
-           token == "-follow" || token == "-mount" || token == "-xdev" ||
-           token == "-noleaf" || token == "-daystart" ||
+           token == "-newer" || is_newerxy_option(token) ||
+           token == "-samefile" || token == "-files0-from" ||
+           token == "-mindepth" || token == "-maxdepth" || token == "-print" ||
+           token == "-print0" || token == "-fprint" || token == "-fprint0" ||
+           token == "-printf" || token == "-prune" || token == "-quit" ||
+           token == "-true" || token == "-false" || token == "-depth" ||
+           token == "-d" || token == "-follow" || token == "-mount" ||
+           token == "-xdev" || token == "-noleaf" || token == "-daystart" ||
            token == "-regextype" || token == "-O" || token == "-delete" ||
            token == "-exec" || token == "-ok" || token == "-L" ||
            token == "-P" || token == "-H";
@@ -2084,7 +2082,8 @@ auto entry_matches(Config& cfg, const std::filesystem::path& p,
   if (cfg.size_filter && !size_matches(e, *cfg.size_filter)) return false;
 
   if (cfg.atime_filter) {
-    auto age = file_age_units(p, FindFileTimeKind::Access, std::chrono::hours(24));
+    auto age =
+        file_age_units(p, FindFileTimeKind::Access, std::chrono::hours(24));
     if (!age || !numeric_matches(*cfg.atime_filter, *age)) return false;
   }
 
@@ -2095,7 +2094,8 @@ auto entry_matches(Config& cfg, const std::filesystem::path& p,
   }
 
   if (cfg.ctime_filter) {
-    auto age = file_age_units(p, FindFileTimeKind::Change, std::chrono::hours(24));
+    auto age =
+        file_age_units(p, FindFileTimeKind::Change, std::chrono::hours(24));
     if (!age || !numeric_matches(*cfg.ctime_filter, *age)) return false;
   }
 

--- a/src/commands/find.cpp
+++ b/src/commands/find.cpp
@@ -148,6 +148,13 @@ auto constexpr FIND_OPTIONS = std::array{
     OPTION("-size", "", "file uses n units of space", STRING_TYPE),
     OPTION("-empty", "",
            "file is empty and is either a regular file or a directory"),
+    OPTION("-amin", "", "file was last accessed n minutes ago", STRING_TYPE),
+    OPTION("-atime", "", "file was last accessed n*24 hours ago",
+           STRING_TYPE),
+    OPTION("-cmin", "", "file status was last changed n minutes ago",
+           STRING_TYPE),
+    OPTION("-ctime", "", "file status was last changed n*24 hours ago",
+           STRING_TYPE),
     OPTION("-mtime", "", "file data was last modified n*24 hours ago",
            STRING_TYPE),
     OPTION("-mmin", "", "file data was last modified n minutes ago",
@@ -185,6 +192,7 @@ auto constexpr FIND_OPTIONS = std::array{
         "i,%A@,%B@,%C@,%T@,%AY,%Am,%Ad,%AH,%AM,%AS,%Aj,%BY,%Bm,%Bd,%BH,%BM,%BS,"
         "%Bj,%CY,%Cm,%Cd,%CH,%CM,%CS,%Cj,%TY,%Tm,%Td,%TH,%TM,%TS,%Tj,%%]",
         STRING_TYPE),
+    OPTION("-fprintf", "", "print format into FILE", STRING_TYPE),
     OPTION("-prune", "", "prune tree"),
     OPTION("-quit", "", "exit immediately"),
     OPTION("-true", "", "always true"),
@@ -308,6 +316,10 @@ enum class ExprKind {
   Gid,
   Empty,
   Size,
+  ATime,
+  AMin,
+  CTime,
+  CMin,
   MTime,
   MMin,
   Newer,
@@ -318,6 +330,7 @@ enum class ExprKind {
   FPrint,
   FPrint0,
   Printf,
+  FPrintf,
   False,
   Exec,
   Delete,
@@ -332,6 +345,7 @@ enum class ExprKind {
 struct ExprNode {
   ExprKind kind = ExprKind::Always;
   std::string text;
+  std::string format_text;
   std::optional<portable_regex::Pattern> regex;
   std::optional<SizePredicate> size;
   std::optional<NumericPredicate> numeric;
@@ -362,6 +376,10 @@ struct Config {
   std::string type_filter;
   std::optional<SizePredicate> size_filter;
   bool empty_filter = false;
+  std::optional<NumericPredicate> atime_filter;
+  std::optional<NumericPredicate> amin_filter;
+  std::optional<NumericPredicate> ctime_filter;
+  std::optional<NumericPredicate> cmin_filter;
   std::optional<NumericPredicate> mtime_filter;
   std::optional<NumericPredicate> mmin_filter;
   int mindepth = 0;
@@ -1136,7 +1154,9 @@ class ExpressionParser {
            token == "-executable" || token == "-inum" || token == "-links" ||
            token == "-user" || token == "-group" || token == "-uid" ||
            token == "-gid" || token == "-size" || token == "-empty" ||
-           token == "-mtime" || token == "-mmin" || token == "-newer" ||
+           token == "-amin" || token == "-atime" || token == "-cmin" ||
+           token == "-ctime" || token == "-mtime" || token == "-mmin" ||
+           token == "-newer" ||
            is_newerxy_option(token) || token == "-samefile" ||
            token == "-files0-from" || token == "-mindepth" ||
            token == "-maxdepth" || token == "-print" || token == "-print0" ||
@@ -1329,13 +1349,19 @@ class ExpressionParser {
       return node;
     }
 
-    if (option == "-mtime" || option == "-mmin") {
+    if (option == "-amin" || option == "-atime" || option == "-cmin" ||
+        option == "-ctime" || option == "-mtime" || option == "-mmin") {
       auto value = require_value(option);
       if (!value) return std::unexpected(value.error());
       auto parsed = parse_numeric_predicate(*value);
       if (!parsed) return std::unexpected(parsed.error());
-      auto node =
-          make_expr(option == "-mtime" ? ExprKind::MTime : ExprKind::MMin);
+      ExprKind kind = ExprKind::MMin;
+      if (option == "-amin") kind = ExprKind::AMin;
+      if (option == "-atime") kind = ExprKind::ATime;
+      if (option == "-cmin") kind = ExprKind::CMin;
+      if (option == "-ctime") kind = ExprKind::CTime;
+      if (option == "-mtime") kind = ExprKind::MTime;
+      auto node = make_expr(kind);
       node->numeric = *parsed;
       return node;
     }
@@ -1623,6 +1649,34 @@ auto build_config(const CommandContext<FIND_OPTIONS.size()>& ctx)
     cfg.size_filter = *parsed;
   }
 
+  auto atime_text = ctx.get<std::string>("-atime", "");
+  if (!atime_text.empty()) {
+    auto parsed = parse_numeric_predicate(atime_text);
+    if (!parsed) return std::unexpected(parsed.error());
+    cfg.atime_filter = *parsed;
+  }
+
+  auto amin_text = ctx.get<std::string>("-amin", "");
+  if (!amin_text.empty()) {
+    auto parsed = parse_numeric_predicate(amin_text);
+    if (!parsed) return std::unexpected(parsed.error());
+    cfg.amin_filter = *parsed;
+  }
+
+  auto ctime_text = ctx.get<std::string>("-ctime", "");
+  if (!ctime_text.empty()) {
+    auto parsed = parse_numeric_predicate(ctime_text);
+    if (!parsed) return std::unexpected(parsed.error());
+    cfg.ctime_filter = *parsed;
+  }
+
+  auto cmin_text = ctx.get<std::string>("-cmin", "");
+  if (!cmin_text.empty()) {
+    auto parsed = parse_numeric_predicate(cmin_text);
+    if (!parsed) return std::unexpected(parsed.error());
+    cfg.cmin_filter = *parsed;
+  }
+
   auto mtime_text = ctx.get<std::string>("-mtime", "");
   if (!mtime_text.empty()) {
     auto parsed = parse_numeric_predicate(mtime_text);
@@ -1747,22 +1801,24 @@ auto permission_matches(const std::filesystem::path& p,
   return false;
 }
 
+auto file_age_units(const std::filesystem::path& p, FindFileTimeKind kind,
+                    std::chrono::seconds unit) -> std::optional<long long> {
+  auto ticks = win32_file_time_ticks(p, kind);
+  if (!ticks) return std::nullopt;
+
+  FILETIME now_filetime{};
+  GetSystemTimeAsFileTime(&now_filetime);
+  long long elapsed_ticks = filetime_ticks(now_filetime) - *ticks;
+  if (elapsed_ticks < 0) elapsed_ticks = 0;
+
+  auto elapsed_seconds = std::chrono::seconds(elapsed_ticks / 10000000LL);
+  return elapsed_seconds.count() / unit.count();
+}
+
 auto modification_age_units(const std::filesystem::directory_entry& e,
                             std::chrono::seconds unit)
     -> std::optional<long long> {
-  std::error_code ec;
-  auto write_time = e.last_write_time(ec);
-  if (ec) return std::nullopt;
-
-  auto now = std::filesystem::file_time_type::clock::now();
-  auto elapsed = now - write_time;
-  if (elapsed < std::filesystem::file_time_type::duration::zero()) {
-    elapsed = std::filesystem::file_time_type::duration::zero();
-  }
-
-  auto elapsed_seconds =
-      std::chrono::duration_cast<std::chrono::seconds>(elapsed);
-  return elapsed_seconds.count() / unit.count();
+  return file_age_units(e.path(), FindFileTimeKind::Modify, unit);
 }
 
 auto print_path(std::string_view path, bool null_terminated) -> void;
@@ -1859,6 +1915,34 @@ auto evaluate_expression(const ExprNode& expr, const std::filesystem::path& p,
 
     case ExprKind::Size:
       return expr.size && size_matches(e, *expr.size);
+
+    case ExprKind::ATime: {
+      if (!expr.numeric) return false;
+      auto age =
+          file_age_units(p, FindFileTimeKind::Access, std::chrono::hours(24));
+      return age && numeric_matches(*expr.numeric, *age);
+    }
+
+    case ExprKind::AMin: {
+      if (!expr.numeric) return false;
+      auto age =
+          file_age_units(p, FindFileTimeKind::Access, std::chrono::minutes(1));
+      return age && numeric_matches(*expr.numeric, *age);
+    }
+
+    case ExprKind::CTime: {
+      if (!expr.numeric) return false;
+      auto age =
+          file_age_units(p, FindFileTimeKind::Change, std::chrono::hours(24));
+      return age && numeric_matches(*expr.numeric, *age);
+    }
+
+    case ExprKind::CMin: {
+      if (!expr.numeric) return false;
+      auto age =
+          file_age_units(p, FindFileTimeKind::Change, std::chrono::minutes(1));
+      return age && numeric_matches(*expr.numeric, *age);
+    }
 
     case ExprKind::MTime: {
       if (!expr.numeric) return false;
@@ -1998,6 +2082,28 @@ auto entry_matches(Config& cfg, const std::filesystem::path& p,
   if (cfg.empty_filter && !is_empty_entry(e)) return false;
 
   if (cfg.size_filter && !size_matches(e, *cfg.size_filter)) return false;
+
+  if (cfg.atime_filter) {
+    auto age = file_age_units(p, FindFileTimeKind::Access, std::chrono::hours(24));
+    if (!age || !numeric_matches(*cfg.atime_filter, *age)) return false;
+  }
+
+  if (cfg.amin_filter) {
+    auto age =
+        file_age_units(p, FindFileTimeKind::Access, std::chrono::minutes(1));
+    if (!age || !numeric_matches(*cfg.amin_filter, *age)) return false;
+  }
+
+  if (cfg.ctime_filter) {
+    auto age = file_age_units(p, FindFileTimeKind::Change, std::chrono::hours(24));
+    if (!age || !numeric_matches(*cfg.ctime_filter, *age)) return false;
+  }
+
+  if (cfg.cmin_filter) {
+    auto age =
+        file_age_units(p, FindFileTimeKind::Change, std::chrono::minutes(1));
+    if (!age || !numeric_matches(*cfg.cmin_filter, *age)) return false;
+  }
 
   if (cfg.mtime_filter) {
     auto age = modification_age_units(e, std::chrono::hours(24));

--- a/src/commands/mv.cpp
+++ b/src/commands/mv.cpp
@@ -487,7 +487,7 @@ auto process_command(const CommandContext<N>& ctx) -> cp::Result<bool> {
           if (!is_dir) {
             return std::unexpected(is_dir.error());
           }
-          dest_is_dir = *is_dir;
+          dest_is_dir = *is_dir && !move_ctx.no_target_directory;
         }
         if ((move_ctx.target_directory_option ||
              move_ctx.source_paths.size() > 1) &&

--- a/src/commands/numfmt.cpp
+++ b/src/commands/numfmt.cpp
@@ -62,7 +62,8 @@ auto constexpr NUMFMT_OPTIONS = std::array{
            BOOL_TYPE),
     OPTION("", "--invalid",
            "set policy for invalid values: 'abort' (default), 'warn', 'ignore'",
-           STRING_TYPE)};
+           STRING_TYPE),
+    OPTION("", "--debug", "print conversion diagnostics", BOOL_TYPE)};
 
 // ======================================================
 // Helper functions
@@ -282,10 +283,17 @@ REGISTER_COMMAND(
   header = ctx.get<int>("--header", 0);
   bool grouping = ctx.get<bool>("--grouping", false);
   std::string invalid_policy = ctx.get<std::string>("--invalid", "abort");
+  bool debug = ctx.get<bool>("--debug", false);
   std::string round_mode = ctx.get<std::string>("--round", "");
   int padding = ctx.get<int>("--padding", ctx.get<int>("--pad", 0));
   std::string suffix = ctx.get<std::string>("--suffix", "");
   int selected_field = ctx.get<int>("--field", 0);
+
+  auto debug_log = [&](const std::string& msg) {
+    if (debug) {
+      safeErrorPrint("numfmt: debug: " + msg + "\n");
+    }
+  };
 
   auto add_grouping = [](const std::string& s) -> std::string {
     // Add thousands separator commas
@@ -324,6 +332,9 @@ REGISTER_COMMAND(
   auto process_number = [&](const std::string& s) -> std::string {
     long long num;
     if (!parse_number(s, num, round_mode, from_unit)) {
+      if (debug) {
+        debug_log("failed to parse input '" + s + "'");
+      }
       if (invalid_policy == "warn") {
         safeErrorPrint("numfmt: invalid number: '" + s + "'\n");
       } else if (invalid_policy == "abort") {
@@ -353,6 +364,9 @@ REGISTER_COMMAND(
       } else {
         formatted = format_number(num);
       }
+      if (debug) {
+        debug_log("converted '" + s + "' -> '" + formatted + suffix + "'");
+      }
       return formatted + suffix;
     }
     if (!format_str.empty()) {
@@ -360,10 +374,18 @@ REGISTER_COMMAND(
       if (parse_number_value(s, value, from_unit)) {
         char buf[256];
         snprintf(buf, sizeof(buf), format_str.c_str(), value);
+        if (debug) {
+          debug_log("formatted '" + s + "' -> '" + std::string(buf) + suffix +
+                    "'");
+        }
         return std::string(buf) + suffix;
       }
     }
-    return apply_format(num) + suffix;
+    auto applied = apply_format(num) + suffix;
+    if (debug) {
+      debug_log("formatted '" + s + "' -> '" + applied + "'");
+    }
+    return applied;
   };
 
   int line_num = 0;

--- a/src/commands/od.cpp
+++ b/src/commands/od.cpp
@@ -45,18 +45,21 @@ using cmd::meta::OptionType;
 // ======================================================
 
 auto constexpr OD_OPTIONS = std::array{
-    OPTION("-A", "", "select input base", STRING_TYPE),
+    OPTION("-A", "--address-radix", "select output address radix",
+           STRING_TYPE),
     OPTION("-a", "", "select named character output"),
     OPTION("-b", "", "select octal byte output"),
     OPTION("-c", "", "select ASCII output"),
     OPTION("-d", "", "select unsigned decimal 2-byte output"),
-    OPTION("-j", "", "skip bytes", STRING_TYPE),
-    OPTION("-N", "", "limit bytes", STRING_TYPE),
+    OPTION("-j", "--skip-bytes", "skip bytes", STRING_TYPE),
+    OPTION("-N", "--read-bytes", "limit bytes", STRING_TYPE),
     OPTION("-o", "", "select octal 2-byte output"),
-    OPTION("-t", "", "select output type", STRING_TYPE),
-    OPTION("-v", "", "write all input data"),
+    OPTION("-t", "--format", "select output type", STRING_TYPE),
+    OPTION("-v", "--output-duplicates", "write all input data"),
     OPTION("-w", "--width", "output bytes per line", OPTIONAL_STRING_TYPE),
     OPTION("-x", "", "select hexadecimal 2-byte units"),
+    OPTION("", "--endian", "byte order for multi-byte input units",
+           STRING_TYPE),
     OPTION("", "--traditional",
            "accept arguments in traditional form (e.g., od -x file)")};
 
@@ -66,6 +69,7 @@ auto constexpr OD_OPTIONS = std::array{
 
 namespace od_pipeline {
 enum class AddressBase { octal, decimal, hex, none };
+enum class Endian { little, big };
 enum class FormatKind {
   octal,
   hexadecimal,
@@ -88,6 +92,7 @@ struct Config {
   std::optional<size_t> limit_bytes;
   size_t bytes_per_line = 16;
   bool abbreviate_duplicate_blocks = true;
+  Endian endian = Endian::little;
   std::vector<FormatSpec> specs;
   std::vector<std::string> files;
 };
@@ -285,11 +290,19 @@ auto address_to_string(size_t address, AddressBase base, size_t width)
   return out.str();
 }
 
-auto load_little_endian(const std::vector<unsigned char>& data, size_t offset,
-                        size_t available, size_t size) -> uint64_t {
+auto load_integer(const std::vector<unsigned char>& data, size_t offset,
+                  size_t available, size_t size, Endian endian) -> uint64_t {
   uint64_t value = 0;
-  for (size_t i = 0; i < size && i < available; ++i) {
-    value |= static_cast<uint64_t>(data[offset + i]) << (i * 8);
+  if (endian == Endian::little) {
+    for (size_t i = 0; i < size && i < available; ++i) {
+      value |= static_cast<uint64_t>(data[offset + i]) << (i * CHAR_BIT);
+    }
+    return value;
+  }
+
+  for (size_t i = 0; i < size; ++i) {
+    value <<= CHAR_BIT;
+    if (i < available) value |= data[offset + i];
   }
   return value;
 }
@@ -392,7 +405,8 @@ auto append_formatted_line(std::string& output, const Config& cfg,
     } else if (spec.kind == FormatKind::named_character) {
       field << std::setw(width) << format_named_character(data[offset + i]);
     } else {
-      uint64_t raw = load_little_endian(data, offset + i, available, spec.size);
+      uint64_t raw =
+          load_integer(data, offset + i, available, spec.size, cfg.endian);
       if (spec.kind == FormatKind::hexadecimal) {
         field << std::setfill('0') << std::setw(width) << std::hex
               << std::nouppercase << raw;
@@ -513,6 +527,18 @@ auto build_config(const CommandContext<OD_OPTIONS.size()>& ctx)
       auto parsed = parse_positive_count("-w", width);
       if (!parsed) return std::nullopt;
       cfg.bytes_per_line = *parsed;
+    }
+  }
+
+  if (ctx.has("--endian")) {
+    const auto endian = ctx.get<std::string>("--endian", "");
+    if (endian == "little") {
+      cfg.endian = Endian::little;
+    } else if (endian == "big") {
+      cfg.endian = Endian::big;
+    } else {
+      safeErrorPrintLn("od: invalid endian value '" + endian + "'");
+      return std::nullopt;
     }
   }
 

--- a/src/commands/ps.cpp
+++ b/src/commands/ps.cpp
@@ -55,6 +55,8 @@ auto constexpr PS_OPTIONS = std::array{
     OPTION("-f", "", "do full-format listing"),
     OPTION("-l", "", "long format"),
     OPTION("-u", "", "display user-oriented format"),
+    OPTION("-p", "--pid", "select processes by process ID", STRING_TYPE),
+    OPTION("-o", "--format", "select output fields", STRING_TYPE),
     OPTION("", "--user", "filter processes by user name", STRING_TYPE),
     OPTION("-x", "", "lift the BSD-style \"must have a tty\" restriction"),
     OPTION("-w", "", "wide output (do not truncate command lines)"),
@@ -87,6 +89,8 @@ struct Config {
   bool user_format = false;
   bool wide_output = false;
   bool no_headers = false;
+  std::vector<DWORD> pid_filter;
+  std::vector<std::string> format_fields;
   std::string user_filter;
   std::string sort_key;
 };
@@ -320,6 +324,81 @@ auto format_memory(SIZE_T bytes) -> std::wstring {
   return buffer;
 }
 
+auto trim_ascii(std::string_view text) -> std::string_view {
+  while (!text.empty() && std::isspace(static_cast<unsigned char>(text.front()))) {
+    text.remove_prefix(1);
+  }
+  while (!text.empty() && std::isspace(static_cast<unsigned char>(text.back()))) {
+    text.remove_suffix(1);
+  }
+  return text;
+}
+
+auto split_ps_list(std::string_view text) -> std::vector<std::string_view> {
+  std::vector<std::string_view> values;
+  size_t start = 0;
+  for (size_t i = 0; i <= text.size(); ++i) {
+    const bool at_end = i == text.size();
+    const bool is_sep = !at_end &&
+                        (text[i] == ',' || std::isspace(static_cast<unsigned char>(text[i])));
+    if (!at_end && !is_sep) continue;
+
+    auto item = trim_ascii(text.substr(start, i - start));
+    if (!item.empty()) values.push_back(item);
+    start = i + 1;
+  }
+  return values;
+}
+
+auto parse_pid_value(std::string_view text) -> std::optional<DWORD> {
+  text = trim_ascii(text);
+  if (text.empty()) return std::nullopt;
+
+  uint64_t value = 0;
+  auto [ptr, ec] = std::from_chars(text.data(), text.data() + text.size(), value);
+  if (ec != std::errc() || ptr != text.data() + text.size() ||
+      value > std::numeric_limits<DWORD>::max()) {
+    return std::nullopt;
+  }
+  return static_cast<DWORD>(value);
+}
+
+auto append_pid_filter(std::string_view raw, std::vector<DWORD>& pids)
+    -> std::optional<std::string> {
+  for (auto token : split_ps_list(raw)) {
+    auto pid = parse_pid_value(token);
+    if (!pid) return "invalid process ID: " + std::string(token);
+    pids.push_back(*pid);
+  }
+  return std::nullopt;
+}
+
+auto normalize_format_field(std::string_view field) -> std::string {
+  auto trimmed = trim_ascii(field);
+  std::string normalized(trimmed);
+  std::transform(normalized.begin(), normalized.end(), normalized.begin(),
+                 [](unsigned char ch) { return static_cast<char>(std::tolower(ch)); });
+  return normalized;
+}
+
+auto is_supported_format_field(std::string_view field) -> bool {
+  return field == "pid" || field == "ppid" || field == "comm" ||
+         field == "args" || field == "user" || field == "etime" ||
+         field == "rss" || field == "pmem" || field == "pcpu";
+}
+
+auto append_format_fields(std::string_view raw, std::vector<std::string>& fields)
+    -> std::optional<std::string> {
+  for (auto token : split_ps_list(raw)) {
+    auto field = normalize_format_field(token);
+    if (!is_supported_format_field(field)) {
+      return "unsupported format field: " + std::string(token);
+    }
+    fields.push_back(std::move(field));
+  }
+  return std::nullopt;
+}
+
 // Build config from context
 auto build_config(const CommandContext<PS_OPTIONS.size()>& ctx)
     -> cp::Result<Config> {
@@ -336,6 +415,18 @@ auto build_config(const CommandContext<PS_OPTIONS.size()>& ctx)
   cfg.wide_output = ctx.get<bool>("-w", false);
   cfg.no_headers = ctx.get<bool>("--no-headers", false);
   cfg.sort_key = ctx.get<std::string>("--sort", "");
+
+  for (const auto& occurrence : ctx.string_occurrences({"-p", "--pid"})) {
+    if (auto error = append_pid_filter(occurrence.value, cfg.pid_filter)) {
+      return std::unexpected(*error);
+    }
+  }
+
+  for (const auto& occurrence : ctx.string_occurrences({"-o", "--format"})) {
+    if (auto error = append_format_fields(occurrence.value, cfg.format_fields)) {
+      return std::unexpected(*error);
+    }
+  }
 
   // If no specific processes requested and no -e/-A, default to current user's
   // processes
@@ -550,6 +641,133 @@ auto print_user(const std::vector<ProcessInfo>& processes, bool no_headers)
   }
 }
 
+auto filetime_to_uint64(const FILETIME& ft) -> ULONGLONG {
+  ULARGE_INTEGER value;
+  value.LowPart = ft.dwLowDateTime;
+  value.HighPart = ft.dwHighDateTime;
+  return value.QuadPart;
+}
+
+auto process_cpu_seconds(const ProcessInfo& proc) -> double {
+  const ULONGLONG total_100ns = filetime_to_uint64(proc.kernel_time) +
+                                filetime_to_uint64(proc.user_time);
+  return static_cast<double>(total_100ns) / 10000000.0;
+}
+
+auto process_elapsed_seconds(const ProcessInfo& proc) -> ULONGLONG {
+  const ULONGLONG started = filetime_to_uint64(proc.create_time);
+  if (started == 0) return 0;
+
+  FILETIME now_ft;
+  GetSystemTimeAsFileTime(&now_ft);
+  const ULONGLONG now = filetime_to_uint64(now_ft);
+  if (now <= started) return 0;
+  return (now - started) / 10000000ULL;
+}
+
+auto format_etime(ULONGLONG seconds) -> std::wstring {
+  const ULONGLONG days = seconds / 86400ULL;
+  seconds %= 86400ULL;
+  const ULONGLONG hours = seconds / 3600ULL;
+  seconds %= 3600ULL;
+  const ULONGLONG minutes = seconds / 60ULL;
+  seconds %= 60ULL;
+
+  wchar_t buffer[32];
+  if (days > 0) {
+    swprintf_s(buffer, L"%llu-%02llu:%02llu:%02llu", days, hours, minutes,
+               seconds);
+  } else if (hours > 0) {
+    swprintf_s(buffer, L"%llu:%02llu:%02llu", hours, minutes, seconds);
+  } else {
+    swprintf_s(buffer, L"%02llu:%02llu", minutes, seconds);
+  }
+  return buffer;
+}
+
+auto total_physical_memory() -> unsigned long long {
+  MEMORYSTATUSEX mem_status;
+  mem_status.dwLength = sizeof(mem_status);
+  if (!GlobalMemoryStatusEx(&mem_status)) return 0;
+  return mem_status.ullTotalPhys;
+}
+
+auto format_percent(double value) -> std::wstring {
+  wchar_t buffer[32];
+  swprintf_s(buffer, L"%.1f", value);
+  return buffer;
+}
+
+auto custom_field_header(std::string_view field) -> std::wstring {
+  if (field == "pid") return L"PID";
+  if (field == "ppid") return L"PPID";
+  if (field == "comm") return L"COMMAND";
+  if (field == "args") return L"COMMAND";
+  if (field == "user") return L"USER";
+  if (field == "etime") return L"ELAPSED";
+  if (field == "rss") return L"RSS";
+  if (field == "pmem") return L"%MEM";
+  if (field == "pcpu") return L"%CPU";
+  return utf8_to_wstring(std::string(field));
+}
+
+auto custom_field_value(const ProcessInfo& proc, std::string_view field,
+                        unsigned long long total_memory) -> std::wstring {
+  if (field == "pid") return std::to_wstring(proc.pid);
+  if (field == "ppid") return std::to_wstring(proc.ppid);
+  if (field == "comm") return proc.name;
+  if (field == "args") return proc.command_line.empty() ? proc.name : proc.command_line;
+  if (field == "user") return proc.user;
+  if (field == "etime") return format_etime(process_elapsed_seconds(proc));
+  if (field == "rss") return std::to_wstring(proc.working_set_size / 1024);
+  if (field == "pmem") {
+    const double percent = total_memory == 0
+                               ? 0.0
+                               : (static_cast<double>(proc.working_set_size) * 100.0 /
+                                  static_cast<double>(total_memory));
+    return format_percent(percent);
+  }
+  if (field == "pcpu") {
+    const auto elapsed = process_elapsed_seconds(proc);
+    const double percent = elapsed == 0
+                               ? 0.0
+                               : (process_cpu_seconds(proc) * 100.0 /
+                                  static_cast<double>(elapsed));
+    return format_percent(percent);
+  }
+  return L"";
+}
+
+auto join_columns(const std::vector<std::wstring>& columns) -> std::wstring {
+  std::wstring line;
+  for (size_t i = 0; i < columns.size(); ++i) {
+    if (i != 0) line += L" ";
+    line += columns[i];
+  }
+  return line;
+}
+
+auto print_custom(const std::vector<ProcessInfo>& processes,
+                  const std::vector<std::string>& fields, bool no_headers)
+    -> void {
+  if (!no_headers) {
+    std::vector<std::wstring> headers;
+    headers.reserve(fields.size());
+    for (const auto& field : fields) headers.push_back(custom_field_header(field));
+    safePrintLn(join_columns(headers));
+  }
+
+  const auto total_memory = total_physical_memory();
+  for (const auto& proc : processes) {
+    std::vector<std::wstring> values;
+    values.reserve(fields.size());
+    for (const auto& field : fields) {
+      values.push_back(custom_field_value(proc, field, total_memory));
+    }
+    safePrintLn(join_columns(values));
+  }
+}
+
 // Main execution
 auto run(const Config& cfg) -> int {
   auto result = enumerate_processes();
@@ -569,6 +787,16 @@ auto run(const Config& cfg) -> int {
     processes.erase(it, processes.end());
   }
 
+  // Filter by PID if specified
+  if (!cfg.pid_filter.empty()) {
+    auto it = std::remove_if(processes.begin(), processes.end(),
+                             [&](const ProcessInfo& p) {
+                               return std::ranges::find(cfg.pid_filter, p.pid) ==
+                                      cfg.pid_filter.end();
+                             });
+    processes.erase(it, processes.end());
+  }
+
   // Sort if requested
   if (!cfg.sort_key.empty()) {
     sort_processes(processes, cfg.sort_key);
@@ -578,7 +806,9 @@ auto run(const Config& cfg) -> int {
   }
 
   // Print in requested format
-  if (cfg.full_format) {
+  if (!cfg.format_fields.empty()) {
+    print_custom(processes, cfg.format_fields, cfg.no_headers);
+  } else if (cfg.full_format) {
     print_full(processes, cfg.no_headers);
   } else if (cfg.user_format || cfg.long_format) {
     print_user(processes, cfg.no_headers);

--- a/src/commands/split.cpp
+++ b/src/commands/split.cpp
@@ -96,12 +96,13 @@ auto resolve_input_file(const CommandContext<SPLIT_OPTIONS.size()>& ctx)
 struct Config {
   enum class Mode { Lines, Bytes, LineBytes, Number };
   enum class SuffixKind { Alpha, Numeric, Hex };
-  enum class NumberMode { ApproximateBytes, PreserveRecords };
+  enum class NumberMode { ApproximateBytes, PreserveRecords, RoundRobin };
 
   Mode mode = Mode::Lines;
   int64_t chunk_size = 0;
   int64_t chunk_lines = 1000;  // Default: 1000 lines per file
   int64_t num_chunks = 0;      // For -n mode
+  std::optional<int64_t> selected_chunk;  // GNU k/N forms, 1-based
   NumberMode number_mode = NumberMode::ApproximateBytes;
   SuffixKind suffix_kind = SuffixKind::Alpha;
   int suffix_length = 2;
@@ -295,8 +296,7 @@ auto build_config(const CommandContext<SPLIT_OPTIONS.size()>& ctx)
   }
 
   if (!number_opt.empty()) {
-    // -n supports: N (n chunks), k/N (chunk k of n), l/N (n line-oriented
-    // chunks), l/k/N (chunk k of n line-oriented), r/N (n round-robin), r/k/N
+    // GNU -n supports: N, k/N, l/N, l/k/N, r/N, and r/k/N.
     bool line_mode = false;
     bool round_robin = false;
     std::string val = number_opt;
@@ -311,21 +311,45 @@ auto build_config(const CommandContext<SPLIT_OPTIONS.size()>& ctx)
       if (!val.empty() && val[0] == '/') val = val.substr(1);
     }
 
-    if (round_robin) {
-      return std::unexpected("unsupported --number mode");
+    std::vector<std::string_view> parts;
+    size_t start = 0;
+    while (start <= val.size()) {
+      size_t slash = val.find('/', start);
+      if (slash == std::string::npos) {
+        parts.push_back(std::string_view(val).substr(start));
+        break;
+      }
+      parts.push_back(std::string_view(val).substr(start, slash - start));
+      start = slash + 1;
+    }
+    if (parts.empty() || parts.size() > 2 ||
+        std::ranges::any_of(parts, [](std::string_view part) {
+          return part.empty();
+        })) {
+      return std::unexpected("invalid number of chunks");
     }
 
-    // Only GNU's plain N and l/N modes are implemented here.
-    if (val.find('/') != std::string::npos) {
-      return std::unexpected("unsupported --number mode");
+    auto parse_number_part = [](std::string_view part, std::string_view name)
+        -> cp::Result<int64_t> {
+      return parse_positive_i64(std::string(part), name);
+    };
+
+    if (parts.size() == 2) {
+      auto chunk_result = parse_number_part(parts[0], "chunk number");
+      if (!chunk_result) return std::unexpected(chunk_result.error());
+      cfg.selected_chunk = *chunk_result;
     }
 
-    auto num_result = parse_positive_i64(val, "number of chunks");
+    auto num_result = parse_number_part(parts.back(), "number of chunks");
     if (!num_result) return std::unexpected(num_result.error());
     cfg.num_chunks = *num_result;
+    if (cfg.selected_chunk.has_value() && *cfg.selected_chunk > cfg.num_chunks) {
+      return std::unexpected("chunk number out of range");
+    }
     cfg.mode = Config::Mode::Number;
-    cfg.number_mode = line_mode ? Config::NumberMode::PreserveRecords
-                                : Config::NumberMode::ApproximateBytes;
+    cfg.number_mode = round_robin ? Config::NumberMode::RoundRobin
+                      : line_mode  ? Config::NumberMode::PreserveRecords
+                                   : Config::NumberMode::ApproximateBytes;
   }
 
   if (ctx.has("--numeric-suffixes") || ctx.has("-d")) {
@@ -739,29 +763,61 @@ auto run(const Config& cfg) -> int {
       }
     }
   } else if (cfg.mode == Config::Mode::Number) {
+    auto write_number_chunk = [&](std::string_view chunk) -> bool {
+      auto result = write_chunk(cfg, part_num, chunk);
+      if (!result) {
+        cp::report_error(result, L"split");
+        return false;
+      }
+      if (*result) ++part_num;
+      return true;
+    };
+
     if (cfg.number_mode == Config::NumberMode::PreserveRecords) {
       auto records = collect_record_spans(input, cfg.separator);
       const size_t total_records = records.size();
 
-      for (int64_t i = 0; i < cfg.num_chunks; ++i) {
-        const size_t start_record = (static_cast<size_t>(i) * total_records) /
+      auto record_chunk = [&](int64_t index) -> std::string_view {
+        const size_t start_record = (static_cast<size_t>(index) * total_records) /
                                     static_cast<size_t>(cfg.num_chunks);
-        const size_t end_record = (static_cast<size_t>(i + 1) * total_records) /
-                                  static_cast<size_t>(cfg.num_chunks);
+        const size_t end_record =
+            (static_cast<size_t>(index + 1) * total_records) /
+            static_cast<size_t>(cfg.num_chunks);
+        if (start_record >= end_record) return {};
 
-        std::string_view chunk;
-        if (start_record < end_record) {
-          const size_t start = records[start_record].start;
-          const size_t end = records[end_record - 1].end;
-          chunk = std::string_view(input.data() + start, end - start);
-        }
+        const size_t start = records[start_record].start;
+        const size_t end = records[end_record - 1].end;
+        return std::string_view(input.data() + start, end - start);
+      };
 
-        auto result = write_chunk(cfg, part_num, chunk);
-        if (!result) {
-          cp::report_error(result, L"split");
-          return 1;
+      if (cfg.selected_chunk.has_value()) {
+        safePrint(record_chunk(*cfg.selected_chunk - 1));
+      } else {
+        for (int64_t i = 0; i < cfg.num_chunks; ++i) {
+          if (!write_number_chunk(record_chunk(i))) return 1;
         }
-        if (*result) ++part_num;
+      }
+    } else if (cfg.number_mode == Config::NumberMode::RoundRobin) {
+      auto records = collect_record_spans(input, cfg.separator);
+      const size_t num_chunks = static_cast<size_t>(cfg.num_chunks);
+
+      if (cfg.selected_chunk.has_value()) {
+        const size_t selected = static_cast<size_t>(*cfg.selected_chunk - 1);
+        for (size_t i = selected; i < records.size(); i += num_chunks) {
+          const auto& record = records[i];
+          safePrint(std::string_view(input.data() + record.start,
+                                     record.end - record.start));
+        }
+      } else {
+        std::vector<std::string> chunks(num_chunks);
+        for (size_t i = 0; i < records.size(); ++i) {
+          const auto& record = records[i];
+          chunks[i % num_chunks].append(input.data() + record.start,
+                                        record.end - record.start);
+        }
+        for (const auto& chunk : chunks) {
+          if (!write_number_chunk(chunk)) return 1;
+        }
       }
     } else {
       // Split into N roughly equal chunks.
@@ -769,23 +825,29 @@ auto run(const Config& cfg) -> int {
           input.size() / static_cast<size_t>(cfg.num_chunks));
       if (chunk_size == 0) chunk_size = 1;
 
-      for (int64_t i = 0; i < cfg.num_chunks; ++i) {
-        size_t start = static_cast<size_t>(i * chunk_size);
+      auto byte_chunk = [&](int64_t index) -> std::string_view {
+        size_t start = static_cast<size_t>(index * chunk_size);
+        if (start >= input.size()) return {};
+
         size_t end;
-        if (i == cfg.num_chunks - 1) {
+        if (index == cfg.num_chunks - 1) {
           end = input.size();
         } else {
-          end = static_cast<size_t>((i + 1) * chunk_size);
+          end = static_cast<size_t>((index + 1) * chunk_size);
         }
-        if (start >= input.size()) break;
+        return std::string_view(input.data() + start, end - start);
+      };
 
-        auto result = write_chunk(
-            cfg, part_num, std::string_view(input.data() + start, end - start));
-        if (!result) {
-          cp::report_error(result, L"split");
-          return 1;
+      if (cfg.selected_chunk.has_value()) {
+        safePrint(byte_chunk(*cfg.selected_chunk - 1));
+      } else {
+        for (int64_t i = 0; i < cfg.num_chunks; ++i) {
+          auto chunk = byte_chunk(i);
+          if (chunk.empty() && static_cast<size_t>(i * chunk_size) >= input.size()) {
+            break;
+          }
+          if (!write_number_chunk(chunk)) return 1;
         }
-        if (*result) ++part_num;
       }
     }
   } else if (cfg.mode == Config::Mode::Bytes) {

--- a/src/commands/time.cpp
+++ b/src/commands/time.cpp
@@ -1,0 +1,273 @@
+/*
+ *  Copyright © 2026 WinuxCmd
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ *  IN THE SOFTWARE.
+ *
+ *  - File: time.cpp
+ *  - CopyrightYear: 2026
+ */
+
+#include "pch/pch.h"
+#include "core/command_macros.h"
+
+import std;
+import core;
+import utils;
+
+using cmd::meta::OptionMeta;
+using cmd::meta::OptionType;
+
+constexpr auto TIME_OPTIONS = std::array{
+    OPTION("-p", "--posix", "report timing in POSIX format")};
+
+namespace time_pipeline {
+namespace cp = core::pipeline;
+
+struct HandleCloser {
+  void operator()(HANDLE handle) const {
+    if (handle && handle != INVALID_HANDLE_VALUE) {
+      CloseHandle(handle);
+    }
+  }
+};
+
+using unique_handle = std::unique_ptr<std::remove_pointer_t<HANDLE>, HandleCloser>;
+
+struct LaunchCommand {
+  std::optional<std::wstring> application_name;
+  std::wstring command_line;
+};
+
+struct Config {
+  bool posix = false;
+  std::string command;
+  SmallVector<std::string, 64> args;
+};
+
+[[nodiscard]] auto filetime_to_ticks(const FILETIME& ft) -> unsigned long long {
+  ULARGE_INTEGER value{};
+  value.LowPart = ft.dwLowDateTime;
+  value.HighPart = ft.dwHighDateTime;
+  return value.QuadPart;
+}
+
+[[nodiscard]] auto filetime_to_seconds(const FILETIME& ft) -> double {
+  constexpr double kTicksPerSecond = 10000000.0;
+  return static_cast<double>(filetime_to_ticks(ft)) / kTicksPerSecond;
+}
+
+[[nodiscard]] auto build_command_line(std::string_view command,
+                                      std::span<const std::string> args)
+    -> std::wstring {
+  std::wstring command_line =
+      quote_windows_command_arg(utf8_to_wstring(std::string(command)));
+  for (const auto& arg : args) {
+    append_windows_command_arg(command_line, utf8_to_wstring(arg));
+  }
+  return command_line;
+}
+
+[[nodiscard]] auto search_path(std::wstring_view file,
+                               std::wstring_view extension = {})
+    -> std::optional<std::wstring> {
+  const std::wstring file_storage(file);
+  const std::wstring extension_storage(extension);
+  DWORD capacity = MAX_PATH;
+  for (;;) {
+    std::wstring buffer(capacity, L'\0');
+    const DWORD length = SearchPathW(
+        nullptr, file_storage.c_str(),
+        extension_storage.empty() ? nullptr : extension_storage.c_str(), capacity,
+        buffer.data(), nullptr);
+    if (length == 0) return std::nullopt;
+    if (length < capacity) {
+      buffer.resize(length);
+      return buffer;
+    }
+    if (length >= 32768) return std::nullopt;
+    capacity = length + 1;
+  }
+}
+
+[[nodiscard]] auto find_batch_wrapper(std::wstring_view command)
+    -> std::optional<std::wstring> {
+  const std::filesystem::path command_path{command};
+  std::wstring extension = command_path.extension().wstring();
+  std::ranges::transform(extension, extension.begin(), [](wchar_t ch) {
+    return static_cast<wchar_t>(std::towlower(ch));
+  });
+
+  if (extension == L".cmd" || extension == L".bat") {
+    return search_path(command);
+  }
+  if (!extension.empty()) return std::nullopt;
+
+  for (const auto* candidate_extension : {L".cmd", L".bat"}) {
+    if (auto path = search_path(command, candidate_extension)) return path;
+  }
+  return std::nullopt;
+}
+
+[[nodiscard]] auto build_launch_command(std::string_view command,
+                                        std::span<const std::string> args)
+    -> LaunchCommand {
+  const std::wstring wcommand = utf8_to_wstring(std::string(command));
+  if (auto batch_path = find_batch_wrapper(wcommand)) {
+    wchar_t comspec[MAX_PATH]{};
+    const DWORD length = GetEnvironmentVariableW(
+        L"COMSPEC", comspec, static_cast<DWORD>(std::size(comspec)));
+    std::wstring shell = L"cmd.exe";
+    if (length > 0 && length < std::size(comspec)) {
+      shell.assign(comspec, length);
+    }
+
+    std::wstring script_line = quote_windows_command_arg(*batch_path);
+    for (const auto& arg : args) {
+      append_windows_command_arg(script_line, utf8_to_wstring(arg));
+    }
+    return {std::move(shell), L"/d /s /c \"" + script_line + L"\""};
+  }
+
+  return {std::nullopt, build_command_line(command, args)};
+}
+
+[[nodiscard]] auto build_config(const CommandContext<TIME_OPTIONS.size()>& ctx)
+    -> cp::Result<Config> {
+  Config cfg;
+  cfg.posix = ctx.get<bool>("-p", false) || ctx.get<bool>("--posix", false);
+
+  if (ctx.positionals.empty()) {
+    return std::unexpected("missing operand");
+  }
+
+  cfg.command = std::string(ctx.positionals[0]);
+  for (size_t i = 1; i < ctx.positionals.size(); ++i) {
+    cfg.args.push_back(std::string(ctx.positionals[i]));
+  }
+  return cfg;
+}
+
+[[nodiscard]] auto format_seconds(double seconds, bool posix) -> std::string {
+  const auto value = std::max(seconds, 0.0);
+  if (posix) {
+    return std::format("{:.3f}", value);
+  }
+  return std::format("{:.3f}s", value);
+}
+
+[[nodiscard]] auto run(const Config& cfg) -> int {
+  LARGE_INTEGER frequency{};
+  LARGE_INTEGER start{};
+  LARGE_INTEGER finish{};
+  if (!QueryPerformanceFrequency(&frequency) || !QueryPerformanceCounter(&start)) {
+    cp::report_custom_error(L"time", L"failed to read high-resolution clock");
+    return 125;
+  }
+
+  auto launch = build_launch_command(cfg.command, cfg.args);
+
+  STARTUPINFOW si{sizeof(si)};
+  si.dwFlags = STARTF_USESTDHANDLES;
+  si.hStdInput = GetStdHandle(STD_INPUT_HANDLE);
+  si.hStdOutput = GetStdHandle(STD_OUTPUT_HANDLE);
+  si.hStdError = GetStdHandle(STD_ERROR_HANDLE);
+
+  PROCESS_INFORMATION pi{};
+  std::wstring command_line = launch.command_line;
+  const BOOL ok = CreateProcessW(
+      launch.application_name ? launch.application_name->c_str() : nullptr,
+      command_line.data(), nullptr, nullptr, TRUE, 0, nullptr, nullptr, &si,
+      &pi);
+  if (!ok) {
+    const DWORD error = GetLastError();
+    safeErrorPrintLn("time: failed to run command '" + cfg.command + "': " +
+                     win32_posix_error_text(error));
+    return error == ERROR_FILE_NOT_FOUND || error == ERROR_PATH_NOT_FOUND ? 127
+                                                                         : 126;
+  }
+
+  unique_handle process(pi.hProcess);
+  unique_handle thread(pi.hThread);
+
+  const DWORD wait_result = WaitForSingleObject(process.get(), INFINITE);
+  if (wait_result != WAIT_OBJECT_0) {
+    cp::report_custom_error(L"time", L"failed while waiting for command");
+    return 125;
+  }
+
+  if (!QueryPerformanceCounter(&finish)) {
+    cp::report_custom_error(L"time", L"failed to read high-resolution clock");
+    return 125;
+  }
+
+  DWORD exit_code = 0;
+  if (!GetExitCodeProcess(process.get(), &exit_code)) {
+    cp::report_custom_error(L"time", L"failed to read command exit code");
+    return 125;
+  }
+
+  FILETIME creation{};
+  FILETIME exit{};
+  FILETIME kernel{};
+  FILETIME user{};
+  if (!GetProcessTimes(process.get(), &creation, &exit, &kernel, &user)) {
+    cp::report_custom_error(L"time", L"failed to read process times");
+    return 125;
+  }
+
+  const double wall_seconds =
+      static_cast<double>(finish.QuadPart - start.QuadPart) /
+      static_cast<double>(frequency.QuadPart);
+  const double user_seconds = filetime_to_seconds(user);
+  const double sys_seconds = filetime_to_seconds(kernel);
+
+  safeErrorPrintLn("real " + format_seconds(wall_seconds, cfg.posix));
+  safeErrorPrintLn("user " + format_seconds(user_seconds, cfg.posix));
+  safeErrorPrintLn("sys " + format_seconds(sys_seconds, cfg.posix));
+
+  return static_cast<int>(exit_code);
+}
+}  // namespace time_pipeline
+
+REGISTER_COMMAND(
+    time_cmd, "time", "time [OPTION]... COMMAND [ARG]...",
+    "Run a command and report how long it took.\n"
+    "\n"
+    "The command is executed as a child process and the child exit status is\n"
+    "returned unchanged. Timing data is written to standard error.\n"
+    "\n"
+    "With -p, print POSIX-compatible timing lines.",
+    "  time true\n"
+    "  time -p cmd.exe /c exit 7",
+    "bash(1)", "WinuxCmd", "Copyright © 2026 WinuxCmd", TIME_OPTIONS) {
+  using namespace time_pipeline;
+
+  auto cfg_result = build_config(ctx);
+  if (!cfg_result) {
+    if (cfg_result.error() == "missing operand") {
+      safeErrorPrintLn("time: missing operand");
+      safeErrorPrintLn("Try 'time --help' for more information.");
+      return 125;
+    }
+    cp::report_error(cfg_result, L"time");
+    return 1;
+  }
+
+  return run(*cfg_result);
+}

--- a/src/commands/tr.cpp
+++ b/src/commands/tr.cpp
@@ -150,7 +150,7 @@ auto ascii_class(std::string_view name) -> std::optional<std::string> {
   return std::nullopt;
 }
 
-auto parse_set_atom(std::string_view& str) -> cp::Result<std::string> {
+auto parse_atomic_token(std::string_view& str) -> cp::Result<std::string> {
   if (str.empty()) return std::unexpected("missing character");
 
   if (str[0] == '\\') {
@@ -177,6 +177,64 @@ auto parse_set_atom(std::string_view& str) -> cp::Result<std::string> {
   char c = str[0];
   str = str.substr(1);
   return std::string(1, c);
+}
+
+auto parse_repeat_count(std::string_view& str) -> std::optional<size_t> {
+  if (str.empty() || str[0] != '*') return std::nullopt;
+
+  str = str.substr(1);
+  if (str.empty() || str[0] < '0' || str[0] > '9') return std::nullopt;
+
+  size_t count = 0;
+  while (!str.empty() && str[0] >= '0' && str[0] <= '9') {
+    size_t digit = static_cast<size_t>(str[0] - '0');
+    if (count > (std::numeric_limits<size_t>::max() - digit) / 10) {
+      return std::nullopt;
+    }
+    count = count * 10 + digit;
+    str = str.substr(1);
+  }
+
+  return count;
+}
+
+auto parse_set_atom(std::string_view& str) -> cp::Result<std::string> {
+  if (str.empty()) return std::unexpected("missing character");
+
+  if (str[0] == '[') {
+    size_t close = str.find(']');
+    if (close != std::string_view::npos) {
+      std::string_view body = str.substr(1, close - 1);
+
+      if (body.size() >= 3 && body.front() == '=' && body.back() == '=') {
+        std::string_view equiv = body.substr(1, body.size() - 2);
+        auto atom = parse_atomic_token(equiv);
+        if (atom && equiv.empty() && atom->size() == 1) {
+          str = str.substr(close + 1);
+          return *atom;
+        }
+      }
+
+      if (body.find('*') != std::string_view::npos) {
+        std::string_view repeated = body;
+        auto atom = parse_atomic_token(repeated);
+        if (atom && atom->size() == 1) {
+          auto count = parse_repeat_count(repeated);
+          if (count && repeated.empty()) {
+            std::string result;
+            result.reserve(*count);
+            for (size_t i = 0; i < *count; ++i) {
+              result += *atom;
+            }
+            str = str.substr(close + 1);
+            return result;
+          }
+        }
+      }
+    }
+  }
+
+  return parse_atomic_token(str);
 }
 
 // Parse a character set string

--- a/src/commands/xargs.cpp
+++ b/src/commands/xargs.cpp
@@ -149,6 +149,22 @@ auto option_present(const CommandContext<N> &ctx, std::string_view name)
   return false;
 }
 
+template <typename T, size_t N>
+auto last_option_value(const CommandContext<N> &ctx,
+                       std::string_view short_name, std::string_view long_name,
+                       T fallback) -> T {
+  T value = fallback;
+  if (!ctx.metas) return value;
+
+  for (const auto &occurrence : ctx.options.occurrences()) {
+    if (occurrence.index >= N) continue;
+    const auto &meta = (*ctx.metas)[occurrence.index];
+    if (!option_matches(meta, short_name, long_name)) continue;
+    if (const auto *parsed = std::get_if<T>(&occurrence.value)) value = *parsed;
+  }
+  return value;
+}
+
 enum class BatchOptionFamily {
   None,
   MaxArgs,
@@ -1189,10 +1205,8 @@ REGISTER_COMMAND(
   int max_args = batch_options.max_args;
   int max_lines = batch_options.max_lines;
   std::string replace_str = batch_options.replace_str;
-  int max_procs = ctx.get<int>("--max-procs", 1);
-  if (max_procs == 1) max_procs = ctx.get<int>("-P", 1);
-  int max_chars = ctx.get<int>("--max-chars", 0);
-  if (max_chars == 0) max_chars = ctx.get<int>("-s", 0);
+  int max_procs = last_option_value<int>(ctx, "-P", "--max-procs", 1);
+  int max_chars = last_option_value<int>(ctx, "-s", "--max-chars", 0);
   // Windows CreateProcess has a finite command-line limit.  GNU xargs
   // batches by default, so an omitted -s must still enforce that limit.
   if (max_chars == 0) max_chars = kWindowsCommandLineLimit;

--- a/src/commands/xxd.cpp
+++ b/src/commands/xxd.cpp
@@ -8,14 +8,17 @@ import core;
 import utils;
 import container;
 
-auto constexpr XXD_OPTIONS =
-    std::array{OPTION("-r", "--reverse", "reverse: convert hex to binary"),
-               OPTION("-p", "--plain", "plain hexdump"),
-               OPTION("-c", "--cols", "set bytes per line", INT_TYPE),
-               OPTION("-l", "--len", "limit input to LEN bytes", INT_TYPE),
-               OPTION("-u", "--upper-case", "use upper-case hex digits"),
-               OPTION("-i", "--include", "output in C include file style"),
-               OPTION("-n", "--name", "set the variable name used in C include output", STRING_TYPE)};
+auto constexpr XXD_OPTIONS = std::array{
+    OPTION("-r", "--reverse", "reverse: convert hex to binary"),
+    OPTION("-p", "--plain", "plain hexdump"),
+    OPTION("-c", "--cols", "set bytes per line", INT_TYPE),
+    OPTION("-l", "--len", "limit input to LEN bytes", INT_TYPE),
+    OPTION("-s", "--seek", "start at SEEK bytes into input", INT_TYPE),
+    OPTION("-o", "--offset", "add OFFSET to displayed file position", INT_TYPE),
+    OPTION("-u", "--upper-case", "use upper-case hex digits"),
+    OPTION("-i", "--include", "output in C include file style"),
+    OPTION("-n", "--name", "set the variable name used in C include output",
+           STRING_TYPE)};
 
 namespace {
 struct XxdConfig {
@@ -25,6 +28,8 @@ struct XxdConfig {
   bool include = false;
   std::optional<std::string> name;
   std::optional<size_t> length;
+  size_t seek = 0;
+  size_t display_offset = 0;
   size_t columns = 16;
   bool columns_specified = false;
   std::string input_file = "-";
@@ -179,10 +184,10 @@ void print_plain_xxd(const std::vector<unsigned char>& data, size_t columns,
 }
 
 void print_default_xxd(const std::vector<unsigned char>& data, size_t columns,
-                       bool upper_case) {
+                       bool upper_case, size_t display_offset) {
   for (size_t offset = 0; offset < data.size(); offset += columns) {
     size_t count = std::min(columns, data.size() - offset);
-    safePrint(offset_hex(offset, upper_case));
+    safePrint(offset_hex(display_offset + offset, upper_case));
     safePrint(": ");
 
     for (size_t i = 0; i < columns; ++i) {
@@ -210,7 +215,8 @@ std::string include_identifier(std::string_view value) {
   for (unsigned char c : value) {
     identifier.push_back(std::isalnum(c) ? static_cast<char>(c) : '_');
   }
-  if (!identifier.empty() && std::isdigit(static_cast<unsigned char>(identifier.front()))) {
+  if (!identifier.empty() &&
+      std::isdigit(static_cast<unsigned char>(identifier.front()))) {
     identifier.insert(0, "__");
   }
   return identifier;
@@ -218,7 +224,8 @@ std::string include_identifier(std::string_view value) {
 
 std::string default_include_name(std::string_view filename) {
   const size_t separator = filename.find_last_of("/\\");
-  if (separator != std::string_view::npos) filename.remove_prefix(separator + 1);
+  if (separator != std::string_view::npos)
+    filename.remove_prefix(separator + 1);
   return include_identifier(filename);
 }
 
@@ -239,7 +246,8 @@ void print_include_xxd(const std::vector<unsigned char>& data, size_t columns,
       safePrint(offset + count == data.size() ? "\n" : ",\n");
     }
     safePrint("};\n");
-    safePrint("unsigned int " + name + "_len = " + std::to_string(data.size()) + ";\n");
+    safePrint("unsigned int " + name + "_len = " + std::to_string(data.size()) +
+              ";\n");
     return;
   }
 
@@ -260,14 +268,21 @@ XxdConfig build_config(const CommandContext<XXD_OPTIONS.size()>& ctx) {
   cfg.plain = ctx.get<bool>("-p", false) || ctx.get<bool>("--plain", false);
   cfg.upper_case =
       ctx.get<bool>("-u", false) || ctx.get<bool>("--upper-case", false);
-  cfg.include =
-      ctx.get<bool>("-i", false) || ctx.get<bool>("--include", false);
+  cfg.include = ctx.get<bool>("-i", false) || ctx.get<bool>("--include", false);
   if (ctx.has("-n") || ctx.has("--name")) {
     cfg.name = ctx.get<std::string>("--name", ctx.get<std::string>("-n", ""));
   }
   if (ctx.has("-l") || ctx.has("--len")) {
     const int length = ctx.get<int>("--len", ctx.get<int>("-l", 0));
     if (length >= 0) cfg.length = static_cast<size_t>(length);
+  }
+  if (ctx.has("-s") || ctx.has("--seek")) {
+    const int seek = ctx.get<int>("--seek", ctx.get<int>("-s", 0));
+    if (seek >= 0) cfg.seek = static_cast<size_t>(seek);
+  }
+  if (ctx.has("-o") || ctx.has("--offset")) {
+    const int offset = ctx.get<int>("--offset", ctx.get<int>("-o", 0));
+    if (offset >= 0) cfg.display_offset = static_cast<size_t>(offset);
   }
   if (ctx.has("-c") || ctx.has("--cols")) {
     cfg.columns_specified = true;
@@ -336,6 +351,11 @@ REGISTER_COMMAND(xxd,
     return 1;
   }
 
+  if (cfg.seek >= input->size()) {
+    input->clear();
+  } else if (cfg.seek > 0) {
+    input->erase(input->begin(), input->begin() + cfg.seek);
+  }
   if (cfg.length && *cfg.length < input->size()) input->resize(*cfg.length);
 
   if (cfg.reverse) {
@@ -382,7 +402,7 @@ REGISTER_COMMAND(xxd,
   } else if (cfg.plain) {
     print_plain_xxd(*input, cfg.columns, cfg.upper_case);
   } else {
-    print_default_xxd(*input, cfg.columns, cfg.upper_case);
+    print_default_xxd(*input, cfg.columns, cfg.upper_case, cfg.display_offset);
   }
   return 0;
 }

--- a/src/commands/xxd.cpp
+++ b/src/commands/xxd.cpp
@@ -12,14 +12,19 @@ auto constexpr XXD_OPTIONS =
     std::array{OPTION("-r", "--reverse", "reverse: convert hex to binary"),
                OPTION("-p", "--plain", "plain hexdump"),
                OPTION("-c", "--cols", "set bytes per line", INT_TYPE),
-               OPTION("-u", "--upper-case", "use upper-case hex digits")};
+               OPTION("-u", "--upper-case", "use upper-case hex digits"),
+               OPTION("-i", "--include", "output in C include file style"),
+               OPTION("-n", "--name", "set the variable name used in C include output", STRING_TYPE)};
 
 namespace {
 struct XxdConfig {
   bool reverse = false;
   bool plain = false;
   bool upper_case = false;
+  bool include = false;
+  std::optional<std::string> name;
   size_t columns = 16;
+  bool columns_specified = false;
   std::string input_file = "-";
   std::optional<std::string> output_file;
 };
@@ -197,13 +202,69 @@ void print_default_xxd(const std::vector<unsigned char>& data, size_t columns,
   }
 }
 
+std::string include_identifier(std::string_view value) {
+  std::string identifier;
+  identifier.reserve(value.size() + 2);
+  for (unsigned char c : value) {
+    identifier.push_back(std::isalnum(c) ? static_cast<char>(c) : '_');
+  }
+  if (!identifier.empty() && std::isdigit(static_cast<unsigned char>(identifier.front()))) {
+    identifier.insert(0, "__");
+  }
+  return identifier;
+}
+
+std::string default_include_name(std::string_view filename) {
+  const size_t separator = filename.find_last_of("/\\");
+  if (separator != std::string_view::npos) filename.remove_prefix(separator + 1);
+  return include_identifier(filename);
+}
+
+void print_include_xxd(const std::vector<unsigned char>& data, size_t columns,
+                       bool upper_case, std::string_view filename,
+                       const std::optional<std::string>& explicit_name) {
+  if (explicit_name || filename != "-") {
+    const std::string name = explicit_name ? include_identifier(*explicit_name)
+                                           : default_include_name(filename);
+    safePrint("unsigned char " + name + "[] = {\n");
+    for (size_t offset = 0; offset < data.size(); offset += columns) {
+      const size_t count = std::min(columns, data.size() - offset);
+      safePrint("  ");
+      for (size_t i = 0; i < count; ++i) {
+        if (i != 0) safePrint(", ");
+        safePrint("0x" + byte_hex(data[offset + i], upper_case));
+      }
+      safePrint(offset + count == data.size() ? "\n" : ",\n");
+    }
+    safePrint("};\n");
+    safePrint("unsigned int " + name + "_len = " + std::to_string(data.size()) + ";\n");
+    return;
+  }
+
+  for (size_t offset = 0; offset < data.size(); offset += columns) {
+    const size_t count = std::min(columns, data.size() - offset);
+    safePrint("  ");
+    for (size_t i = 0; i < count; ++i) {
+      if (i != 0) safePrint(", ");
+      safePrint("0x" + byte_hex(data[offset + i], upper_case));
+    }
+    safePrint("\n");
+  }
+}
+
 XxdConfig build_config(const CommandContext<XXD_OPTIONS.size()>& ctx) {
   XxdConfig cfg;
   cfg.reverse = ctx.get<bool>("-r", false) || ctx.get<bool>("--reverse", false);
   cfg.plain = ctx.get<bool>("-p", false) || ctx.get<bool>("--plain", false);
   cfg.upper_case =
       ctx.get<bool>("-u", false) || ctx.get<bool>("--upper-case", false);
+  cfg.include =
+      ctx.get<bool>("-i", false) || ctx.get<bool>("--include", false);
+  if (ctx.has("-n") || ctx.has("--name")) {
+    cfg.name = ctx.get<std::string>("--name", ctx.get<std::string>("-n", ""));
+  }
   if (ctx.has("-c") || ctx.has("--cols")) {
+    cfg.columns_specified = true;
     int cols = ctx.get<int>("--cols", ctx.get<int>("-c", 16));
     if (cols <= 0) {
       throw std::runtime_error(winux::i18n::translate(
@@ -307,7 +368,10 @@ REGISTER_COMMAND(xxd,
     return 0;
   }
 
-  if (cfg.plain) {
+  if (cfg.include) {
+    print_include_xxd(*input, cfg.columns_specified ? cfg.columns : 12,
+                      cfg.upper_case, cfg.input_file, cfg.name);
+  } else if (cfg.plain) {
     print_plain_xxd(*input, cfg.columns, cfg.upper_case);
   } else {
     print_default_xxd(*input, cfg.columns, cfg.upper_case);

--- a/src/commands/xxd.cpp
+++ b/src/commands/xxd.cpp
@@ -12,6 +12,7 @@ auto constexpr XXD_OPTIONS =
     std::array{OPTION("-r", "--reverse", "reverse: convert hex to binary"),
                OPTION("-p", "--plain", "plain hexdump"),
                OPTION("-c", "--cols", "set bytes per line", INT_TYPE),
+               OPTION("-l", "--len", "limit input to LEN bytes", INT_TYPE),
                OPTION("-u", "--upper-case", "use upper-case hex digits"),
                OPTION("-i", "--include", "output in C include file style"),
                OPTION("-n", "--name", "set the variable name used in C include output", STRING_TYPE)};
@@ -23,6 +24,7 @@ struct XxdConfig {
   bool upper_case = false;
   bool include = false;
   std::optional<std::string> name;
+  std::optional<size_t> length;
   size_t columns = 16;
   bool columns_specified = false;
   std::string input_file = "-";
@@ -263,6 +265,10 @@ XxdConfig build_config(const CommandContext<XXD_OPTIONS.size()>& ctx) {
   if (ctx.has("-n") || ctx.has("--name")) {
     cfg.name = ctx.get<std::string>("--name", ctx.get<std::string>("-n", ""));
   }
+  if (ctx.has("-l") || ctx.has("--len")) {
+    const int length = ctx.get<int>("--len", ctx.get<int>("-l", 0));
+    if (length >= 0) cfg.length = static_cast<size_t>(length);
+  }
   if (ctx.has("-c") || ctx.has("--cols")) {
     cfg.columns_specified = true;
     int cols = ctx.get<int>("--cols", ctx.get<int>("-c", 16));
@@ -329,6 +335,8 @@ REGISTER_COMMAND(xxd,
                                          cfg.input_file));
     return 1;
   }
+
+  if (cfg.length && *cfg.length < input->size()) input->resize(*cfg.length);
 
   if (cfg.reverse) {
     std::optional<std::vector<unsigned char>> decoded;

--- a/tests/unit/cal/cal_unit_test.cpp
+++ b/tests/unit/cal/cal_unit_test.cpp
@@ -99,3 +99,27 @@ TEST(cal, cal_single_year_outputs_year_calendar) {
   EXPECT_TRUE(r.stdout_text.find("December 2026") != std::string::npos);
   EXPECT_TRUE(r.stdout_text.find("July 2026") != std::string::npos);
 }
+TEST(cal, cal_monday_first_month) {
+  Pipeline p;
+  p.add(L"cal.exe", {L"-m", L"3", L"2024"});
+
+  TEST_LOG_CMD_LIST("cal.exe", L"-m", L"3", L"2024");
+
+  auto r = p.run();
+
+  TEST_LOG_EXIT_CODE(r);
+  TEST_LOG("cal output", r.stdout_text);
+
+  std::string expected;
+  expected += "          March 2024\n";
+  expected += "Mo Tu We Th Fr Sa Su\n";
+  expected += "             1  2  3\n";
+  expected += " 4  5  6  7  8  9 10\n";
+  expected += "11 12 13 14 15 16 17\n";
+  expected += "18 19 20 21 22 23 24\n";
+  expected += "25 26 27 28 29 30 31\n";
+  expected += "                    \n";
+
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_EQ_TEXT(r.stdout_text, expected);
+}

--- a/tests/unit/cp/cp_unit_test.cpp
+++ b/tests/unit/cp/cp_unit_test.cpp
@@ -22,6 +22,8 @@
  *  - File: cp_unit_test.cpp
  *  - CopyrightYear: 2026
  */
+#include <chrono>
+
 #include "framework/winuxtest.h"
 
 TEST(cp, cp_basic_copy) {
@@ -477,6 +479,11 @@ TEST(cp, cp_update_skips_newer_destination) {
   tmp.write("source.txt", "source content");
   tmp.write("dest.txt", "newer destination");
 
+  const auto now = std::filesystem::file_time_type::clock::now();
+  std::filesystem::last_write_time(tmp.path / "source.txt",
+                                   now - std::chrono::hours(2));
+  std::filesystem::last_write_time(tmp.path / "dest.txt", now);
+
   Pipeline p;
   p.set_cwd(tmp.wpath());
   p.add(L"cp.exe", {L"-u", L"source.txt", L"dest.txt"});
@@ -485,6 +492,26 @@ TEST(cp, cp_update_skips_newer_destination) {
 
   EXPECT_EQ(r.exit_code, 0);
   EXPECT_EQ(tmp.read("dest.txt"), "newer destination");
+}
+
+TEST(cp, cp_update_overwrites_older_destination) {
+  TempDir tmp;
+  tmp.write("source.txt", "newer source");
+  tmp.write("dest.txt", "old destination");
+
+  const auto now = std::filesystem::file_time_type::clock::now();
+  std::filesystem::last_write_time(tmp.path / "dest.txt",
+                                   now - std::chrono::hours(2));
+  std::filesystem::last_write_time(tmp.path / "source.txt", now);
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"cp.exe", {L"--update", L"source.txt", L"dest.txt"});
+
+  auto r = p.run();
+
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_EQ(tmp.read("dest.txt"), "newer source");
 }
 
 TEST(cp, cp_wildcard_sources_expand) {

--- a/tests/unit/cp/cp_unit_test.cpp
+++ b/tests/unit/cp/cp_unit_test.cpp
@@ -377,6 +377,58 @@ TEST(cp, cp_backup_suffix_uses_custom_suffix) {
   EXPECT_EQ(tmp.read("dest.txt.bak"), "old content");
 }
 
+TEST(cp, cp_backup_numbered_control_creates_next_numbered_file) {
+  TempDir tmp;
+  tmp.write("source.txt", "new content");
+  tmp.write("dest.txt", "old content");
+  tmp.write("dest.txt.~1~", "first backup");
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"cp.exe", {L"--backup=numbered", L"source.txt", L"dest.txt"});
+
+  auto r = p.run();
+
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_EQ(tmp.read("dest.txt"), "new content");
+  EXPECT_EQ(tmp.read("dest.txt.~1~"), "first backup");
+  EXPECT_EQ(tmp.read("dest.txt.~2~"), "old content");
+}
+
+TEST(cp, cp_backup_existing_control_uses_numbered_when_numbered_exists) {
+  TempDir tmp;
+  tmp.write("source.txt", "new content");
+  tmp.write("dest.txt", "old content");
+  tmp.write("dest.txt.~1~", "first backup");
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"cp.exe", {L"--backup=existing", L"source.txt", L"dest.txt"});
+
+  auto r = p.run();
+
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_EQ(tmp.read("dest.txt"), "new content");
+  EXPECT_EQ(tmp.read("dest.txt.~1~"), "first backup");
+  EXPECT_EQ(tmp.read("dest.txt.~2~"), "old content");
+}
+
+TEST(cp, cp_backup_none_control_overwrites_without_backup) {
+  TempDir tmp;
+  tmp.write("source.txt", "new content");
+  tmp.write("dest.txt", "old content");
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"cp.exe", {L"--backup=none", L"source.txt", L"dest.txt"});
+
+  auto r = p.run();
+
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_EQ(tmp.read("dest.txt"), "new content");
+  EXPECT_FALSE(std::filesystem::exists(tmp.path / "dest.txt~"));
+}
+
 TEST(cp, cp_refuses_copy_onto_self) {
   TempDir tmp;
   tmp.write("file.txt", "content");

--- a/tests/unit/date/date_unit_test.cpp
+++ b/tests/unit/date/date_unit_test.cpp
@@ -157,6 +157,34 @@ TEST(date, date_rfc3339_seconds) {
   EXPECT_EQ(r.stdout_text, "2024-01-02 03:04:05+00:00\n");
 }
 
+TEST(date, date_reference_uses_file_modification_time) {
+  TempDir tmp;
+
+  Pipeline touch;
+  touch.set_cwd(tmp.wpath());
+  touch.add(L"touch.exe",
+            {L"-d", L"2024-01-02 03:04:05 UTC", L"reference.txt"});
+  EXPECT_EQ(touch.run().exit_code, 0);
+
+  Pipeline date;
+  date.set_cwd(tmp.wpath());
+  date.add(L"date.exe",
+           {L"-u", L"-r", L"reference.txt", L"+%Y-%m-%dT%H:%M:%S%z"});
+
+  auto r = date.run();
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_EQ(r.stdout_text, "2024-01-02T03:04:05+0000\n");
+
+  Pipeline long_date;
+  long_date.set_cwd(tmp.wpath());
+  long_date.add(L"date.exe",
+                {L"-u", L"--reference=reference.txt", L"+%Y-%m-%dT%H:%M:%S%z"});
+
+  auto long_result = long_date.run();
+  EXPECT_EQ(long_result.exit_code, 0);
+  EXPECT_EQ(long_result.stdout_text, "2024-01-02T03:04:05+0000\n");
+}
+
 TEST(date, date_rfc_email_fixed_utc_time) {
   TempDir tmp;
 

--- a/tests/unit/diff3/diff3_unit_test.cpp
+++ b/tests/unit/diff3/diff3_unit_test.cpp
@@ -195,6 +195,24 @@ TEST(diff3, diff3_wildcard_triplet_expands) {
   EXPECT_TRUE(r.stdout_text.empty());
 }
 
+TEST(diff3, diff3_ed_script_applies_non_overlapping_yours_change) {
+  TempDir tmp;
+  tmp.write("mine.txt", "base\n");
+  tmp.write("base.txt", "base\n");
+  tmp.write("yours.txt", "yours\n");
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"diff3.exe", {L"-e", L"mine.txt", L"base.txt", L"yours.txt"});
+  auto r = p.run();
+
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_EQ_TEXT(r.stdout_text, "1c\n"
+                                "yours\n"
+                                ".\n");
+  EXPECT_TRUE(r.stderr_text.empty());
+}
+
 TEST(diff3, diff3_ed_script_options_remain_accepted) {
   TempDir tmp;
   tmp.write("mine.txt", "same\nmine\n");

--- a/tests/unit/file/file_unit_test.cpp
+++ b/tests/unit/file/file_unit_test.cpp
@@ -71,6 +71,30 @@ TEST(file, file_brief) {
   EXPECT_TRUE(r.stdout_text.find("PDF") != std::string::npos);
 }
 
+TEST(file, file_mime) {
+  TempDir tmp;
+  tmp.write("notes.txt", "Hello, World!");
+  tmp.write("payload.bin", "%PDF-1.4");
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"file.exe", {L"--mime", L"notes.txt", L"payload.bin"});
+
+  TEST_LOG_CMD_LIST("file.exe", L"--mime", L"notes.txt", L"payload.bin");
+
+  auto r = p.run();
+
+  TEST_LOG_EXIT_CODE(r);
+  TEST_LOG("file.exe --mime output", r.stdout_text);
+
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_TRUE(r.stdout_text.find("notes.txt: text/plain; charset=us-ascii") !=
+              std::string::npos);
+  EXPECT_TRUE(
+      r.stdout_text.find("payload.bin: application/pdf; charset=binary") !=
+      std::string::npos);
+}
+
 TEST(file, file_directory) {
   TempDir tmp;
   std::filesystem::create_directory(tmp.path / "subdir");

--- a/tests/unit/numfmt/numfmt_unit_test.cpp
+++ b/tests/unit/numfmt/numfmt_unit_test.cpp
@@ -139,3 +139,29 @@ TEST(numfmt, numfmt_invalid_input) {
   // Should report error for invalid input
   EXPECT_NE(r.exit_code, 0);
 }
+
+TEST(numfmt, numfmt_debug_reports_conversions) {
+  Pipeline p;
+  p.set_stdin("1500\n");
+  p.add(L"numfmt.exe", {L"--to=si", L"--debug"});
+  auto r = p.run();
+
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_EQ(r.stdout_text, "1.5k\n");
+  EXPECT_NE(r.stderr_text.find("numfmt: debug: converted '1500' -> '1.5k'"),
+            std::string::npos);
+}
+
+TEST(numfmt, numfmt_debug_reports_invalid_input) {
+  Pipeline p;
+  p.set_stdin("notanumber\n");
+  p.add(L"numfmt.exe", {L"--debug"});
+  auto r = p.run();
+
+  EXPECT_NE(r.exit_code, 0);
+  EXPECT_NE(
+      r.stderr_text.find("numfmt: debug: failed to parse input 'notanumber'"),
+      std::string::npos);
+  EXPECT_NE(r.stderr_text.find("numfmt: invalid number: 'notanumber'"),
+            std::string::npos);
+}

--- a/tests/unit/od/od_unit_test.cpp
+++ b/tests/unit/od/od_unit_test.cpp
@@ -171,3 +171,50 @@ TEST(od, od_width) {
   EXPECT_EQ(r.exit_code, 0);
   EXPECT_FALSE(r.stdout_text.empty());
 }
+
+TEST(od, od_long_aliases_match_short_options) {
+  Pipeline p;
+  p.set_stdin("abcdefghijklmnopqrstuvwxyz");
+  p.add(L"od.exe", {L"--address-radix=n", L"--format=x1",
+                     L"--read-bytes=4", L"--skip-bytes=2"});
+
+  auto r = p.run();
+
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_EQ_TEXT(r.stdout_text, " 63 64 65 66\n");
+}
+
+TEST(od, od_endian_big_formats_multibyte_units) {
+  Pipeline p;
+  p.set_stdin("abc");
+  p.add(L"od.exe", {L"-An", L"-tx2", L"--endian=big"});
+
+  auto r = p.run();
+
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_EQ_TEXT(r.stdout_text, " 6162 6300\n");
+}
+
+TEST(od, od_endian_little_keeps_existing_multibyte_order) {
+  Pipeline p;
+  p.set_stdin("abc");
+  p.add(L"od.exe", {L"-An", L"-tx2", L"--endian=little"});
+
+  auto r = p.run();
+
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_EQ_TEXT(r.stdout_text, " 6261 0063\n");
+}
+
+TEST(od, od_output_duplicates_long_alias_disables_squeezing) {
+  Pipeline p;
+  p.set_stdin(std::string(32, 'A'));
+  p.add(L"od.exe", {L"-An", L"--format=x1", L"--output-duplicates"});
+
+  auto r = p.run();
+
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_EQ_TEXT(r.stdout_text,
+                 " 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41\n"
+                 " 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41 41\n");
+}

--- a/tests/unit/ps/ps_unit_test.cpp
+++ b/tests/unit/ps/ps_unit_test.cpp
@@ -142,6 +142,76 @@ TEST(ps, ps_sort_by_memory) {
   EXPECT_FALSE(r.stdout_text.empty());
 }
 
+TEST(ps, ps_pid_filter_with_custom_format_and_no_headers) {
+  TempDir tmp;
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  const DWORD current_pid = GetCurrentProcessId();
+  const auto pid = std::to_wstring(current_pid);
+  const auto pid_text = std::to_string(current_pid);
+  p.add(L"ps.exe", {L"-p", pid, L"-o", L"pid,ppid,comm", L"--no-headers"});
+
+  TEST_LOG_CMD_LIST("ps.exe", L"-p", L"<current-pid>", L"-o",
+                    L"pid,ppid,comm", L"--no-headers");
+
+  auto r = p.run();
+
+  TEST_LOG_EXIT_CODE(r);
+  TEST_LOG("ps.exe -p <current-pid> -o pid,ppid,comm --no-headers output",
+           r.stdout_text);
+
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_FALSE(r.stdout_text.empty());
+  EXPECT_TRUE(r.stdout_text.find(pid_text) != std::string::npos);
+  EXPECT_TRUE(r.stdout_text.find("PID") == std::string::npos);
+}
+
+TEST(ps, ps_long_pid_and_format_print_common_headers) {
+  TempDir tmp;
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  const DWORD current_pid = GetCurrentProcessId();
+  const auto pid = std::to_wstring(current_pid);
+  const auto pid_text = std::to_string(current_pid);
+  p.add(L"ps.exe", {L"--pid", pid, L"--format",
+                    L"pid,ppid,comm,args,user,etime,rss,pmem,pcpu"});
+
+  TEST_LOG_CMD_LIST("ps.exe", L"--pid", L"<current-pid>", L"--format",
+                    L"pid,ppid,comm,args,user,etime,rss,pmem,pcpu");
+
+  auto r = p.run();
+
+  TEST_LOG_EXIT_CODE(r);
+  TEST_LOG("ps.exe --pid <current-pid> --format common fields output",
+           r.stdout_text);
+
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_FALSE(r.stdout_text.empty());
+  EXPECT_TRUE(r.stdout_text.find("PID PPID COMMAND COMMAND USER ELAPSED RSS %MEM %CPU") !=
+              std::string::npos);
+  EXPECT_TRUE(r.stdout_text.find(pid_text) != std::string::npos);
+}
+
+TEST(ps, ps_format_rejects_unknown_field) {
+  TempDir tmp;
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"ps.exe", {L"-o", L"pid,unknown_field"});
+
+  TEST_LOG_CMD_LIST("ps.exe", L"-o", L"pid,unknown_field");
+
+  auto r = p.run();
+
+  TEST_LOG_EXIT_CODE(r);
+  TEST_LOG("ps.exe -o pid,unknown_field stderr", r.stderr_text);
+
+  EXPECT_NE(r.exit_code, 0);
+  EXPECT_TRUE(r.stderr_text.find("unsupported format field") != std::string::npos);
+}
+
 TEST(ps, ps_invalid_option) {
   TempDir tmp;
 

--- a/tests/unit/split/split_unit_test.cpp
+++ b/tests/unit/split/split_unit_test.cpp
@@ -141,19 +141,64 @@ TEST(split, split_number_mode_reassembles_without_overlap) {
   EXPECT_EQ(rebuilt, input);
 }
 
-TEST(split, split_number_k_of_n_mode_is_rejected) {
+TEST(split, split_number_k_of_n_mode_writes_selected_chunk_to_stdout) {
   TempDir tmp;
-  tmp.write("input.txt", "line1\nline2\n");
+  tmp.write("input.txt", "abcdefghi");
 
   Pipeline p;
   p.set_cwd(tmp.wpath());
-  p.add(L"split.exe", {L"-n", L"1/2", L"input.txt", L"part"});
+  p.add(L"split.exe", {L"-n", L"2/3", L"input.txt", L"part"});
 
   auto r = p.run();
 
-  EXPECT_EQ(r.exit_code, 1);
-  EXPECT_TRUE(r.stderr_text.find("split: unsupported --number mode") !=
-              std::string::npos);
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_EQ_TEXT(r.stdout_text, "def");
+  EXPECT_FALSE(std::filesystem::exists(tmp.path / "partaa"));
+}
+
+TEST(split, split_number_line_k_of_n_mode_preserves_records_to_stdout) {
+  TempDir tmp;
+  tmp.write("input.txt", "a\nb\nc\nd\ne\n");
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"split.exe", {L"-n", L"l/2/3", L"input.txt", L"part"});
+
+  auto r = p.run();
+
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_EQ_TEXT(r.stdout_text, "b\nc\n");
+  EXPECT_FALSE(std::filesystem::exists(tmp.path / "partaa"));
+}
+
+TEST(split, split_number_round_robin_mode_writes_each_output_file) {
+  TempDir tmp;
+  tmp.write("input.txt", "a\nb\nc\nd\ne\n");
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"split.exe", {L"-n", L"r/2", L"input.txt", L"part"});
+
+  auto r = p.run();
+
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_EQ_TEXT(tmp.read("partaa"), "a\nc\ne\n");
+  EXPECT_EQ_TEXT(tmp.read("partab"), "b\nd\n");
+}
+
+TEST(split, split_number_round_robin_k_of_n_mode_writes_selected_records) {
+  TempDir tmp;
+  tmp.write("input.txt", "a\nb\nc\nd\ne\n");
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"split.exe", {L"-n", L"r/2/3", L"input.txt", L"part"});
+
+  auto r = p.run();
+
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_EQ_TEXT(r.stdout_text, "b\ne\n");
+  EXPECT_FALSE(std::filesystem::exists(tmp.path / "partaa"));
 }
 
 TEST(split, split_elide_empty_files_keeps_suffixes_dense) {

--- a/tests/unit/time/time_unit_test.cpp
+++ b/tests/unit/time/time_unit_test.cpp
@@ -1,0 +1,62 @@
+/*
+ *  Copyright © 2026 WinuxCmd
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to
+ * deal in the Software without restriction, including without limitation the
+ * rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ * sell copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ *  IN THE SOFTWARE.
+ *
+ *  - File: time_unit_test.cpp
+ *  - CopyrightYear: 2026
+ */
+
+#include "framework/winuxtest.h"
+
+TEST(time_cmd, time_preserves_exit_code) {
+  Pipeline p;
+  p.add(L"time.exe", {L"cmd.exe", L"/c", L"exit", L"7"});
+
+  TEST_LOG_CMD_LIST("time.exe", L"cmd.exe", L"/c", L"exit", L"7");
+
+  auto r = p.run();
+
+  TEST_LOG_EXIT_CODE(r);
+  TEST_LOG("time.exe output", r.stderr_text);
+
+  EXPECT_EQ(r.exit_code, 7);
+  EXPECT_FALSE(r.stderr_text.empty());
+  EXPECT_NE(r.stderr_text.find("real"), std::string::npos);
+  EXPECT_NE(r.stderr_text.find("user"), std::string::npos);
+  EXPECT_NE(r.stderr_text.find("sys"), std::string::npos);
+}
+
+TEST(time_cmd, time_posix_format) {
+  Pipeline p;
+  p.add(L"time.exe", {L"-p", L"cmd.exe", L"/c", L"exit", L"0"});
+
+  TEST_LOG_CMD_LIST("time.exe", L"-p", L"cmd.exe", L"/c", L"exit", L"0");
+
+  auto r = p.run();
+
+  TEST_LOG_EXIT_CODE(r);
+  TEST_LOG("time.exe -p output", r.stderr_text);
+
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_FALSE(r.stderr_text.empty());
+  EXPECT_NE(r.stderr_text.find("real "), std::string::npos);
+  EXPECT_NE(r.stderr_text.find("user "), std::string::npos);
+  EXPECT_NE(r.stderr_text.find("sys "), std::string::npos);
+}

--- a/tests/unit/xargs/xargs_unit_test.cpp
+++ b/tests/unit/xargs/xargs_unit_test.cpp
@@ -1147,6 +1147,22 @@ TEST(xargs, xargs_max_chars_splits_batches) {
   EXPECT_TRUE(r.stderr_text.find("cmd.exe") != r.stderr_text.rfind("cmd.exe"));
 }
 
+TEST(xargs, xargs_long_max_chars_overrides_earlier_short_alias) {
+  TempDir tmp;
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"xargs.exe", {L"-t", L"-s", L"8", L"--max-chars", L"100", L"cmd.exe",
+                       L"/C", L"echo"});
+  p.set_stdin("one\ntwo\nthree\n");
+
+  auto r = p.run();
+
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_EQ(r.stderr_text.find("cmd.exe"), r.stderr_text.rfind("cmd.exe"));
+  EXPECT_EQ_TEXT(r.stdout_text, "one two three\r\n");
+}
+
 TEST(xargs, xargs_exit_if_exceeded_rejects_oversized_command_line) {
   TempDir tmp;
 

--- a/tests/unit/xxd/xxd_unit_test.cpp
+++ b/tests/unit/xxd/xxd_unit_test.cpp
@@ -46,6 +46,27 @@ TEST(xxd, plain_columns) {
   EXPECT_EQ_TEXT(r.stdout_text, "61626364\n65666768\n");
 }
 
+TEST(xxd, len_limits_input_for_short_and_long_options) {
+  TempDir tmp;
+  tmp.write("input.txt", "abcdef");
+
+  Pipeline short_option;
+  short_option.set_cwd(tmp.wpath());
+  short_option.add(L"xxd.exe", {L"-p", L"-l", L"2", L"input.txt"});
+
+  Pipeline long_option;
+  long_option.set_cwd(tmp.wpath());
+  long_option.add(L"xxd.exe", {L"-p", L"--len", L"3", L"input.txt"});
+
+  auto short_result = short_option.run();
+  auto long_result = long_option.run();
+
+  EXPECT_EQ(short_result.exit_code, 0);
+  EXPECT_EQ_TEXT(short_result.stdout_text, "6162\n");
+  EXPECT_EQ(long_result.exit_code, 0);
+  EXPECT_EQ_TEXT(long_result.stdout_text, "616263\n");
+}
+
 TEST(xxd, plain_uppercase) {
   TempDir tmp;
   tmp.write_bytes("input.bin", {'\xAB', '\xCD', '\xEF'});

--- a/tests/unit/xxd/xxd_unit_test.cpp
+++ b/tests/unit/xxd/xxd_unit_test.cpp
@@ -73,3 +73,89 @@ TEST(xxd, reverse_plain) {
   EXPECT_EQ(r.exit_code, 0);
   EXPECT_EQ(r.stdout_text, "hello");
 }
+
+TEST(xxd, include_file_uses_normalized_filename_and_length_symbol) {
+  TempDir tmp;
+  tmp.write("hello-world.bin", "hello");
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"xxd.exe", {L"-i", L"hello-world.bin"});
+
+  auto r = p.run();
+
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_EQ_TEXT(r.stdout_text,
+                 "unsigned char hello_world_bin[] = {\n"
+                 "  0x68, 0x65, 0x6c, 0x6c, 0x6f\n"
+                 "};\n"
+                 "unsigned int hello_world_bin_len = 5;\n");
+}
+
+TEST(xxd, include_explicit_name_normalizes_identifier) {
+  TempDir tmp;
+  tmp.write("input.bin", "AB");
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"xxd.exe", {L"--include", L"--name", L"my-data.v1", L"input.bin"});
+
+  auto r = p.run();
+
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_EQ_TEXT(r.stdout_text,
+                 "unsigned char my_data_v1[] = {\n"
+                 "  0x41, 0x42\n"
+                 "};\n"
+                 "unsigned int my_data_v1_len = 2;\n");
+}
+
+TEST(xxd, include_leading_digit_gets_reserved_prefix) {
+  TempDir tmp;
+  tmp.write("9patch.bin", "Z");
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"xxd.exe", {L"-i", L"9patch.bin"});
+
+  auto r = p.run();
+
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_EQ_TEXT(r.stdout_text,
+                 "unsigned char __9patch_bin[] = {\n"
+                 "  0x5a\n"
+                 "};\n"
+                 "unsigned int __9patch_bin_len = 1;\n");
+}
+
+TEST(xxd, include_stdin_emits_values_without_implicit_identifier) {
+  TempDir tmp;
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.set_stdin("hi");
+  p.add(L"xxd.exe", {L"-i"});
+
+  auto r = p.run();
+
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_EQ_TEXT(r.stdout_text, "  0x68, 0x69\n");
+}
+
+TEST(xxd, include_preserves_uppercase_and_custom_columns) {
+  TempDir tmp;
+  tmp.write_bytes("input.bin", {'\xAB', '\xCD', '\xEF'});
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"xxd.exe", {L"-i", L"-u", L"-c", L"2", L"input.bin"});
+
+  auto r = p.run();
+
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_EQ_TEXT(r.stdout_text,
+                 "unsigned char input_bin[] = {\n"
+                 "  0xAB, 0xCD,\n"
+                 "  0xEF\n"
+                 "};\n"
+                 "unsigned int input_bin_len = 3;\n");
+}

--- a/tests/unit/xxd/xxd_unit_test.cpp
+++ b/tests/unit/xxd/xxd_unit_test.cpp
@@ -32,6 +32,22 @@ TEST(xxd, custom_columns) {
   EXPECT_EQ_TEXT(r.stdout_text, "00000000: 6865 6c6c  hell\n");
 }
 
+TEST(xxd, offset_adds_to_default_addresses) {
+  TempDir tmp;
+  tmp.write("input.txt", "abcdefgh");
+
+  Pipeline p;
+  p.set_cwd(tmp.wpath());
+  p.add(L"xxd.exe", {L"-o", L"16", L"-c", L"4", L"input.txt"});
+
+  auto r = p.run();
+
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_EQ_TEXT(r.stdout_text,
+                 "00000010: 6162 6364  abcd\n"
+                 "00000014: 6566 6768  efgh\n");
+}
+
 TEST(xxd, plain_columns) {
   TempDir tmp;
   tmp.write("input.txt", "abcdefgh");
@@ -65,6 +81,27 @@ TEST(xxd, len_limits_input_for_short_and_long_options) {
   EXPECT_EQ_TEXT(short_result.stdout_text, "6162\n");
   EXPECT_EQ(long_result.exit_code, 0);
   EXPECT_EQ_TEXT(long_result.stdout_text, "616263\n");
+}
+
+TEST(xxd, seek_starts_input_for_short_and_long_options) {
+  TempDir tmp;
+  tmp.write("input.txt", "abcdef");
+
+  Pipeline short_option;
+  short_option.set_cwd(tmp.wpath());
+  short_option.add(L"xxd.exe", {L"-p", L"-s", L"2", L"input.txt"});
+
+  Pipeline long_option;
+  long_option.set_cwd(tmp.wpath());
+  long_option.add(L"xxd.exe", {L"-p", L"--seek", L"3", L"input.txt"});
+
+  auto short_result = short_option.run();
+  auto long_result = long_option.run();
+
+  EXPECT_EQ(short_result.exit_code, 0);
+  EXPECT_EQ_TEXT(short_result.stdout_text, "63646566\n");
+  EXPECT_EQ(long_result.exit_code, 0);
+  EXPECT_EQ_TEXT(long_result.stdout_text, "646566\n");
 }
 
 TEST(xxd, plain_uppercase) {


### PR DESCRIPTION
## Summary

Implements the first staged compatibility wave from issues #161 and #162.

### Included

- xxd C include output: -i/--include and -n/--name (ef09466)
- GNU/upstream slices for cal, cp, diff, file, find, numfmt, od, ps, split, tr
- Native Windows time command with POSIX timing output and child exit-code preservation
- Focused unit coverage for each changed slice
- WPM curl package (published separately in unixwin-wpm-source)
- zh-CN catalog synchronization (published separately in unixwin/winuxcmd-i18n)

### Verification

- clang-format completed for all changed WinuxCmd sources/tests
- git diff --check passed
- i18n extraction and zh-CN validation passed
- VS wrapper reached project configuration; compilation is blocked by the current environment missing Windows.h / standard MSVC include paths

Tracks: #161 #162