### PR TITLE
fix: correct .wpm/ ignore pattern

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,4 +46,4 @@ README-GIT-PROTECTION.md
 
 /tmp
 
-.wpm/.wpm/
+.wpm/


### PR DESCRIPTION
上一 PR 因原文件缺行尾换行,追加后变成 .wpm/.wpm/,无法匹配实际目录。修正为 .wpm/。