### PR TITLE
fix: preserve timeout command arguments

### DIFF
--- a/src/core/command_context.cppm
+++ b/src/core/command_context.cppm
@@ -32,6 +32,9 @@ export auto option_policy_for_command(std::string_view command)
   policy.allow_unknown_short_options_as_positionals =
       command == "printf" || command == "expr" || command == "test" ||
       command == "[";
+  if (command == "timeout") {
+    policy.stop_options_after_positionals = 2;
+  }
   return policy;
 }
 

--- a/src/core/opt.cppm
+++ b/src/core/opt.cppm
@@ -122,6 +122,9 @@ export struct OptionParsePolicy {
   // Some utilities accept operands such as -5 or -n after their syntax
   // establishes that the remaining arguments are operands.
   bool allow_unknown_short_options_as_positionals = false;
+  // Stop option parsing after this many positional operands. A value of zero
+  // keeps the traditional parser behavior.
+  size_t stop_options_after_positionals = 0;
 };
 
 export ParseResultRuntime parse_command_runtime(
@@ -560,6 +563,10 @@ export ParseResultRuntime parse_command_runtime(
 
     // ---------- positional ----------
     result.positionals.push_back(arg);
+    if (policy.stop_options_after_positionals != 0 &&
+        result.positionals.size() >= policy.stop_options_after_positionals) {
+      end_of_options = true;
+    }
   }
 
   return result;

--- a/tests/unit/timeout/timeout_unit_test.cpp
+++ b/tests/unit/timeout/timeout_unit_test.cpp
@@ -122,6 +122,17 @@ TEST(timeout, timeout_executes_command_and_preserves_exit_status) {
   EXPECT_EQ(r.exit_code, 7);
 }
 
+TEST(timeout, timeout_forwards_option_like_command_arguments) {
+  Pipeline p;
+  p.add(L"timeout.exe", {L"5", L"printf.exe", L"%s", L"-n"});
+
+  auto r = p.run();
+
+  EXPECT_EQ(r.exit_code, 0);
+  EXPECT_EQ_TEXT(r.stdout_text, "-n");
+  EXPECT_TRUE(r.stderr_text.empty());
+}
+
 TEST(timeout, timeout_executes_batch_commands) {
   TempDir tmp;
   tmp.write("runner.cmd", "@echo off\r\nexit /b 7\r\n");


### PR DESCRIPTION
## Summary

- Stop option parsing after timeout DURATION and COMMAND positionals.
- Forward option-like command arguments such as sh -c and printf -n unchanged.
- Add a focused timeout regression.

## Verification

- Project VS build script: winuxcmd target passed.
- timeout 1 sh -c sleep 2 returns 124.
- timeout 5 printf percent-s -n outputs -n and returns 0.
- Full unit target configuration is currently blocked by the existing Google Benchmark C++14/modules CMake error.