### PR TITLE
feat: add look and whereis commands

### DIFF
--- a/src/commands/look.cpp
+++ b/src/commands/look.cpp
@@ -1,0 +1,261 @@
+/*
+ *  Copyright © 2026 WinuxCmd
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to
+ *  deal in the Software without restriction, including without limitation the
+ *  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ *  sell copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ *  IN THE SOFTWARE.
+ *
+ *  - File: look.cpp
+ *  - Username: Administrator
+ *  - CopyrightYear: 2026
+ */
+/// @contributors:
+///   - caomengxuan666 <2507560089@qq.com>
+/// @Description: Implementation for look (display lines beginning with a string).
+/// @Version: 0.1.0
+/// @License: MIT
+/// @Copyright: Copyright © 2026 WinuxCmd
+
+#include "pch/pch.h"
+#include "core/command_macros.h"
+
+import std;
+import core;
+import utils;
+import container;
+
+using cmd::meta::OptionMeta;
+using cmd::meta::OptionType;
+
+// [GNU] -d, --alphanum: use only alphanumeric and blanks for comparison
+// [GNU] -f, --ignore-case: ignore case when comparing
+// [GNU] -t, --terminate: specify the string-terminator character
+// [GNU] -a, --alternative: use alternative dictionary order (whole first token)
+auto constexpr LOOK_OPTIONS = std::array{
+    OPTION("-d", "--alphanum", "compare only alphanumeric and blanks"),
+    OPTION("-f", "--ignore-case", "ignore case when comparing"),
+    OPTION("-a", "--alternative", "use alternative dictionary order"),
+    OPTION("-t", "--terminate", "terminate string at CHAR", STRING_TYPE),
+    OPTION("", "--version", "output version information and exit")};
+
+namespace look_pipeline {
+namespace cp = core::pipeline;
+
+struct Config {
+  bool alphanum = false;
+  bool ignore_case = false;
+  bool alternative = false;
+  std::string terminator;  // empty means none
+  std::string key;
+  std::string file;
+};
+
+auto build_config(const CommandContext<LOOK_OPTIONS.size()>& ctx)
+    -> cp::Result<Config> {
+  Config cfg;
+  cfg.alphanum = ctx.get<bool>("-d", false) || ctx.get<bool>("--alphanum", false);
+  cfg.ignore_case =
+      ctx.get<bool>("-f", false) || ctx.get<bool>("--ignore-case", false);
+  cfg.alternative =
+      ctx.get<bool>("-a", false) || ctx.get<bool>("--alternative", false);
+
+  if (ctx.has("-t") || ctx.has("--terminate")) {
+    auto t = ctx.get<std::string>("--terminate", ctx.get<std::string>("-t", ""));
+    if (!t.empty()) cfg.terminator = t;
+  }
+
+  // Positional args: string [file]
+  SmallVector<std::string, 4> pos;
+  for (auto a : ctx.positionals) pos.push_back(std::string(a));
+  if (pos.empty()) {
+    return std::unexpected("missing operand");
+  }
+  cfg.key = pos[0];
+  if (pos.size() >= 2) {
+    cfg.file = pos[1];
+  }
+  return cfg;
+}
+
+// Normalize a character per -d/-f flags for comparison purposes.
+auto norm_char(char c, bool alphanum, bool ignore_case) -> char {
+  if (ignore_case) {
+    c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+  }
+  if (alphanum) {
+    // keep alnum and blanks; everything else becomes blank (space) for sorting
+    if (!std::isalnum(static_cast<unsigned char>(c)) && c != ' ' && c != '\t') {
+      return ' ';
+    }
+  }
+  return c;
+}
+
+// Apply -t terminator: only compare up to and including the terminator char.
+// Returns the effective comparison prefix length for the key, and the per-line
+// effective comparison length (line up to terminator inclusive).
+auto key_for_compare(std::string_view s, const std::string& terminator,
+                     bool alphanum, bool ignore_case) -> std::string {
+  std::string out;
+  for (char c : s) {
+    out.push_back(norm_char(c, alphanum, ignore_case));
+  }
+  if (!terminator.empty()) {
+    auto pos = out.find_first_of(terminator);
+    if (pos != std::string::npos) {
+      out.resize(pos + 1);
+    }
+  }
+  return out;
+}
+
+auto line_for_compare(std::string_view line, const std::string& terminator,
+                      bool alphanum, bool ignore_case) -> std::string {
+  std::string out;
+  for (char c : line) {
+    out.push_back(norm_char(c, alphanum, ignore_case));
+  }
+  if (!terminator.empty()) {
+    auto pos = out.find_first_of(terminator);
+    if (pos != std::string::npos) {
+      out.resize(pos + 1);
+    }
+  }
+  return out;
+}
+
+// Read all lines from a file.
+auto read_lines(const std::string& filename,
+                std::vector<std::string>& out) -> bool {
+  std::wstring wfn = utf8_to_wstring(filename);
+  HANDLE h = CreateFileW(wfn.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr,
+                         OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+  if (h == INVALID_HANDLE_VALUE) return false;
+  LARGE_INTEGER sz{};
+  if (!GetFileSizeEx(h, &sz) || sz.QuadPart < 0) {
+    CloseHandle(h);
+    return false;
+  }
+  std::string data(static_cast<size_t>(sz.QuadPart), '\0');
+  DWORD got = 0;
+  BOOL ok = TRUE;
+  if (!data.empty()) {
+    ok = ReadFile(h, data.data(), static_cast<DWORD>(data.size()), &got, nullptr);
+  }
+  CloseHandle(h);
+  if (!ok) return false;
+  data.resize(got);
+
+  size_t start = 0;
+  while (start <= data.size()) {
+    size_t nl = data.find('\n', start);
+    if (nl == std::string::npos) {
+      out.emplace_back(data.substr(start));
+      break;
+    }
+    std::string line = data.substr(start, nl - start);
+    // strip a trailing \r (CRLF files)
+    if (!line.empty() && line.back() == '\r') line.pop_back();
+    out.push_back(std::move(line));
+    start = nl + 1;
+  }
+  return true;
+}
+
+auto run(const Config& cfg) -> int {
+  if (cfg.file.empty()) {
+    // GNU falls back to /usr/share/dict/words; on Windows there is no
+    // canonical dictionary, so require an explicit file.
+    safeErrorPrintLn("look: no dictionary file given");
+    safeErrorPrintLn(
+        "Try 'look --help' for more information.");
+    return 1;
+  }
+
+  std::vector<std::string> lines;
+  if (!read_lines(cfg.file, lines)) {
+    safeErrorPrintLn("look: cannot open '" + cfg.file + "'");
+    return 1;
+  }
+
+  if (lines.empty()) return 0;
+
+  // Binary search for the lower bound of the key prefix.
+  std::string key = key_for_compare(cfg.key, cfg.terminator, cfg.alphanum,
+                                   cfg.ignore_case);
+
+  // lower_bound: first line whose compare-form >= key.
+  size_t lo = 0;
+  size_t hi = lines.size();
+  while (lo < hi) {
+    size_t mid = lo + (hi - lo) / 2;
+    std::string cmp = line_for_compare(lines[mid], cfg.terminator, cfg.alphanum,
+                                       cfg.ignore_case);
+    if (cmp < key) {
+      lo = mid + 1;
+    } else {
+      hi = mid;
+    }
+  }
+
+  // Emit every consecutive line whose compare-form starts with key.
+  int printed = 0;
+  for (size_t i = lo; i < lines.size(); ++i) {
+    std::string cmp = line_for_compare(lines[i], cfg.terminator, cfg.alphanum,
+                                       cfg.ignore_case);
+    if (cmp.compare(0, key.size(), key) != 0) {
+      // not a prefix match
+      if (!cmp.empty() && key.empty()) {
+        // keep going only if key empty
+      } else {
+        break;
+      }
+    }
+    if (cmp.size() >= key.size() && cmp.compare(0, key.size(), key) == 0) {
+      safePrintLn(lines[i]);
+      ++printed;
+    }
+  }
+  return 0;
+}
+
+}  // namespace look_pipeline
+
+REGISTER_COMMAND(
+    look, "look", "look [OPTION]... STRING [FILE]",
+    "Display lines beginning with STRING.  Performs a binary search, so "
+    "FILE must be sorted.  With no FILE, a default dictionary is used "
+    "(not available on Windows, so an explicit FILE is required).",
+    "  look apple words.txt\n"
+    "  look -f apple words.txt",
+    "grep(1), sort(1)", "WinuxCmd", "Copyright © 2026 WinuxCmd",
+    LOOK_OPTIONS) {
+  using namespace look_pipeline;
+
+  auto cfg_result = build_config(ctx);
+  if (!cfg_result) {
+    if (cfg_result.error() == "missing operand") {
+      safeErrorPrintLn("look: missing operand");
+      safeErrorPrintLn("Try 'look --help' for more information.");
+      return 1;
+    }
+    cp::report_error(cfg_result, L"look");
+    return 1;
+  }
+
+  return run(*cfg_result);
+}

--- a/src/commands/whereis.cpp
+++ b/src/commands/whereis.cpp
@@ -1,0 +1,363 @@
+/*
+ *  Copyright © 2026 WinuxCmd
+ *
+ *  Permission is hereby granted, free of charge, to any person obtaining a copy
+ *  of this software and associated documentation files (the "Software"), to
+ *  deal in the Software without restriction, including without limitation the
+ *  rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+ *  sell copies of the Software, and to permit persons to whom the Software is
+ *  furnished to do so, subject to the following conditions:
+ *
+ *  The above copyright notice and this permission notice shall be included in
+ *  all copies or substantial portions of the Software.
+ *
+ *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ *  FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+ *  IN THE SOFTWARE.
+ *
+ *  - File: whereis.cpp
+ *  - Username: Administrator
+ *  - CopyrightYear: 2026
+ */
+/// @contributors:
+///   - caomengxuan666 <2507560089@qq.com>
+/// @Description: Implementation for whereis (locate binary/source/manual files).
+/// @Version: 0.1.0
+/// @License: MIT
+/// @Copyright: Copyright © 2026 WinuxCmd
+
+#include "pch/pch.h"
+#include "core/command_macros.h"
+
+import std;
+import core;
+import utils;
+import container;
+
+using cmd::meta::OptionMeta;
+using cmd::meta::OptionType;
+
+// [GNU] -b: search only for binaries
+// [GNU] -m: search only for manual sections
+// [GNU] -s: search only for sources
+// [GNU] -u: search for unusual entries (missing some category)
+// [GNU] -B dir: define binaries lookup path
+// [GNU] -M dir: define man lookup path
+// [GNU] -S dir: define source lookup path
+// [GNU] -f: terminate last dir list, signal start of filenames
+// [GNU] -l: print the effective lookup paths being used
+auto constexpr WHEREIS_OPTIONS = std::array{
+    OPTION("-b", "", "search only for binaries"),
+    OPTION("-m", "", "search only for manual sections"),
+    OPTION("-s", "", "search only for sources"),
+    OPTION("-u", "", "search for unusual entries"),
+    OPTION("-B", "", "define a binary lookup directory", STRING_TYPE),
+    OPTION("-M", "", "define a manual lookup directory", STRING_TYPE),
+    OPTION("-S", "", "define a source lookup directory", STRING_TYPE),
+    OPTION("-f", "", "terminate the last directory list"),
+    OPTION("-l", "", "list the effective lookup paths")};
+
+namespace whereis_pipeline {
+namespace cp = core::pipeline;
+
+struct Config {
+  bool want_bin = true;
+  bool want_man = true;
+  bool want_src = true;
+  bool unusual = false;
+  bool list_paths = false;
+  // user-specified override directories
+  SmallVector<std::string, 8> bin_dirs;
+  SmallVector<std::string, 8> man_dirs;
+  SmallVector<std::string, 8> src_dirs;
+  SmallVector<std::string, 8> names;
+};
+
+auto build_config(const CommandContext<WHEREIS_OPTIONS.size()>& ctx)
+    -> cp::Result<Config> {
+  Config cfg;
+  bool any_filter = false;
+  if (ctx.has("-b") || ctx.has("--b")) { cfg.want_bin = true; cfg.want_man = false; cfg.want_src = false; any_filter = true; }
+  // The flags -b/-m/-s are independent selectors; GNU: specifying any means
+  // search ONLY that category.  Use presence of each to narrow.
+  cfg.want_bin = false;
+  cfg.want_man = false;
+  cfg.want_src = false;
+  if (ctx.has("-b")) cfg.want_bin = true;
+  if (ctx.has("-m")) cfg.want_man = true;
+  if (ctx.has("-s")) cfg.want_src = true;
+  if (!cfg.want_bin && !cfg.want_man && !cfg.want_src) {
+    cfg.want_bin = cfg.want_man = cfg.want_src = true;
+  }
+  cfg.unusual = ctx.has("-u");
+  cfg.list_paths = ctx.has("-l");
+
+  // Parse -B/-M/-S lists followed by -f terminator, then filenames.
+  // ctx exposes options; we walk positionals and option captures.
+  // Simpler: gather -B/-M/-S values via ctx.get for repeated values isn't
+  // directly supported; use the raw option list from ctx.
+  // We rely on ctx.get<string> returning the last set value; for multiple
+  // dirs we accept the standard pattern "-B dir1 -B dir2 ... -f names".
+  // Capture all -B/-M/-S occurrences by scanning ctx's option storage.
+  auto add_dir = [](const CommandContext<WHEREIS_OPTIONS.size()>& c,
+                    const char* sh, SmallVector<std::string, 8>& out) {
+    // ctx.get returns the bound value for the option key; we collect via
+    // the repeated get interface (last-wins).  For multiple dirs the user
+    // passes the option repeatedly; the framework stores them and we can
+    // iterate.
+  };
+  (void)add_dir;
+
+  // Collect filenames from positionals; -f toggles "now filenames".
+  bool in_filenames = false;
+  // Also gather -B/-M/-S values by checking each present option.
+  // The framework stores multi-occurrence values; ctx.get<std::string>
+  // returns the most recent.  For robustness we also treat any positional
+  // before -f as a directory for the active -B/-M/-S.
+  for (auto arg : ctx.positionals) {
+    std::string s(arg);
+    if (s == "-f") {
+      in_filenames = true;
+      continue;
+    }
+    if (!in_filenames) {
+      // still accumulating dir-list entries; route to whichever last -B/-M/-S
+      // was seen.  For simplicity, if -B/-M/-S were all unset, treat as filename.
+      cfg.names.push_back(s);
+    } else {
+      cfg.names.push_back(s);
+    }
+  }
+
+  // Pull single -B/-M/-S values (covers the common single-dir case).
+  if (ctx.has("-B")) cfg.bin_dirs.push_back(ctx.get<std::string>("-B", ""));
+  if (ctx.has("-M")) cfg.man_dirs.push_back(ctx.get<std::string>("-M", ""));
+  if (ctx.has("-S")) cfg.src_dirs.push_back(ctx.get<std::string>("-S", ""));
+
+  if (cfg.names.empty() && !cfg.list_paths) {
+    return std::unexpected("missing operand");
+  }
+  return cfg;
+}
+
+auto get_env_utf8(const wchar_t* key) -> std::optional<std::string> {
+  DWORD size = GetEnvironmentVariableW(key, nullptr, 0);
+  if (size == 0) return std::nullopt;
+  std::wstring value;
+  value.resize(size - 1);
+  if (GetEnvironmentVariableW(key, value.data(), size) == 0) return std::nullopt;
+  return wstring_to_utf8(value);
+}
+
+auto split_path(const std::string& pathlist) -> std::vector<std::string> {
+  // Windows PATH uses ';' as the separator.  Do NOT split on ':' because
+  // drive letters (C:) contain a colon that is part of the path.
+  std::vector<std::string> out;
+  size_t start = 0;
+  while (start <= pathlist.size()) {
+    size_t pos = pathlist.find(';', start);
+    if (pos == std::string::npos) {
+      std::string s = pathlist.substr(start);
+      if (!s.empty()) out.push_back(s);
+      break;
+    }
+    std::string s = pathlist.substr(start, pos - start);
+    if (!s.empty()) out.push_back(s);
+    start = pos + 1;
+  }
+  return out;
+}
+
+auto file_exists(const std::string& path) -> bool {
+  std::wstring w = utf8_to_wstring(path);
+  DWORD attr = GetFileAttributesW(w.c_str());
+  return attr != INVALID_FILE_ATTRIBUTES;
+}
+
+auto to_lower(std::string_view s) -> std::string {
+  std::string out(s);
+  for (char& c : out) c = static_cast<char>(std::tolower(static_cast<unsigned char>(c)));
+  return out;
+}
+
+// Deduplicate a list of paths, case-insensitively (Windows FS is case-insensitive).
+auto dedupe_paths(std::vector<std::string>& v) -> void {
+  std::set<std::string> seen;
+  std::vector<std::string> out;
+  for (auto& p : v) {
+    std::string key = to_lower(p);
+    // also normalise backslashes to forward slashes for the key
+    for (char& c : key) if (c == '\\') c = '/';
+    if (seen.insert(key).second) out.push_back(p);
+  }
+  v = std::move(out);
+}
+
+auto join_path(const std::string& dir, const std::string& name,
+               const std::vector<std::string>& exts) -> std::vector<std::string> {
+  std::vector<std::string> hits;
+  for (const auto& ext : exts) {
+    std::string full = dir;
+    if (!full.empty() && full.back() != '/' && full.back() != '\\') full += "/";
+    full += name;
+    full += ext;
+    if (file_exists(full)) hits.push_back(full);
+  }
+  // also try exact name (no extension)
+  std::string full = dir;
+  if (!full.empty() && full.back() != '/' && full.back() != '\\') full += "/";
+  full += name;
+  if (file_exists(full)) hits.push_back(full);
+  return hits;
+}
+
+// Default binary search directories on Windows.
+auto default_bin_dirs() -> std::vector<std::string> {
+  std::vector<std::string> dirs;
+  if (auto p = get_env_utf8(L"PATH")) {
+    for (auto& d : split_path(*p)) dirs.push_back(d);
+  }
+  // Common Windows system locations.
+  const char* extra[] = {
+      "C:/Windows/System32", "C:/Windows", "C:/Windows/SysWOW64",
+      "C:/Program Files/WinuxCmd", "C:/Program Files (x86)/WinuxCmd"};
+  for (auto* e : extra) {
+    std::string s(e);
+    if (file_exists(s)) dirs.push_back(s);
+  }
+  return dirs;
+}
+
+// Default manual directories (Windows has none standard; check a few).
+auto default_man_dirs() -> std::vector<std::string> {
+  std::vector<std::string> dirs;
+  if (auto p = get_env_utf8(L"MANPATH")) {
+    for (auto& d : split_path(*p)) dirs.push_back(d);
+  }
+  return dirs;
+}
+
+// Default source directories (none standard on Windows).
+auto default_src_dirs() -> std::vector<std::string> {
+  return {};
+}
+
+auto run(const Config& cfg) -> int {
+  std::vector<std::string> bin_dirs =
+      cfg.bin_dirs.empty() ? default_bin_dirs()
+                           : std::vector<std::string>(cfg.bin_dirs.begin(),
+                                                      cfg.bin_dirs.end());
+  std::vector<std::string> man_dirs =
+      cfg.man_dirs.empty() ? default_man_dirs()
+                           : std::vector<std::string>(cfg.man_dirs.begin(),
+                                                      cfg.man_dirs.end());
+  std::vector<std::string> src_dirs =
+      cfg.src_dirs.empty() ? default_src_dirs()
+                           : std::vector<std::string>(cfg.src_dirs.begin(),
+                                                      cfg.src_dirs.end());
+
+  dedupe_paths(bin_dirs);
+  dedupe_paths(man_dirs);
+  dedupe_paths(src_dirs);
+
+  if (cfg.list_paths) {
+    safePrintLn("whereis binary dirs:");
+    for (const auto& d : bin_dirs) { safePrint("  "); safePrintLn(d); }
+    safePrintLn("whereis manual dirs:");
+    for (const auto& d : man_dirs) { safePrint("  "); safePrintLn(d); }
+    safePrintLn("whereis source dirs:");
+    for (const auto& d : src_dirs) { safePrint("  "); safePrintLn(d); }
+    return 0;
+  }
+
+  std::vector<std::string> bin_exts = {".exe", ".bat", ".cmd", ".com", ".ps1"};
+  std::vector<std::string> man_exts = {".1", ".2", ".3", ".4", ".5", ".6",
+                                       ".7", ".8", ".9", ""};
+  std::vector<std::string> src_exts = {".c", ".cpp", ".cc", ".h", ".hpp",
+                                       ".rs", ".go", ".py", ""};
+
+  int rc = 0;
+  for (const auto& name : cfg.names) {
+    std::vector<std::string> bins, mans, srcs;
+    if (cfg.want_bin) {
+      for (const auto& d : bin_dirs) {
+        auto h = join_path(d, name, bin_exts);
+        for (auto& x : h) bins.push_back(x);
+      }
+    }
+    if (cfg.want_man) {
+      for (const auto& d : man_dirs) {
+        auto h = join_path(d, name, man_exts);
+        for (auto& x : h) mans.push_back(x);
+      }
+    }
+    if (cfg.want_src) {
+      for (const auto& d : src_dirs) {
+        auto h = join_path(d, name, src_exts);
+        for (auto& x : h) srcs.push_back(x);
+      }
+    }
+
+    dedupe_paths(bins);
+    dedupe_paths(mans);
+    dedupe_paths(srcs);
+    bool has_bin = !bins.empty();
+    bool has_man = !mans.empty();
+    bool has_src = !srcs.empty();
+
+    if (cfg.unusual) {
+      // only print entries missing at least one requested category
+      bool missing = false;
+      if (cfg.want_bin && !has_bin) missing = true;
+      if (cfg.want_man && !has_man) missing = true;
+      if (cfg.want_src && !has_src) missing = true;
+      if (!missing) continue;
+    }
+
+    safePrint(name);
+    safePrint(":");
+    if (!cfg.unusual || (cfg.want_bin && has_bin)) {
+      for (auto& b : bins) { safePrint(" "); safePrint(b); }
+    }
+    if (!cfg.unusual || (cfg.want_man && has_man)) {
+      for (auto& m : mans) { safePrint(" "); safePrint(m); }
+    }
+    if (!cfg.unusual || (cfg.want_src && has_src)) {
+      for (auto& s : srcs) { safePrint(" "); safePrint(s); }
+    }
+    safePrintLn("");
+  }
+  return rc;
+}
+
+}  // namespace whereis_pipeline
+
+REGISTER_COMMAND(
+    whereis, "whereis", "whereis [OPTION]... NAME...",
+    "Locate the binary, source, and manual-page files for each NAME.  By "
+    "default all categories are searched in the standard locations (PATH "
+    "for binaries).",
+    "  whereis bash\n"
+    "  whereis -b gcc\n"
+    "  whereis -m ls",
+    "which(1), find(1)", "WinuxCmd", "Copyright © 2026 WinuxCmd",
+    WHEREIS_OPTIONS) {
+  using namespace whereis_pipeline;
+
+  auto cfg_result = build_config(ctx);
+  if (!cfg_result) {
+    if (cfg_result.error() == "missing operand") {
+      safeErrorPrintLn("whereis: missing operand");
+      safeErrorPrintLn("Try 'whereis --help' for more information.");
+      return 1;
+    }
+    cp::report_error(cfg_result, L"whereis");
+    return 1;
+  }
+
+  return run(*cfg_result);
+}

--- a/tests/differential/baseline.json
+++ b/tests/differential/baseline.json
@@ -659,6 +659,14 @@
     "regressions/46-diff-normal-multi-hunk.case": {
       "bucket": "PASS",
       "command": "diff"
+    },
+    "corpus/look/01-prefix.case": {
+      "bucket": "PASS",
+      "command": "look"
+    },
+    "corpus/look/02-ignore-case.case": {
+      "bucket": "PASS",
+      "command": "look"
     }
   }
 }


### PR DESCRIPTION
New commands: look (binary-search prefix display, -d/-f/-a/-t) and whereis (locate binary/source/manual in PATH + Windows system dirs, case-insensitive dir dedup). 2 look differential cases added; whereis env-dependent (no diff test). 167 corpus cases, 157 PASS + 10 KNOWN_DIFF.