### PR TITLE
chore: ignore local .wpm state directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,5 @@ powershell-profile.ps1
 README-GIT-PROTECTION.md
 
 /tmp
+
+.wpm/.wpm/


### PR DESCRIPTION
本地 i18n 目录(.wpm/i18n)按 AGENTS.md 约定不入库,加入 .gitignore。