### PR TITLE
WinuxCmd v1.0.4: GNU parity batches (112/112 differential green)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,7 @@ when `WINUX_LANG` selects a catalog under `.wpm/i18n/<locale>/catalog.json`.
 - For small batches, edit `catalogs/zh-CN/catalog.json` directly, preserving stable keys and valid JSON. Add the English fallback in WinuxCmd first, then add or update the Chinese translation in the I18N repository.
 - Validate the catalog against the generated English catalog, commit both repositories separately, and push both before reporting completion.
 - Check the previous WinuxCmd commit and the I18N repository history for missed catalog changes before starting a new sync.
+- Every change under `catalogs/` in the I18N repository MUST bump the `VERSION` file in that repository in the same PR (at least the patch segment). CI blocks the PR otherwise. Merging the bump automatically publishes the `winuxcmd-i18n-zh-cn` release and opens the WPM index update PR; never ship catalog text changes without a version bump, because WPM treats an unchanged version as already installed.
 
 ## Catalog ownership
 

--- a/scripts/build-with-vs.ps1
+++ b/scripts/build-with-vs.ps1
@@ -46,7 +46,11 @@ $buildPath = Join-Path $rootPath $BuildDir
 $cmdExe = Join-Path $env:SystemRoot "System32\cmd.exe"
 
 if ([string]::IsNullOrWhiteSpace($VsEnvScript)) {
-    $vswhere = Join-Path ${env:ProgramFiles(x86)} "Microsoft Visual Studio\Installer\vswhere.exe"
+    $pfX86 = ${env:ProgramFiles(x86)}
+    if ([string]::IsNullOrWhiteSpace($pfX86)) {
+        $pfX86 = $env:ProgramFiles
+    }
+    $vswhere = Join-Path $pfX86 "Microsoft Visual Studio\Installer\vswhere.exe"
     if (Test-Path -LiteralPath $vswhere -PathType Leaf) {
         $VsEnvScript = & $vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -find "VC\Auxiliary\Build\vcvars64.bat" |
             Select-Object -First 1

--- a/scripts/i18n_batch.py
+++ b/scripts/i18n_batch.py
@@ -319,6 +319,13 @@ MANUAL_MESSAGES = {
     "common.error.invalid_number": "Invalid number: '{}'",
     "common.error.invalid_field_number": "invalid field number: '{}'",
     "common.error.size_or_reference": "you must specify either '--size' or '--reference'",
+    "common.error.summarize_and_show_all": "cannot both summarize and show all",
+    "common.error.multiple_output_files": "multiple output files specified",
+    "common.error.options_incompatible": "options '{}' are incompatible",
+    "common.error.invalid_tab_size": "invalid tab size: '{}'",
+    "common.error.too_few_xs": "too few X's in template '{}'",
+    "command.pr.error.invalid_number": "'{}' invalid number of {}: '{}'",
+    "command.pr.error.extra_characters": "'{}' extra characters or invalid number in the argument: '{}'",
 }
 
 

--- a/scripts/i18n_batch.py
+++ b/scripts/i18n_batch.py
@@ -144,7 +144,11 @@ MANUAL_MESSAGES = {
     "command.wpm.error.stage": "wpm: failed to stage exe: {}",
     "command.wpm.status.clean_empty": "wpm: {} is already clean",
     "command.wpm.status.clean_dry_run": "wpm: would remove {} ({} in {} files)",
-    "command.wpm.status.cleaned_detail": "wpm: cleaned {} ({} in {} files)",
+    "command.wpm.status.clean_file": "wpm: - {}",
+    "command.wpm.status.clean_progress":
+        "wpm: removing {}... {}% ({}/{} files, {})",
+    "command.wpm.status.clean_summary":
+        "wpm: removed {} ({} in {} files) in {:.1f}s",
     "command.wpm.status.install_summary": "wpm: install summary: requested={} failed={}",
     "command.wpm.status.keep_running": "wpm: keeping running executable: {}",
     "command.wpm.error.refuse_directory": "wpm: refusing to replace directory: {}",

--- a/scripts/i18n_batch.py
+++ b/scripts/i18n_batch.py
@@ -326,6 +326,9 @@ MANUAL_MESSAGES = {
     "common.error.too_few_xs": "too few X's in template '{}'",
     "command.pr.error.invalid_number": "'{}' invalid number of {}: '{}'",
     "command.pr.error.extra_characters": "'{}' extra characters or invalid number in the argument: '{}'",
+    "command.readlink.error.too_many_symlinks": "Too many levels of symbolic links",
+    "command.tsort.error.odd_tokens": "tsort: input contains an odd number of tokens",
+    "command.numfmt.error.valid_to_args": "Valid arguments are:\n  - 'none'\n  - 'si'\n  - 'iec'\n  - 'iec-i'\n",
 }
 
 

--- a/scripts/i18n_batch.py
+++ b/scripts/i18n_batch.py
@@ -105,37 +105,42 @@ MANUAL_MESSAGES = {
         "      setenv TZ `tzset`\n"
     ),
     "command.wpm.custom_help": (
-        "Winux Package Manager {}\n"
-        "Usage: wpm <command> [args] [options]\n\n"
-        "Commands:\n"
-        "  links list|rebuild|remove     manage WinuxCmd hardlinks\n"
-        "  clean [cache|staging|all]     remove transient downloads and staging\n"
-        "  cache clean [cache|staging|all]\n"
-        "                                alias for clean\n"
-        "  index status|update           inspect or refresh local index\n"
-        "  update-index                  alias for index update\n"
-        "  source list|use|add|test      manage and test index sources\n"
-        "  list                          list indexed packages and install state\n"
-        "  categories                    list package categories and counts\n"
-        "  search <query>                search names, commands, categories, licenses\n"
-        "  info <package>                show package metadata\n"
-        "  install <package>...          install one or more packages\n"
-        "  installed                     list packages present in this root\n"
-        "  export [--plain]              print installed package names for profiles\n"
-        "  restore <file>                install packages from a plain list\n"
-        "  update|upgrade winuxcmd       update WinuxCmd from local index\n\n"
-        "Options:\n"
-        "  -r, --root <dir>              manage a specific WinuxCmd root\n"
-        "  -s, --source <name>           use a specific index source\n"
-        "  -a, --all                     show index-only packages in list output\n"
-        "  -f, --force                   overwrite existing files when safe\n"
-        "  -n, --dry-run                 show planned changes without writing\n"
-        "  -v, --verbose                 print detailed progress\n"
-        "      --category <name>         filter list/search output by category\n"
-        "      --json                    print machine-readable JSON\n"
-        "      --plain                   print only package names for export\n"
-        "      --help                    display this help and exit\n"
-        "  -V, --version                 output version information and exit\n"
+        'Winux Package Manager {}\\n'
+        'Usage: wpm <command> [args] [options]\\n'
+        '\\n'
+        'Commands:\\n'
+        '  links list|rebuild|remove             manage WinuxCmd hardlinks\\n'
+        '  clean [cache|staging|all]             remove transient downloads and staging\\n'
+        '  cache clean [cache|staging|all]       alias for clean\\n'
+        '  index status|update                   inspect or refresh local index\\n'
+        '  update-index                          alias for index update\\n'
+        '  source list|use|add|test              manage and test index sources\\n'
+        '  list                                  list indexed packages and install state\\n'
+        '  categories                            list package categories and counts\\n'
+        '  search <query>                        search names, commands, categories, licenses\\n'
+        '  info <package>                        show package metadata\\n'
+        '  install <package>...                  install one or more packages\\n'
+        '  installed                             list packages present in this root\\n'
+        '  export [--plain]                      print installed package names for profiles\\n'
+        '  restore <file>                        install packages from a plain list\\n'
+        '  outdated                              list installed packages with updates\\n'
+        '  uninstall|remove|erase <package>...   uninstall one or more packages\\n'
+        '  update|upgrade winuxcmd               update WinuxCmd from local index\\n'
+        '\\n'
+        'Options:\\n'
+        '  -r, --root <dir>                      manage a specific WinuxCmd root\\n'
+        '  -s, --source <name>                   use a specific index source\\n'
+        '  -a, --all                             show index-only packages in list output\\n'
+        '  -f, --force                           overwrite existing files when safe\\n'
+        '  -n, --dry-run                         show planned changes without writing\\n'
+        '  -v, --verbose                         print detailed progress\\n'
+        '  -y, --yes                             assume yes for interactive prompts\\n'
+        '      --category <name>                 filter list/search output by category\\n'
+        '      --json                            print machine-readable JSON\\n'
+        '      --plain                           print only package names for export\\n'
+        '      --help                            display this help and exit\\n'
+        '  -V, --version                         output version information and exit\\n'
+        ''
     ),
     "command.chown.error.unsupported_ownership": "chown: changing ownership is not supported on Windows",
     "command.wpm.error.invalid_json": "wpm: invalid JSON: {}",
@@ -150,6 +155,48 @@ MANUAL_MESSAGES = {
     "command.wpm.status.clean_summary":
         "wpm: removed {} ({} in {} files) in {:.1f}s",
     "command.wpm.status.install_summary": "wpm: install summary: requested={} failed={}",
+    "command.wpm.status.uninstall_confirm": "wpm: the following packages will be removed: {}",
+    "command.wpm.status.uninstall_prompt": "wpm: continue? [y/N] ",
+    "command.wpm.status.uninstall_aborted": "wpm: aborted; nothing was removed",
+    "command.wpm.status.uninstall_progress":
+        "wpm: removing {}... {}% ({}/{} files, {})",
+    "command.wpm.status.installing_files": "wpm: installing files...",
+    "command.wpm.status.installed": "wpm: installed {}",
+    "command.wpm.status.install_dry_run": "wpm: dry-run complete; would install {}",
+    "command.wpm.status.extracting": "wpm: extracting {}",
+    "command.wpm.status.downloading": "wpm: downloading {}",
+    "command.wpm.status.using_cache": "wpm: using cached {}",
+    "command.wpm.status.fetching_index": "wpm: fetching index from {}",
+    "command.wpm.status.index_updated": "wpm: index updated from {}",
+    "command.wpm.status.auto_index_update":
+        "wpm: {}; updating index from configured sources",
+    "command.wpm.status.update_dry_run":
+        "wpm: dry-run: would apply update from {}",
+    "command.wpm.status.update_staged":
+        "wpm: update staged; helper will replace winuxcmd after exit",
+    "command.wpm.error.install_not_found":
+        "wpm: package not found after index update: {}",
+    "command.wpm.error.not_installable":
+        "wpm: package is not installable for {}: {}",
+    "command.wpm.error.fix_index_hint":
+        "wpm: update the source index artifact urls, sha256, and files mapping",
+    "command.wpm.error.unsupported_type": "wpm: unsupported artifact type: {}",
+    "command.wpm.error.no_urls": "wpm: package '{}' has no URLs in the local index",
+    "command.wpm.error.run_index_update_hint":
+        "wpm: run 'wpm index update' or choose another source",
+    "command.wpm.error.download_failed": "wpm: download failed from {}: {}",
+    "command.wpm.error.write_cache": "wpm: failed to write cache file {}",
+    "command.wpm.error.no_source": "wpm: no reachable index source",
+    "command.wpm.error.save_index": "wpm: failed to save index",
+    "command.wpm.error.auto_index_failed": "wpm: automatic index update failed",
+    "command.wpm.error.auto_index_hint":
+        "wpm: run 'wpm index update' to retry or 'wpm source list' to inspect sources",
+    "command.wpm.error.core_missing":
+        "wpm: winuxcmd package missing after index update",
+    "command.wpm.error.stage_core": "wpm: failed to stage winuxcmd.exe: {}",
+    "command.wpm.error.staged_missing": "wpm: staged winuxcmd.exe not found",
+    "command.wpm.error.extract_failed":
+        "wpm: {} extraction failed; Windows tar.exe returned {}",
     "command.wpm.status.keep_running": "wpm: keeping running executable: {}",
     "command.wpm.error.refuse_directory": "wpm: refusing to replace directory: {}",
     "command.wpm.error.remove": "wpm: failed to remove '{}': {}",
@@ -262,6 +309,16 @@ MANUAL_MESSAGES = {
     "common.error.open_script": "cannot open script file '{}'",
     "command.dd.error.open_input": "dd: failed to open '{}': {}",
     "command.dd.error.read": "dd: read error",
+    "command.dd.error.cannot_skip": "dd: {}: cannot skip: Value too large for defined data type",
+    "command.dd.error.cannot_seek": "dd: {}: cannot seek: Value too large for defined data type",
+    "command.pr.error.page_exceeds": "pr: starting page number {} exceeds page count {}",
+    "command.kill.error.invalid_signal": "'{}': invalid signal",
+    "command.kill.error.multiple_signals": "'{}': multiple signals specified",
+    "common.error.invalid_gap_width": "invalid gap width: '{}'",
+    "common.error.invalid_parallel_argument": "invalid --parallel argument '{}'",
+    "common.error.invalid_number": "Invalid number: '{}'",
+    "common.error.invalid_field_number": "invalid field number: '{}'",
+    "common.error.size_or_reference": "you must specify either '--size' or '--reference'",
 }
 
 

--- a/scripts/sync_wpm_help.py
+++ b/scripts/sync_wpm_help.py
@@ -1,0 +1,62 @@
+"""Sync the wpm custom_help entry in i18n_batch.py from src/commands/wpm.cpp.
+
+Extracts the concatenated C++ string literal of print_usage()'s `help`
+variable and rewrites the MANUAL_MESSAGES entry "command.wpm.custom_help".
+"""
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(r"D:\repo\unixwin-winuxcmd")
+CPP = ROOT / "src" / "commands" / "wpm.cpp"
+PY = ROOT / "scripts" / "i18n_batch.py"
+
+cpp_text = CPP.read_text(encoding="utf-8")
+
+# Locate the help string inside print_usage()
+start = cpp_text.index("auto print_usage() -> int {")
+seg = cpp_text[start:]
+m = re.search(r"const std::string help =\n(.*?);\n", seg, re.S)
+if not m:
+    sys.exit("help literal not found")
+literal_block = m.group(1)
+
+# Extract each C++ string literal piece and unescape
+pieces = re.findall(r'"((?:[^"\\]|\\.)*)"', literal_block)
+
+
+def unescape(s: str) -> str:
+    return (
+        s.replace('\\"', '"')
+        .replace("\\\\", "\\")
+        .replace("\\n", "\n")
+        .replace("\\t", "\t")
+    )
+
+
+text = "".join(unescape(p) for p in pieces)
+
+# Build the Python literal: one repr per line, implicit concatenation
+lines = text.split("\n")
+parts = []
+for i, line in enumerate(lines):
+    suffix = "\\n" if i < len(lines) - 1 else ""
+    value = line + suffix
+    parts.append("        %s" % repr(value))
+py_literal = "(\n" + "\n".join(parts) + "\n    )"
+
+py_text = PY.read_text(encoding="utf-8")
+key = '    "command.wpm.custom_help": '
+begin = py_text.index(key)
+end = py_text.index("    ),", begin) + len("    ),")
+new_entry = key + py_literal + ","
+py_text = py_text[:begin] + new_entry + py_text[end:]
+PY.write_text(py_text, encoding="utf-8")
+
+print("custom_help synced:", len(lines), "lines,", len(text), "chars")
+print("--- first 3 / last 3 ---")
+for l in lines[:3]:
+    print(repr(l))
+for l in lines[-3:]:
+    print(repr(l))

--- a/src/commands/date.cpp
+++ b/src/commands/date.cpp
@@ -410,6 +410,13 @@ auto append_number(std::string &out, int value, int width, char fill = '0') {
   out += buf;
 }
 
+// Left-pad s with fill until it is at least width chars long.
+auto pad_left(std::string s, size_t width, char fill) -> std::string {
+  if (s.size() >= width) return s;
+  s.insert(0, width - s.size(), fill);
+  return s;
+}
+
 // [GNU] %^ forces upper case, %# swaps the natural case of textual output
 // (gnulib strftime semantics: to_lowcase wins over to_uppcase).
 auto apply_case(std::string text, bool to_uppcase, bool to_lowcase)
@@ -442,6 +449,13 @@ auto format_time(const TimeValue &tv, const std::string &format)
       bool to_lowcase = false;
       bool change_case = false;
       bool colon_zone = false;
+      // [GNU] numeric width/padding flags: '-' (no pad), '_' (space pad),
+      // '0' (zero pad, default) and a decimal width that overrides the
+      // per-specifier default precision (%02j -> "01", %3N -> milliseconds).
+      char pad_char = '0';
+      bool no_pad = false;
+      int width = 0;
+      bool has_width = false;
       const size_t spec_start = i;
       ++i;
       while (i < format.size()) {
@@ -452,6 +466,13 @@ auto format_time(const TimeValue &tv, const std::string &format)
           change_case = true;
         } else if (flag == ':' && !colon_zone) {
           colon_zone = true;
+        } else if (flag == '-') {
+          no_pad = true;
+        } else if (flag == '_') {
+          pad_char = ' ';
+        } else if (flag >= '0' && flag <= '9') {
+          has_width = true;
+          width = width * 10 + (flag - '0');
         } else {
           break;
         }
@@ -504,9 +525,28 @@ auto format_time(const TimeValue &tv, const std::string &format)
         case 'S':
           append_number(result, st.wSecond, 2);
           break;
-        case 'N':
-          append_number(result, st.wMilliseconds * 1000000, 9);
+        case 'N': {
+          // [GNU] %N prints 9-digit nanoseconds. An explicit width smaller
+          // than 9 truncates (%3N -> "123"), a larger width left-pads
+          // (%12N), '-' keeps the first digit only.
+          std::string nanos = pad_left(std::to_string(
+                                           static_cast<long long>(
+                                               st.wMilliseconds) *
+                                           1000000),
+                                       9, '0');
+          if (no_pad) {
+            result += nanos.substr(0, 1);
+          } else if (has_width) {
+            if (width < static_cast<int>(nanos.size())) {
+              result += nanos.substr(0, width);
+            } else {
+              result += pad_left(nanos, width, '0');
+            }
+          } else {
+            result += nanos;
+          }
           break;
+        }
         case 'p': {
           std::string text = st.wHour < 12 ? "AM" : "PM";
           // [GNU] %#p prints the meridiem in lower case.
@@ -593,9 +633,21 @@ auto format_time(const TimeValue &tv, const std::string &format)
           result +=
               apply_case(format_time(tv, "%H:%M:%S"), to_uppcase, to_lowcase);
           break;
-        case 'j':
-          append_number(result, day_of_year(st), 3);
+        case 'j': {
+          const int doy = day_of_year(st);
+          if (has_width) {
+            std::string digits = std::to_string(doy);
+            if (no_pad) {
+              result += digits;
+            } else if (static_cast<int>(digits.size()) < width) {
+              result.append(width - digits.size(), pad_char);
+            }
+            result += digits;
+          } else {
+            append_number(result, doy, 3);
+          }
           break;
+        }
         case 'q':
           // [GNU] %q: quarter of year (1-4).
           append_number(result, (st.wMonth - 1) / 3 + 1, 1);
@@ -693,6 +745,82 @@ auto parse_date_argument(const std::string &arg, bool use_utc)
   if (lower == "now" || lower == "today") return now;
   if (lower == "tomorrow") return relative(1, 86400);
   if (lower == "yesterday") return relative(-1, 86400);
+
+  // [GNU] "yesterday 10:00 GMT" / "tomorrow 09:30" / "today 08:00" — a
+  // relative day word followed by a wall-clock time and an optional
+  // UTC-ish zone name (uutils #10788). Parsed manually to keep the
+  // hot path free of regex machinery.
+  {
+    const std::string_view day_words[] = {"yesterday", "today", "tomorrow"};
+    for (const auto& word : day_words) {
+      if (!lower.starts_with(word)) continue;
+      std::string rest = trim_copy(lower.substr(word.size()));
+      if (rest.empty()) continue;  // bare day word handled above
+
+      // rest: "HH:MM[:SS]" optionally followed by a UTC-ish zone name.
+      std::string time_part = rest;
+      bool utc_zone = false;
+      if (auto space = rest.find(' '); space != std::string::npos) {
+        time_part = trim_copy(rest.substr(0, space));
+        std::string zone = trim_copy(rest.substr(space + 1));
+        utc_zone = zone == "gmt" || zone == "utc" || zone == "ut" ||
+                   zone == "z";
+        if (!utc_zone) return std::nullopt;
+      }
+      int hour = -1;
+      int minute = -1;
+      int second = 0;
+      {
+        const auto colon1 = time_part.find(':');
+        if (colon1 == std::string::npos) return std::nullopt;
+        const auto colon2 = time_part.find(':', colon1 + 1);
+        auto parse_field = [](const std::string& text) -> int {
+          if (text.empty() || text.size() > 2) return -1;
+          for (const char ch : text) {
+            if (!std::isdigit(static_cast<unsigned char>(ch))) return -1;
+          }
+          return (text[0] - '0') * 10 +
+                 (text.size() > 1 ? text[1] - '0' : 0);
+        };
+        hour = parse_field(time_part.substr(0, colon1));
+        if (colon2 == std::string::npos) {
+          minute = parse_field(time_part.substr(colon1 + 1));
+        } else {
+          minute = parse_field(time_part.substr(colon1 + 1, colon2 - colon1 - 1));
+          second = parse_field(time_part.substr(colon2 + 1));
+        }
+      }
+      if (hour < 0 || minute < 0 || second < 0 || hour > 23 || minute > 59 ||
+          second > 59) {
+        return std::nullopt;
+      }
+      long long day_shift = 0;
+      if (word == "yesterday") day_shift = -86400;
+      else if (word == "tomorrow") day_shift = 86400;
+      const FILETIME shifted = add_seconds(now, day_shift);
+      SYSTEMTIME base{};
+      if (utc_zone) {
+        if (!FileTimeToSystemTime(&shifted, &base)) return std::nullopt;
+        base.wHour = static_cast<WORD>(hour);
+        base.wMinute = static_cast<WORD>(minute);
+        base.wSecond = static_cast<WORD>(second);
+        base.wMilliseconds = 0;
+        FILETIME out{};
+        if (!SystemTimeToFileTime(&base, &out)) return std::nullopt;
+        return out;
+      }
+      FILETIME local_shifted{};
+      if (!FileTimeToLocalFileTime(&shifted, &local_shifted)) {
+        return std::nullopt;
+      }
+      if (!FileTimeToSystemTime(&local_shifted, &base)) return std::nullopt;
+      base.wHour = static_cast<WORD>(hour);
+      base.wMinute = static_cast<WORD>(minute);
+      base.wSecond = static_cast<WORD>(second);
+      base.wMilliseconds = 0;
+      return local_system_time_to_filetime(base);
+    }
+  }
 
   // "next monday", "next week", etc.
   std::smatch next_match;

--- a/src/commands/date.cpp
+++ b/src/commands/date.cpp
@@ -760,6 +760,67 @@ auto parse_date_argument(const std::string &arg, bool use_utc)
     return relative(-days_back, 86400);
   }
 
+  // [GNU] military timezone specs: <digits><letter>, e.g. 9j, 1230z.
+  // J = local time, Z = UTC, A-M (except J) = UTC+1..+12, N-Y = UTC-1..-12
+  // (uutils #12684)
+  {
+    static const std::regex military_re(R"(^([0-9]{1,4})([A-Za-z])$)");
+    std::smatch mil;
+    if (std::regex_match(value, mil, military_re)) {
+      const std::string digits = mil[1].str();
+      const char letter = static_cast<char>(std::tolower(
+          static_cast<unsigned char>(mil[2].str()[0])));
+      int hour = 0;
+      int minute = 0;
+      if (digits.size() <= 2) {
+        hour = std::stoi(digits);
+      } else {
+        hour = std::stoi(digits.substr(0, digits.size() - 2));
+        minute = std::stoi(digits.substr(digits.size() - 2));
+      }
+      bool ok = hour <= 23 && minute <= 59;
+      int zone_offset_minutes = 0;
+      if (letter != 'j') {
+        if (letter >= 'a' && letter <= 'm') {
+          zone_offset_minutes = (letter - 'a' + 1) * 60;
+        } else if (letter == 'z') {
+          zone_offset_minutes = 0;
+        } else if (letter >= 'n' && letter <= 'y') {
+          zone_offset_minutes = -(letter - 'n' + 1) * 60;
+        } else {
+          ok = false;
+        }
+      }
+      if (!ok) return std::nullopt;
+
+      FILETIME now_ft{};
+      GetSystemTimeAsFileTime(&now_ft);
+      FILETIME local_now_ft{};
+      if (!FileTimeToLocalFileTime(&now_ft, &local_now_ft)) return std::nullopt;
+      SYSTEMTIME local_now{};
+      if (!FileTimeToSystemTime(&local_now_ft, &local_now)) return std::nullopt;
+
+      SYSTEMTIME target{};
+      target.wYear = local_now.wYear;
+      target.wMonth = local_now.wMonth;
+      target.wDay = local_now.wDay;
+      target.wHour = static_cast<WORD>(hour);
+      target.wMinute = static_cast<WORD>(minute);
+
+      if (letter == 'j') {
+        // J is the local military zone: wall time is local
+        return local_system_time_to_filetime(target);
+      }
+      auto as_local = local_system_time_to_filetime(target);
+      if (!as_local) return std::nullopt;
+      // Shift from "wall time as local" to "wall time in the target zone"
+      const int local_offset = timezone_offset_minutes(now_ft, false);
+      return add_seconds(*as_local, static_cast<long long>(
+                                        local_offset - zone_offset_minutes) *
+                                        60);
+    }
+  }
+
   return parse_fixed_date_time(arg, use_utc);
 }
 

--- a/src/commands/dd.cpp
+++ b/src/commands/dd.cpp
@@ -524,7 +524,25 @@ REGISTER_COMMAND(dd,
   auto skip_bytes = checked_product(cfg.skip, cfg.ibs);
   auto seek_bytes = checked_product(cfg.seek, cfg.obs);
   if (!skip_bytes || !seek_bytes) {
-    safeErrorPrintLn("dd: skip/seek offset overflow");
+    // [GNU] an offset that overflows reports EOVERFLOW wording
+    // (uutils #14199)
+    if (!skip_bytes) {
+      const std::string& in_name =
+          cfg.input_file.empty() ? std::string("standard input")
+                                 : cfg.input_file;
+      safeErrorPrintLn(winux::i18n::format(
+          "command.dd.error.cannot_skip",
+          "dd: {}: cannot skip: Value too large for defined data type",
+          in_name));
+    } else {
+      const std::string& out_name =
+          cfg.output_file.empty() ? std::string("standard output")
+                                  : cfg.output_file;
+      safeErrorPrintLn(winux::i18n::format(
+          "command.dd.error.cannot_seek",
+          "dd: {}: cannot seek: Value too large for defined data type",
+          out_name));
+    }
     if (hIn != INVALID_HANDLE_VALUE && hIn != stdin_handle) CloseHandle(hIn);
     if (hOut != INVALID_HANDLE_VALUE && hOut != stdout_handle)
       CloseHandle(hOut);

--- a/src/commands/du.cpp
+++ b/src/commands/du.cpp
@@ -637,6 +637,9 @@ auto configure_du(const CommandContext<DU_OPTIONS.size()>& ctx)
       ctx.get<bool>("--summarize", false) || ctx.get<bool>("-s", false);
 
   cfg.max_depth = ctx.get<int>("--max-depth", -1);
+  if (cfg.count_all && cfg.summarize) {
+    return std::unexpected("cannot both summarize and show all");
+  }
   if (ctx.get<int>("-d", -1) != -1) {
     cfg.max_depth = ctx.get<int>("-d", -1);
   }

--- a/src/commands/du.cpp
+++ b/src/commands/du.cpp
@@ -544,7 +544,8 @@ auto print_time_if_requested(const UsageSummary& summary, const DuConfig& cfg)
   if (!cfg.show_time || !summary.has_time) {
     return;
   }
-  safePrint("  ");
+  // [GNU] size and time are tab-separated (uutils #13267)
+  safePrint("\t");
   safePrint(format_time_long_iso(summary.latest_time, cfg.time_style));
 }
 

--- a/src/commands/du.cpp
+++ b/src/commands/du.cpp
@@ -808,6 +808,31 @@ auto get_hard_link_count(const std::wstring& path) -> DWORD {
 }
 
 /**
+ * @brief Get a stable per-inode key (volume serial + file index)
+ * @param path File path
+ * @return L"<volume>:<index>" or empty if unavailable
+ */
+auto get_inode_key(const std::wstring& path) -> std::wstring {
+  HANDLE hFile = CreateFileW(
+      path.c_str(), 0, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+      nullptr, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
+  if (hFile == INVALID_HANDLE_VALUE) {
+    return L"";
+  }
+  BY_HANDLE_FILE_INFORMATION info{};
+  std::wstring key;
+  if (GetFileInformationByHandle(hFile, &info)) {
+    const uint64_t index =
+        (static_cast<uint64_t>(info.nFileIndexHigh) << 32) |
+        info.nFileIndexLow;
+    key = std::to_wstring(info.dwVolumeSerialNumber) + L":" +
+          std::to_wstring(index);
+  }
+  CloseHandle(hFile);
+  return key;
+}
+
+/**
  * @brief Get file size
  * @param path File path
  * @return File size or 0 if error
@@ -835,6 +860,7 @@ auto calculate_dir_size(const std::wstring& path,
                         std::unordered_map<std::wstring, uint64_t>& sizes,
                         std::unordered_map<std::wstring, FILETIME>& times,
                         int current_depth, const DuConfig& cfg,
+                        std::unordered_set<std::wstring>& seen_inodes,
                         const std::wstring& root_drive = L"") -> UsageSummary {
   WIN32_FIND_DATAW find_data;
   std::wstring search_path = path + L"\\*";
@@ -887,7 +913,8 @@ auto calculate_dir_size(const std::wstring& path,
 
       // Recursively calculate subdirectory size
       UsageSummary child_summary =
-          calculate_dir_size(full_path, sizes, times, child_depth, cfg, drive);
+          calculate_dir_size(full_path, sizes, times, child_depth, cfg,
+                             seen_inodes, drive);
       if (!cfg.separate_dirs) {
         summary.size += child_summary.size;
       }
@@ -897,9 +924,23 @@ auto calculate_dir_size(const std::wstring& path,
     } else {
       // It's a file
       uint64_t file_size = get_file_size(full_path);
-      // --count-links: multiply by hard link count [DIFFERS]
-      if (cfg.count_links) {
-        DWORD nlinks = get_hard_link_count(full_path);
+      // [GNU] Hard-linked files are counted once per invocation; later
+      // occurrences of the same inode contribute nothing (uutils #9202
+      // #10241 #10312 #9871). --count-links opts out.
+      bool counted = true;
+      if (!cfg.count_links) {
+        const DWORD nlinks = get_hard_link_count(full_path);
+        if (nlinks > 1) {
+          const std::wstring inode_key = get_inode_key(full_path);
+          if (!inode_key.empty()) {
+            if (!seen_inodes.insert(inode_key).second) {
+              counted = false;
+              file_size = 0;
+            }
+          }
+        }
+      } else {
+        const DWORD nlinks = get_hard_link_count(full_path);
         if (nlinks > 1) {
           file_size *= nlinks;
         }
@@ -911,7 +952,7 @@ auto calculate_dir_size(const std::wstring& path,
                                  &file_data)) {
           FILETIME file_time = get_selected_time(file_data, cfg.time_mode);
           update_latest_time(summary, file_time);
-          if (cfg.count_all &&
+          if (cfg.count_all && counted &&
               (cfg.max_depth < 0 || child_depth <= cfg.max_depth)) {
             times[full_path] = file_time;
           }
@@ -919,7 +960,7 @@ auto calculate_dir_size(const std::wstring& path,
       }
 
       // Count individual files if requested
-      if (cfg.count_all &&
+      if (counted && cfg.count_all &&
           (cfg.max_depth < 0 || child_depth <= cfg.max_depth)) {
         sizes[full_path] = file_size;
       }
@@ -994,6 +1035,8 @@ auto print_disk_usage(const CommandContext<DU_OPTIONS.size()>& ctx)
 
   bool all_ok = true;
   uint64_t grand_total = 0;
+  // [GNU] Hard-link dedup spans all arguments of one invocation.
+  std::unordered_set<std::wstring> seen_inodes;
 
   for (size_t i = 0; i < paths.size(); ++i) {
     const auto& path = paths[i];
@@ -1020,7 +1063,7 @@ auto print_disk_usage(const CommandContext<DU_OPTIONS.size()>& ctx)
     if (attrs & FILE_ATTRIBUTE_DIRECTORY) {
       // Calculate directory size
       UsageSummary dir_summary =
-          calculate_dir_size(wpath, sizes, times, 0, cfg);
+          calculate_dir_size(wpath, sizes, times, 0, cfg, seen_inodes);
 
       // Print directory size
       uint64_t dir_size = sizes[wpath];

--- a/src/commands/false.cpp
+++ b/src/commands/false.cpp
@@ -43,7 +43,7 @@ using cmd::meta::OptionType;
 
 auto constexpr FALSE_OPTIONS =
     // [GNU]
-    std::array{OPTION("", "", "do nothing, unsuccessfully", STRING_TYPE)};
+    std::array{OPTION("--help", "", "display this help and exit", BOOL_TYPE)};
 
 REGISTER_COMMAND(
     false_cmd,
@@ -62,6 +62,16 @@ REGISTER_COMMAND(
 
     /* see also */
     "true(1)", "WinuxCmd", "Copyright © 2026 WinuxCmd", FALSE_OPTIONS) {
+  // [GNU] false --help prints a usage summary and exits successfully.
+  if (ctx.has("--help")) {
+    safePrint("Usage: false [ignored command line arguments]\n"
+              "  or:  false OPTION\n"
+              "Exit with a status code indicating failure.\n"
+              "\n"
+              "      --help     display this help and exit\n"
+              "      --version  output version information and exit\n");
+    return 0;
+  }
   // Do nothing, just return 1 (failure)
   return 1;
 }

--- a/src/commands/hostname.cpp
+++ b/src/commands/hostname.cpp
@@ -92,33 +92,38 @@ struct Config {
 auto build_config(const CommandContext<HOSTNAME_OPTIONS.size()>& ctx)
     -> cp::Result<Config> {
   Config cfg;
-  cfg.show_ip =
-      ctx.get<bool>("--ip-address", false) || ctx.get<bool>("-i", false);
-  cfg.show_all_ips =
-      ctx.get<bool>("--all-ip-addresses", false) || ctx.get<bool>("-I", false);
-  cfg.short_name =
-      ctx.get<bool>("--short", false) || ctx.get<bool>("-s", false);
-  cfg.fqdn = ctx.get<bool>("--fqdn", false) || ctx.get<bool>("-f", false);
-  cfg.domain = ctx.get<bool>("--domain", false) || ctx.get<bool>("-d", false);
-  cfg.node = ctx.get<bool>("--node", false) || ctx.get<bool>("-n", false);
-  auto file_opt = ctx.get<std::string>("--file", "");
-  if (!file_opt.empty()) {
-    cfg.file = file_opt;
+  // [GNU] coreutils hostname only prints/sets the system name; the
+  // net-tools option set (-i/-s/-f/-d/...) is rejected with an
+  // "unknown option" error (uutils #8656).
+  struct UnsupportedOption {
+    std::string_view short_name;
+    std::string_view long_name;
+  };
+  static constexpr UnsupportedOption unsupported[] = {
+      {"-b", "--boot"},         {"-i", "--ip-address"},
+      {"-I", "--all-ip-addresses"}, {"-s", "--short"},
+      {"-f", "--fqdn"},         {"-a", "--alias"},
+      {"-A", "--all-fqdns"},    {"-d", "--domain"},
+      {"-F", "--file"},         {"-y", "--yp"},
+      {"-n", "--node"}};
+  for (const auto& opt : unsupported) {
+    if (!opt.short_name.empty() && ctx.has(std::string(opt.short_name))) {
+      return std::unexpected(
+          "unknown option -- " + std::string(opt.short_name.substr(1)) +
+          "\nTry 'hostname --help' for more information.");
+    }
+    if (ctx.has(std::string(opt.long_name))) {
+      return std::unexpected(
+          "unrecognized option '" + std::string(opt.long_name) +
+          "'\nTry 'hostname --help' for more information.");
+    }
   }
-
-  // [DIFFERS] -a/--alias: host alias names not supported on Windows
-  if (ctx.get<bool>("--alias", false) || ctx.get<bool>("-a", false)) {
-    return std::unexpected("host alias names are not supported on Windows");
-  }
-  // [DIFFERS] -A/--all-fqdns: all FQDNs not supported on Windows
-  if (ctx.get<bool>("--all-fqdns", false) || ctx.get<bool>("-A", false)) {
-    return std::unexpected(
-        "all FQDNs of the host are not supported on Windows");
-  }
-  // [DIFFERS] -y/--yp: NIS/YP domain name not supported on Windows
-  if (ctx.get<bool>("--yp", false) || ctx.get<bool>("-y", false)) {
-    return std::unexpected("NIS/YP domain name is not supported on Windows");
-  }
+  (void)cfg.show_ip;
+  (void)cfg.show_all_ips;
+  (void)cfg.short_name;
+  (void)cfg.fqdn;
+  (void)cfg.domain;
+  (void)cfg.node;
 
   return cfg;
 }

--- a/src/commands/join.cpp
+++ b/src/commands/join.cpp
@@ -114,13 +114,17 @@ struct Config {
   SmallVector<std::string, 64> files;
 };
 
-auto parse_positive_field(const std::string& text, std::string_view option)
-    -> cp::Result<int> {
+auto parse_positive_field(const std::string& text) -> cp::Result<int> {
   int value = 0;
   auto [ptr, ec] =
       std::from_chars(text.data(), text.data() + text.size(), value);
+  if (ec == std::errc::result_out_of_range) {
+    // [GNU] out-of-range field numbers are silently clamped, matching
+    // xstrtoimax's PTRDIFF_MAX clamp (uutils #13376)
+    return std::numeric_limits<int>::max();
+  }
   if (ec != std::errc() || ptr != text.data() + text.size() || value <= 0) {
-    return std::unexpected("invalid field number for " + std::string(option));
+    return std::unexpected("invalid field number: '" + text + "'");
   }
   return value;
 }
@@ -244,7 +248,7 @@ auto parse_output_format(const std::string& format)
       return std::unexpected("invalid output file number");
     }
 
-    auto field = parse_positive_field(field_part, "-o");
+    auto field = parse_positive_field(field_part);
     if (!field) {
       return std::unexpected(field.error());
     }
@@ -289,21 +293,21 @@ auto build_config(const CommandContext<JOIN_OPTIONS.size()>& ctx)
 
   auto field1_opt = ctx.get<std::string>("-1", "");
   if (!field1_opt.empty()) {
-    auto field = parse_positive_field(field1_opt, "-1");
+    auto field = parse_positive_field(field1_opt);
     if (!field) return std::unexpected(field.error());
     cfg.field1 = *field;
   }
 
   auto field2_opt = ctx.get<std::string>("-2", "");
   if (!field2_opt.empty()) {
-    auto field = parse_positive_field(field2_opt, "-2");
+    auto field = parse_positive_field(field2_opt);
     if (!field) return std::unexpected(field.error());
     cfg.field2 = *field;
   }
 
   auto j_opt = ctx.get<std::string>("-j", "");
   if (!j_opt.empty()) {
-    auto field = parse_positive_field(j_opt, "-j");
+    auto field = parse_positive_field(j_opt);
     if (!field) return std::unexpected(field.error());
     cfg.field1 = *field;
     cfg.field2 = cfg.field1;

--- a/src/commands/kill.cpp
+++ b/src/commands/kill.cpp
@@ -462,7 +462,8 @@ auto list_signals(bool table_format) -> cp::Result<bool> {
 auto convert_and_print_signal(std::string_view signal_arg) -> cp::Result<bool> {
   auto converted = kill_constants::convert_signal_token(signal_arg);
   if (!converted) {
-    return std::unexpected("unknown signal: " + std::string(signal_arg));
+    // [GNU] operand2sig wording (uutils #14177)
+    return std::unexpected("'" + std::string(signal_arg) + "': invalid signal");
   }
   safePrint(*converted);
   safePrint("\n");
@@ -475,14 +476,15 @@ auto convert_and_print_signal(std::string_view signal_arg) -> cp::Result<bool> {
 auto parse_signal(const std::string& signal_arg) -> cp::Result<int> {
   if (auto signal_num = kill_constants::parse_decimal(signal_arg)) {
     if (*signal_num < 0 || *signal_num > kill_constants::kMaxSignal) {
-      return std::unexpected("invalid signal number");
+      // [GNU] operand2sig wording (uutils #14177)
+      return std::unexpected("'" + signal_arg + "': invalid signal");
     }
     return *signal_num;
   }
 
   auto signal_num = kill_constants::get_signal_by_name(signal_arg);
   if (!signal_num) {
-    return std::unexpected("unknown signal: " + signal_arg);
+    return std::unexpected("'" + signal_arg + "': invalid signal");
   }
   return *signal_num;
 }
@@ -519,6 +521,11 @@ auto signal_from_option_occurrences(const CommandContext<N>& ctx)
       auto value = std::get_if<std::string>(&occurrence.value);
       if (!value) continue;
 
+      // [GNU] a second signal spec is rejected, not silently overridden
+      // (uutils #14177)
+      if (signal) {
+        return std::unexpected("'" + *value + "': multiple signals specified");
+      }
       auto parsed = parse_signal(*value);
       if (!parsed) return std::unexpected(parsed.error());
       signal = *parsed;
@@ -527,14 +534,26 @@ auto signal_from_option_occurrences(const CommandContext<N>& ctx)
 
     if (meta.short_name == "-NUM") {
       auto value = std::get_if<int>(&occurrence.value);
-      if (value && *value >= 0 && *value <= kill_constants::kMaxSignal) {
-        signal = *value;
-        continue;
+      if (value) {
+        if (*value >= 0 && *value <= kill_constants::kMaxSignal) {
+          signal = *value;
+          continue;
+        }
+        // [GNU] operand2sig wording; the leading dash is stripped
+        // (uutils #14177)
+        return std::unexpected("'" + std::to_string(*value) +
+                               "': invalid signal");
       }
       return std::unexpected("invalid signal number");
     }
 
     if (auto parsed = parse_signal_option_name(meta.short_name)) {
+      // [GNU] a second signal spec is rejected, not silently overridden
+      // (uutils #14177)
+      if (signal) {
+        return std::unexpected("'" + std::string(meta.short_name.substr(1)) +
+                               "': multiple signals specified");
+      }
       signal = *parsed;
     }
   }
@@ -733,6 +752,7 @@ auto process_command(const CommandContext<N>& ctx) -> cp::Result<bool> {
   if (!signal_result) {
     return std::unexpected(signal_result.error());
   }
+  bool signal_explicit = signal_result->has_value();
   if (*signal_result) {
     signal = **signal_result;
   }
@@ -740,6 +760,32 @@ auto process_command(const CommandContext<N>& ctx) -> cp::Result<bool> {
   // Parse PIDs from positional arguments
   std::vector<std::string> pid_args;
   for (auto arg : ctx.positionals) {
+    std::string text(arg);
+    // [GNU] an unregistered -SPEC operand is a signal specification, so
+    // -SIGSIGTERM is rejected as invalid instead of being parsed as an
+    // option cluster (uutils #14177)
+    if (text.size() > 1 && text[0] == '-' &&
+        !kill_constants::parse_decimal(text.substr(1))) {
+      std::string spec = text.substr(1);
+      if (signal_explicit) {
+        return std::unexpected("'" + spec + "': multiple signals specified");
+      }
+      auto parsed = kill_constants::get_signal_by_name(spec);
+      if (!parsed) {
+        return std::unexpected("'" + spec + "': invalid signal");
+      }
+      signal = *parsed;
+      signal_explicit = true;
+      continue;
+    }
+    // [GNU] operand2sig rejects a numeric -SPEC above the signal bound as a
+    // signal, so -99 is not parsed as a PID (uutils #14177)
+    if (text.size() > 1 && text[0] == '-') {
+      auto numeric = kill_constants::parse_decimal(text.substr(1));
+      if (numeric && (*numeric < 0 || *numeric > kill_constants::kMaxSignal)) {
+        return std::unexpected("'" + text.substr(1) + "': invalid signal");
+      }
+    }
     pid_args.push_back(std::string(arg));
   }
 

--- a/src/commands/kill.cpp
+++ b/src/commands/kill.cpp
@@ -733,6 +733,14 @@ auto process_command(const CommandContext<N>& ctx) -> cp::Result<bool> {
   // Handle list/table options
   if (list || table) {
     if (list && !table) {
+      // [GNU] a -SPEC operand (consumed as the -NUM signal form) cannot be
+      // combined with -l: operand2sig rejects the negative spec, so
+      // "kill -l -9" is an error, not a signal listing (uutils #7066).
+      if (ctx.count({"-NUM"}) > 0) {
+        return std::unexpected("'-" +
+                               std::to_string(ctx.get<int>("-NUM", 0)) +
+                               "': invalid signal");
+      }
       if (auto conversion_arg = list_conversion_argument(ctx)) {
         return convert_and_print_signal(*conversion_arg);
       }

--- a/src/commands/ln.cpp
+++ b/src/commands/ln.cpp
@@ -185,13 +185,11 @@ auto create_symlink(const std::string &source, const std::string &target,
 
   // Check if source is a directory
   DWORD attrs = GetFileAttributesW(wsource.c_str());
-  if (attrs == INVALID_FILE_ATTRIBUTES) {
-    return std::unexpected("failed to access '" + source +
-                           "': No such file or directory");
-  }
-
-  bool is_directory = (attrs & FILE_ATTRIBUTE_DIRECTORY) != 0;
+  bool is_directory = attrs != INVALID_FILE_ATTRIBUTES &&
+                      (attrs & FILE_ATTRIBUTE_DIRECTORY) != 0;
   DWORD flags = is_directory ? SYMBOLIC_LINK_FLAG_DIRECTORY : 0;
+  // [GNU] a symlink source may be dangling; creation must not fail when the
+  // source does not exist (uutils #13667)
 
   if (CreateSymbolicLinkW(wtarget.c_str(), wsource.c_str(), flags)) {
     if (verbose) {

--- a/src/commands/ls.cpp
+++ b/src/commands/ls.cpp
@@ -1793,6 +1793,16 @@ auto validate_arguments(const CommandContext<LS_OPTIONS.size()> &ctx)
     paths.push_back(".");
   }
 
+  // [GNU] rejects a non-positive tab size ("invalid tab size: '-1'").
+  if (ctx.count({"-T", "--tabsize"}) > 0) {
+    int tab_size = ctx.get<int>("-T", 0);
+    if (tab_size == 0) tab_size = ctx.get<int>("--tabsize", 0);
+    if (tab_size <= 0) {
+      return std::unexpected("invalid tab size: '" + std::to_string(tab_size) +
+                             "'");
+    }
+  }
+
   return paths;
 }
 
@@ -3442,6 +3452,12 @@ REGISTER_COMMAND(
     if (error.starts_with(kInvalidTimeStylePrefix)) {
       safeErrorPrint(error);
       safeErrorPrint("\n");
+      return 2;
+    }
+    // [GNU] Bad command-line option values (e.g. "invalid tab size: '-1'")
+    // are serious usage errors: exit 2, not 1 (uutils #12835).
+    if (error.starts_with("invalid tab size")) {
+      report_error(result, L"ls");
       return 2;
     }
     report_error(result, L"ls");

--- a/src/commands/mktemp.cpp
+++ b/src/commands/mktemp.cpp
@@ -257,6 +257,21 @@ auto default_temporary_directory() -> cp::Result<std::string> {
   return native_display_path(std::filesystem::path(buffer));
 }
 
+// [GNU] the template (plus suffix) must contain a run of at least 3
+// consecutive X's in its final path component.
+auto has_x_run_of_three(std::string_view templ) -> bool {
+  size_t run = 0;
+  for (char c : templ) {
+    if (c == 'X') {
+      ++run;
+      if (run >= 3) return true;
+    } else {
+      run = 0;
+    }
+  }
+  return false;
+}
+
 auto build_config(const CommandContext<MKTEMP_OPTIONS.size()>& ctx)
     -> cp::Result<Config> {
   Config cfg;
@@ -268,6 +283,15 @@ auto build_config(const CommandContext<MKTEMP_OPTIONS.size()>& ctx)
   auto tmpdir_opt = ctx.get<std::string>("--tmpdir", "");
   if (tmpdir_opt.empty()) {
     tmpdir_opt = ctx.get<std::string>("-p", "");
+  }
+  if (tmpdir_opt.empty() && ctx.count({"--tmpdir", "-p"}) > 0) {
+    // [GNU] an explicitly empty --tmpdir falls back to the default
+    // temporary directory (uutils #8445/#10189).
+    auto default_tmpdir = default_temporary_directory();
+    if (!default_tmpdir) {
+      return std::unexpected(default_tmpdir.error());
+    }
+    tmpdir_opt = *default_tmpdir;
   }
   if (!tmpdir_opt.empty()) {
     cfg.tmpdir = tmpdir_opt;
@@ -312,6 +336,22 @@ auto build_config(const CommandContext<MKTEMP_OPTIONS.size()>& ctx)
         return std::unexpected(default_tmpdir.error());
       }
       cfg.tmpdir = *default_tmpdir;
+    }
+  }
+
+  // [GNU] reject templates without a run of >= 3 consecutive X's:
+  // "too few X's in template '...'" (uutils #10187).
+  {
+    std::string full = cfg.template_str + cfg.suffix;
+    std::string component =
+        std::filesystem::path(normalize_win_shell_path(full))
+            .filename()
+            .string();
+    if (component.empty()) {
+      component = full;
+    }
+    if (!has_x_run_of_three(component)) {
+      return std::unexpected("too few X's in template '" + full + "'");
     }
   }
 

--- a/src/commands/numfmt.cpp
+++ b/src/commands/numfmt.cpp
@@ -118,55 +118,82 @@ double apply_rounding(double value, const std::string& mode) {
 }
 
 // Parse number with SI suffixes (K, M, G, T, P)
-bool parse_number(const std::string& s, long long& result,
-                  const std::string& round_mode = "", std::string from = "") {
-  std::string num_str;
-  char suffix = 0;
+enum class NumParseStatus { Ok, InvalidNumber, InvalidSuffix };
 
-  // Extract numeric part and suffix
-  for (size_t i = 0; i < s.size(); ++i) {
-    if (std::isdigit(s[i]) || s[i] == '.' || s[i] == '-') {
-      num_str += s[i];
-    } else {
-      suffix = std::toupper(s[i]);
-      break;
+NumParseStatus parse_number_ex(const std::string& s, long long& result,
+                               const std::string& round_mode = "",
+                               std::string from = "",
+                               double* raw_value = nullptr) {
+  size_t i = 0;
+  if (i < s.size() && (s[i] == '-' || s[i] == '+')) ++i;
+  const size_t num_start = i;
+  while (i < s.size() &&
+         (std::isdigit(static_cast<unsigned char>(s[i])) || s[i] == '.')) {
+    ++i;
+  }
+  const std::string num_str = s.substr(0, i);
+  const std::string suffix_text = s.substr(i);
+  if (num_str.empty() ||
+      num_str.find_first_of("0123456789") == std::string::npos) {
+    return NumParseStatus::InvalidNumber;
+  }
+
+  // Multiplier lookup; anything that is not exactly one recognized suffix
+  // character (or empty) is rejected the way GNU reports it.
+  double multiplier = 1.0;
+  if (!suffix_text.empty()) {
+    if (suffix_text.size() != 1) return NumParseStatus::InvalidSuffix;
+    const char suffix = static_cast<char>(std::toupper(
+        static_cast<unsigned char>(suffix_text[0])));
+    const bool si = from == "si" || from == "auto";
+    const double base = si ? 1000.0 : 1024.0;
+    switch (suffix) {
+      case 'K':
+        multiplier = base;
+        break;
+      case 'M':
+        multiplier = base * base;
+        break;
+      case 'G':
+        multiplier = base * base * base;
+        break;
+      case 'T':
+        multiplier = std::pow(base, 4);
+        break;
+      case 'P':
+        multiplier = std::pow(base, 5);
+        break;
+      case 'E':
+        multiplier = std::pow(base, 6);
+        break;
+      default:
+        return NumParseStatus::InvalidSuffix;
     }
   }
 
   try {
     double num = std::stod(num_str);
-
-    // Apply suffix multiplier
-    const bool si = from == "si" || from == "auto";
-    const double base = si ? 1000.0 : 1024.0;
-    switch (suffix) {
-      case 'K':
-        num *= base;
-        break;
-      case 'M':
-        num *= base * base;
-        break;
-      case 'G':
-        num *= base * base * base;
-        break;
-      case 'T':
-        num *= std::pow(base, 4);
-        break;
-      case 'P':
-        num *= std::pow(base, 5);
-        break;
-      case 0:
-        break;
-      default:
-        return false;
+    if (raw_value != nullptr) *raw_value = num * multiplier;
+    if (suffix_text.empty() &&
+        (num > 9.2233720368547748e18 || num < -9.2233720368547748e18)) {
+      // Keep the exact value for the "value too large to be printed"
+      // diagnostic; callers that scale (--to) can still use the double.
+      result = 0;
+      return NumParseStatus::Ok;
     }
-
+    num *= multiplier;
     // Apply rounding mode when converting from human-readable
     result = static_cast<long long>(apply_rounding(num, round_mode));
-    return true;
+    return NumParseStatus::Ok;
   } catch (...) {
-    return false;
+    return NumParseStatus::InvalidNumber;
   }
+}
+
+bool parse_number(const std::string& s, long long& result,
+                  const std::string& round_mode = "", std::string from = "") {
+  return parse_number_ex(s, result, round_mode, std::move(from)) ==
+         NumParseStatus::Ok;
 }
 
 bool parse_number_value(const std::string& s, double& result,
@@ -213,52 +240,11 @@ bool parse_number_value(const std::string& s, double& result,
   }
 }
 
-// Format number with SI suffix
-std::string format_number(long long num, const std::string& unit = "") {
-  const char* suffixes[] = {"", "K", "M", "G", "T", "P"};
-  int suffix_index = 0;
-  double value = static_cast<double>(num);
-
-  while (value >= 1024 && suffix_index < 5) {
-    value /= 1024;
-    suffix_index++;
-  }
-
-  char buffer[64];
-  if (suffix_index == 0) {
-    sprintf_s(buffer, sizeof(buffer), "%lld", num);
-  } else {
-    sprintf_s(buffer, sizeof(buffer), "%.1f", value);
-  }
-
-  std::string result = buffer;
-  result += suffixes[suffix_index];
-  if (!unit.empty()) {
-    result += unit;
-  }
-
-  return result;
-}
-
-std::string format_iec_i(long long num) {
-  static constexpr const char* suffixes[] = {"", "Ki", "Mi", "Gi", "Ti", "Pi"};
-  double value = static_cast<double>(num);
-  size_t index = 0;
-  while (value >= 1024.0 && index < 5) {
-    value /= 1024.0;
-    ++index;
-  }
-  char buffer[64];
-  if (index == 0)
-    sprintf_s(buffer, sizeof(buffer), "%lld", num);
-  else
-    sprintf_s(buffer, sizeof(buffer), "%.1f", value);
-  return std::string(buffer) + suffixes[index];
-}
-
-std::string format_scaled(long long num, double base,
-                          std::string_view suffixes) {
-  double value = static_cast<double>(num);
+// Scale value by base repeatedly and format the magnitude; returns the
+// numeric text and the selected suffix separately so a caller can reformat
+// the number with a user --format.
+std::pair<std::string, std::string> scale_to(double value, double base,
+                                             std::string_view suffixes) {
   size_t index = 0;
   while (std::abs(value) >= base && index < suffixes.size()) {
     value /= base;
@@ -266,12 +252,12 @@ std::string format_scaled(long long num, double base,
   }
   char buffer[64];
   if (index == 0) {
-    sprintf_s(buffer, sizeof(buffer), "%lld", num);
+    // [GNU] Unscaled values print without a fractional part ("500").
+    snprintf(buffer, sizeof(buffer), "%.0f", value);
   } else {
-    sprintf_s(buffer, sizeof(buffer), "%.1f", value);
+    snprintf(buffer, sizeof(buffer), "%.1f", value);
   }
-  return std::string(buffer) +
-         (index == 0 ? "" : std::string(1, suffixes[index - 1]));
+  return {buffer, index == 0 ? std::string() : std::string(1, suffixes[index - 1])};
 }
 }  // namespace
 
@@ -303,6 +289,16 @@ REGISTER_COMMAND(
   const bool zero_terminated =
       ctx.get<bool>("--zero-terminated", false) || ctx.get<bool>("-z", false);
   const bool iec_short = ctx.get<bool>("-M", false);
+  // [GNU] --to accepts only none/si/iec/iec-i ("auto" is --from-only);
+  // uutils #11662.
+  if (!to_unit.empty() && to_unit != "none" && to_unit != "si" &&
+      to_unit != "iec" && to_unit != "iec-i") {
+    safeErrorPrint("numfmt: invalid argument '" + to_unit + "' for '--to'\n");
+    safeErrorPrint(::winux::i18n::format(
+        "command.numfmt.error.valid_to_args",
+        "Valid arguments are:\n  - 'none'\n  - 'si'\n  - 'iec'\n  - 'iec-i'\n"));
+    return 1;
+  }
   bool to_si = to_unit == "si";
   bool to_iec = to_unit == "iec";
   bool to_iec_i = to_unit == "iec-i";
@@ -409,21 +405,62 @@ REGISTER_COMMAND(
   };
 
   bool had_invalid = false;
-  auto process_number = [&](const std::string& s) -> std::string {
-    long long num;
-    if (!parse_number(s, num, round_mode, from_unit)) {
+  // [GNU] numfmt.c keeps formatted numbers in a 128-byte buffer; anything
+  // longer fails with "failed to prepare value '%f' for printing"
+  // (uutils #12596).
+  constexpr size_t kMaxNumericLength = 126;
+  bool had_prepare_error = false;
+  auto prepare_padded = [&](double value, const std::string& formatted)
+      -> std::optional<std::string> {
+    if (formatted.size() > kMaxNumericLength) {
+      char value_text[64];
+      snprintf(value_text, sizeof(value_text), "%f", value);
+      safeErrorPrint(std::string("numfmt: failed to prepare value '") +
+                     value_text + "' for printing\n");
+      had_prepare_error = true;
+      return std::nullopt;
+    }
+    return formatted;
+  };
+
+  auto process_number = [&](const std::string& s) -> std::optional<std::string> {
+    long long num = 0;
+    double raw_value = 0.0;
+    const auto status =
+        parse_number_ex(s, num, round_mode, from_unit, &raw_value);
+    if (status != NumParseStatus::Ok) {
       if (debug) {
         debug_log("failed to parse input '" + s + "'");
       }
+      const bool suffix_issue = status == NumParseStatus::InvalidSuffix;
+      const char* problem = suffix_issue ? "invalid suffix in input"
+                                         : "invalid number";
       if (invalid_policy == "warn") {
-        safeErrorPrint("numfmt: invalid number: '" + s + "'\n");
-      } else if (invalid_policy == "abort") {
-        safeErrorPrint("numfmt: invalid number: '" + s + "'\n");
+        safeErrorPrint(std::string("numfmt: ") + problem + ": '" + s + "'\n");
         had_invalid = true;
         return s;
       }
+      if (invalid_policy == "abort") {
+        safeErrorPrint(std::string("numfmt: ") + problem + ": '" + s + "'\n");
+        had_invalid = true;
+        return std::nullopt;
+      }
       // "ignore" - return as-is
       return s;
+    }
+
+    // [GNU] Raw (no --to, no --format) printing requires the value to fit
+    // in intmax_t; larger values error out (uutils #11654).
+    const bool raw_print = !to_si && !to_iec && !to_iec_i && format_str.empty();
+    if (raw_print &&
+        (raw_value > 9223372036854775807.0 ||
+         raw_value < -9223372036854775808.0)) {
+      char printed[64];
+      snprintf(printed, sizeof(printed), "%g", raw_value);
+      safeErrorPrint(std::string("numfmt: value too large to be printed: '") +
+                     printed + "' (consider using --to)\n");
+      had_invalid = true;
+      return std::nullopt;
     }
 
     if (from_scale != 1.0 || to_scale != 1.0) {
@@ -441,30 +478,52 @@ REGISTER_COMMAND(
     }
 
     if (to_si || to_iec || to_iec_i) {
+      // With --to, GNU computes in floating point even for values that do
+      // not fit intmax_t ("12345678901234567890 --to=si" -> "12.3E").
+      const bool out_of_intmax =
+          raw_value > 9223372036854775807.0 ||
+          raw_value < -9223372036854775808.0;
+      double scaled = out_of_intmax ? raw_value : static_cast<double>(num);
       std::string formatted;
+      std::string unit_suffix;
       if (to_iec_i) {
-        formatted = format_iec_i(num);
+        std::tie(formatted, unit_suffix) = scale_to(scaled, 1024.0, "KiMiGiTiPi");
       } else if (to_si) {
-        formatted = format_scaled(num, 1000.0, "kMGTPE");
+        // [GNU] SI suffixes are upper case (5.0K, 123.5M); uutils #7221.
+        std::tie(formatted, unit_suffix) = scale_to(scaled, 1000.0, "KMGTPE");
       } else {
-        formatted = format_number(num);
+        std::tie(formatted, unit_suffix) = scale_to(scaled, 1024.0, "KMGTPE");
+      }
+      std::optional<std::string> prepared;
+      if (!format_str.empty()) {
+        char buf[512];
+        snprintf(buf, sizeof(buf), format_str.c_str(), scaled);
+        prepared = prepare_padded(scaled, buf);
+      } else {
+        prepared = prepare_padded(scaled, formatted);
+      }
+      if (!prepared) {
+        return std::nullopt;
       }
       if (debug) {
-        debug_log("converted '" + s + "' -> '" + formatted + suffix + "'");
+        debug_log("converted '" + s + "' -> '" + *prepared + suffix + "'");
       }
-      return formatted + (unit_separator.empty() ? "" : unit_separator) +
-             suffix;
+      return *prepared + (unit_separator.empty() ? "" : unit_separator) +
+             unit_suffix + suffix;
     }
     if (!format_str.empty()) {
       double value = 0.0;
       if (parse_number_value(s, value, from_unit)) {
-        char buf[256];
+        char buf[512];
         snprintf(buf, sizeof(buf), format_str.c_str(), value);
-        if (debug) {
-          debug_log("formatted '" + s + "' -> '" + std::string(buf) + suffix +
-                    "'");
+        auto prepared = prepare_padded(value, buf);
+        if (!prepared) {
+          return std::nullopt;
         }
-        return std::string(buf) + suffix;
+        if (debug) {
+          debug_log("formatted '" + s + "' -> '" + *prepared + suffix + "'");
+        }
+        return *prepared + suffix;
       }
     }
     auto applied = apply_format(num) +
@@ -476,12 +535,12 @@ REGISTER_COMMAND(
   };
 
   int line_num = 0;
-  auto process_line = [&](const std::string& line) {
+  auto process_line = [&](const std::string& line) -> bool {
     if (line_num < header) {
       safePrint(line);
       safePrint(zero_terminated ? std::string(1, '\0') : std::string("\n"));
       ++line_num;
-      return;
+      return true;
     }
     if (!delimiter.empty()) {
       // Split by delimiter, process each field
@@ -492,7 +551,9 @@ REGISTER_COMMAND(
       while (std::getline(ss, field_text, delimiter[0])) {
         if (!first) safePrint(delimiter);
         if (selected_field == 0 || selected_field == field_number) {
-          safePrint(process_number(field_text));
+          auto processed = process_number(field_text);
+          if (!processed) return false;
+          safePrint(*processed);
         } else {
           safePrint(field_text);
         }
@@ -501,15 +562,21 @@ REGISTER_COMMAND(
       }
       safePrint(zero_terminated ? std::string(1, '\0') : std::string("\n"));
     } else {
-      safePrint(process_number(line));
+      auto processed = process_number(line);
+      if (!processed) return false;
+      safePrint(*processed);
       safePrint(zero_terminated ? std::string(1, '\0') : std::string("\n"));
     }
     ++line_num;
+    return true;
   };
 
+  // [GNU] Aborting on invalid input exits 2; a prepare failure exits 1.
+  // NOTE: evaluated at return time — had_prepare_error is set during
+  // processing, so it must not be captured before the processing loop.
   if (!ctx.positionals.empty()) {
     for (const auto& arg : ctx.positionals) {
-      process_line(std::string(arg));
+      if (!process_line(std::string(arg))) return had_prepare_error ? 1 : 2;
     }
   } else {
     std::string input;
@@ -519,7 +586,7 @@ REGISTER_COMMAND(
     std::string line;
     const char delimiter_char = zero_terminated ? '\0' : '\n';
     while (std::getline(iss, line, delimiter_char)) {
-      process_line(line);
+      if (!process_line(line)) return had_prepare_error ? 1 : 2;
     }
   }
 

--- a/src/commands/numfmt.cpp
+++ b/src/commands/numfmt.cpp
@@ -65,9 +65,10 @@ auto constexpr NUMFMT_OPTIONS = std::array{
     // [GNU]
     OPTION("-f", "--format", "use printf style floating-point FORMAT",
            STRING_TYPE),
-    // [GNU]
+    // [GNU] --header[=N]: optional value; a bare --header means N=1 and the
+    // next argument stays an input operand (uutils #13272)
     OPTION("", "--header", "print the first N header lines unchanged",
-           INT_TYPE),
+           OPTIONAL_INT_TYPE),
     // [GNU]
     OPTION("", "--grouping", "group digits with locale thousands separator",
            BOOL_TYPE),
@@ -316,6 +317,10 @@ REGISTER_COMMAND(
   }
   int header = 0;
   header = ctx.get<int>("--header", 0);
+  if (header < 0) {
+    // bare --header (no =N): GNU defaults to one header line
+    header = 1;
+  }
   bool grouping = ctx.get<bool>("--grouping", false);
   const bool locale_grouping = grouping || ctx.get<bool>("-l", false);
   std::string invalid_policy = ctx.get<std::string>("--invalid", "abort");

--- a/src/commands/od.cpp
+++ b/src/commands/od.cpp
@@ -551,7 +551,18 @@ auto read_file_bytes(const std::string& filename,
   std::ifstream input(native_path::normalize_api_operand(filename),
                       std::ios::binary);
   if (!input) {
-    safeErrorPrintLn("od: cannot open '" + filename + "'");
+    // [GNU] od reports "<name>: <reason>"; a directory operand reads as
+    // "Is a directory" on GNU (uutils #12993)
+    std::error_code ec;
+    const std::filesystem::path p(
+        native_path::normalize_api_operand(filename));
+    if (std::filesystem::is_directory(p, ec)) {
+      safeErrorPrintLn("od: " + filename + ": Is a directory");
+    } else if (std::filesystem::exists(p, ec)) {
+      safeErrorPrintLn("od: " + filename + ": Permission denied");
+    } else {
+      safeErrorPrintLn("od: " + filename + ": No such file or directory");
+    }
     return false;
   }
 

--- a/src/commands/pr.cpp
+++ b/src/commands/pr.cpp
@@ -52,8 +52,8 @@ auto constexpr PR_OPTIONS = std::array{
     OPTION("-a", "", "produce multi-column output", BOOL_TYPE),
     // [GNU]
     OPTION("-d", "", "double-space the output", BOOL_TYPE),
-    // [GNU]
-    OPTION("-e", "--expand", "expand input TABs", STRING_TYPE),
+    // [GNU] -e takes an optional *attached* [CHAR[WIDTH]] argument only.
+    OPTION("-e", "--expand", "expand input TABs", OPTIONAL_STRING_TYPE),
     // [GNU]
     OPTION("-f", "--form-feed", "use form feeds instead of newlines",
            BOOL_TYPE),
@@ -61,15 +61,16 @@ auto constexpr PR_OPTIONS = std::array{
     OPTION("-h", "--header", "use a centered HEADER", STRING_TYPE),
     // [GNU]
     OPTION("-l", "--length", "set page length", STRING_TYPE),
-    // [GNU]
-    OPTION("-n", "--number-lines", "number lines", STRING_TYPE),
+    // [GNU] -n takes an optional *attached* [SEP[DIGITS]] argument only.
+    OPTION("-n", "--number-lines", "number lines", OPTIONAL_STRING_TYPE),
     // [GNU]
     OPTION("-o", "--indent", "offset each line", STRING_TYPE),
     // [GNU]
     OPTION("-r", "--no-file-warnings",
            "omit warning when a file cannot be opened", BOOL_TYPE),
-    // [GNU]
-    OPTION("-s", "--separator", "separate columns by characters", STRING_TYPE),
+    // [GNU] -s takes an optional *attached* [CHAR] argument only.
+    OPTION("-s", "--separator", "separate columns by characters",
+           OPTIONAL_STRING_TYPE),
     // [GNU]
     OPTION("-t", "--omit-header", "omit page headers and trailers", BOOL_TYPE),
     // [GNU]
@@ -91,9 +92,9 @@ auto constexpr PR_OPTIONS = std::array{
     // [GNU]
     OPTION("-F", "-f", "use form feeds instead of newlines (same as -f)",
            BOOL_TYPE),
-    // [GNU]
+    // [GNU] -i takes an optional *attached* [CHAR[WIDTH]] argument only.
     OPTION("-i", "--output-tabs", "replace spaces with TABs where possible",
-           STRING_TYPE),
+           OPTIONAL_STRING_TYPE),
     // [GNU]
     OPTION("-J", "--join-lines", "merge full lines (ignore --column warnings)",
            BOOL_TYPE),
@@ -116,8 +117,8 @@ auto constexpr PR_OPTIONS = std::array{
     OPTION("", "--columns", "output COLUMN-column output", STRING_TYPE),
     // [GNU]
     OPTION("", "--double-space", "double-space the output", BOOL_TYPE),
-    // [GNU]
-    OPTION("", "--expand-tabs", "expand input TABs", STRING_TYPE),
+    // [GNU] --expand-tabs takes an optional *attached* [=CHAR[WIDTH]] value.
+    OPTION("", "--expand-tabs", "expand input TABs", OPTIONAL_STRING_TYPE),
     // [GNU]
     OPTION("", "--pages", "begin printing with page PAGE", STRING_TYPE)};
 
@@ -128,11 +129,14 @@ struct Config {
   int start_page = 1;
   int columns = 1;
   bool double_space = false;
-  std::string expand_tabs;
+  // [GNU] -e/--expand-tabs: presence flag + validated width (default 8).
+  bool expand_set = false;
+  int expand_width = 8;
   bool form_feed = false;
   std::string header;
   int page_length = 66;
-  std::string number_lines;
+  // [GNU] -n/--number-lines: presence flag (numbering enabled).
+  bool number_lines_set = false;
   int indent = 0;
   bool no_file_warnings = false;
   std::string separator = "\t";
@@ -143,7 +147,9 @@ struct Config {
   bool show_control_chars = false;
   std::string date_format;
   bool form_feed_ff = false;
-  std::string output_tabs;
+  // [GNU] -i/--output-tabs: presence flag + validated width (default 8).
+  bool output_tabs_set = false;
+  int output_tabs_width = 8;
   bool join_lines = false;
   bool merge = false;
   std::string first_line_number;
@@ -151,6 +157,63 @@ struct Config {
   bool show_nonprinting = false;
   SmallVector<std::string, 64> files;
 };
+
+// [GNU] pr.c validates numeric option values via xstrtoui and reports:
+//   pr: '-l PAGE_LENGTH' invalid number of lines: 'abc'
+//   pr: '-l PAGE_LENGTH' invalid number of lines: '0': Numerical result out of range
+//   pr: '-w PAGE_WIDTH' invalid number of characters: '0': Numerical result out of range
+auto parse_positive_number(const std::string& label, const std::string& what,
+                           const std::string& value)
+    -> std::expected<int, std::string> {
+  auto fail = [&](bool out_of_range) {
+    std::string msg = "'" + label + "' invalid number of " + what + ": '" +
+                      value + "'";
+    if (out_of_range) msg += ": Numerical result out of range";
+    return std::unexpected(msg);
+  };
+  int v = 0;
+  try {
+    size_t pos = 0;
+    v = std::stoi(value, &pos);
+    if (pos != value.size()) return fail(false);
+  } catch (std::out_of_range&) {
+    return fail(true);
+  } catch (...) {
+    return fail(false);
+  }
+  if (v <= 0) return fail(true);
+  return v;
+}
+
+// [GNU] -e/-i take an optional attached [CHAR[WIDTH]] argument. The CHAR part
+// (a single non-digit) selects the tab character (TAB is assumed here); the
+// WIDTH part must be a number >= 1. Mirrors pr.c messages:
+//   pr: '-e' extra characters or invalid number in the argument: '0'
+auto parse_tab_spec(const std::string& label, const std::string& raw)
+    -> std::expected<int, std::string> {
+  auto fail = [&](const std::string& quoted) {
+    return std::unexpected("'" + label +
+                           "' extra characters or invalid number in the "
+                           "argument: '" +
+                           quoted + "'");
+  };
+  size_t i = 0;
+  if (i < raw.size() && !std::isdigit(static_cast<unsigned char>(raw[i]))) {
+    ++i;  // CHAR part (tab character; assumed TAB here)
+  }
+  std::string rest = raw.substr(i);
+  if (rest.empty()) return 8;  // [GNU] default width
+  int v = 0;
+  try {
+    size_t pos = 0;
+    v = std::stoi(rest, &pos);
+    if (pos != rest.size()) return fail(rest);
+  } catch (...) {
+    return fail(rest);
+  }
+  if (v < 1) return fail(rest);
+  return v;
+}
 
 auto build_config(const CommandContext<PR_OPTIONS.size()>& ctx)
     -> cp::Result<Config> {
@@ -195,14 +258,27 @@ auto build_config(const CommandContext<PR_OPTIONS.size()>& ctx)
   cfg.omit_pagination =
       ctx.get<bool>("--omit-pagination", false) || ctx.get<bool>("-T", false);
 
-  auto expand_opt = ctx.get<std::string>("--expand", "");
-  if (expand_opt.empty()) {
-    expand_opt = ctx.get<std::string>("--expand-tabs", "");
+  // [GNU] -e/--expand-tabs accept an optional attached [CHAR[WIDTH]] value;
+  // the option alone enables expansion with the default width 8.
+  cfg.expand_set = ctx.count({"-e", "--expand", "--expand-tabs"}) > 0;
+  std::string expand_raw;
+  const char* expand_label = "-e";
+  for (auto [name, label] :
+       {std::pair{std::string_view("--expand"), std::string_view("--expand-tabs")},
+        std::pair{std::string_view("--expand-tabs"), std::string_view("--expand-tabs")},
+        std::pair{std::string_view("-e"), std::string_view("-e")}}) {
+    auto v = ctx.get<std::string>(name, "");
+    if (!v.empty()) {
+      expand_raw = v;
+      expand_label = label.data();
+      break;
+    }
   }
-  if (expand_opt.empty()) {
-    expand_opt = ctx.get<std::string>("-e", "");
+  if (!expand_raw.empty()) {
+    auto w = parse_tab_spec(expand_label, expand_raw);
+    if (!w) return std::unexpected(w.error());
+    cfg.expand_width = *w;
   }
-  cfg.expand_tabs = expand_opt;
 
   auto header_opt = ctx.get<std::string>("--header", "");
   if (header_opt.empty()) {
@@ -215,18 +291,31 @@ auto build_config(const CommandContext<PR_OPTIONS.size()>& ctx)
     length_opt = ctx.get<std::string>("-l", "");
   }
   if (!length_opt.empty()) {
-    try {
-      cfg.page_length = std::stoi(length_opt);
-    } catch (...) {
-      return std::unexpected("invalid page length");
-    }
+    auto v = parse_positive_number("-l PAGE_LENGTH", "lines", length_opt);
+    if (!v) return std::unexpected(v.error());
+    cfg.page_length = *v;
   }
 
-  auto number_opt = ctx.get<std::string>("--number-lines", "");
-  if (number_opt.empty()) {
-    number_opt = ctx.get<std::string>("-n", "");
+  // [GNU] -n takes an optional attached [SEP[DIGITS]] argument; the option
+  // alone enables numbering with defaults.
+  cfg.number_lines_set = ctx.count({"-n", "--number-lines"}) > 0;
+  std::string number_raw;
+  const char* number_label = "-n";
+  for (auto [name, label] :
+       {std::pair{std::string_view("--number-lines"),
+                  std::string_view("--number-lines")},
+        std::pair{std::string_view("-n"), std::string_view("-n")}}) {
+    auto v = ctx.get<std::string>(name, "");
+    if (!v.empty()) {
+      number_raw = v;
+      number_label = label.data();
+      break;
+    }
   }
-  cfg.number_lines = number_opt;
+  if (!number_raw.empty()) {
+    auto w = parse_tab_spec(number_label, number_raw);
+    if (!w) return std::unexpected(w.error());
+  }
 
   auto indent_opt = ctx.get<std::string>("--indent", "");
   if (indent_opt.empty()) {
@@ -253,11 +342,9 @@ auto build_config(const CommandContext<PR_OPTIONS.size()>& ctx)
     width_opt = ctx.get<std::string>("-w", "");
   }
   if (!width_opt.empty()) {
-    try {
-      cfg.page_width = std::stoi(width_opt);
-    } catch (...) {
-      return std::unexpected("invalid page width");
-    }
+    auto v = parse_positive_number("-w PAGE_WIDTH", "characters", width_opt);
+    if (!v) return std::unexpected(v.error());
+    cfg.page_width = *v;
   }
 
   auto col_opt = ctx.get<std::string>("--columns", "");
@@ -292,11 +379,26 @@ auto build_config(const CommandContext<PR_OPTIONS.size()>& ctx)
   }
   cfg.date_format = date_fmt;
 
-  auto output_tabs_opt = ctx.get<std::string>("--output-tabs", "");
-  if (output_tabs_opt.empty()) {
-    output_tabs_opt = ctx.get<std::string>("-i", "");
+  // [GNU] -i takes an optional attached [CHAR[WIDTH]] argument.
+  cfg.output_tabs_set = ctx.count({"-i", "--output-tabs"}) > 0;
+  std::string output_tabs_raw;
+  const char* output_tabs_label = "-i";
+  for (auto [name, label] :
+       {std::pair{std::string_view("--output-tabs"),
+                  std::string_view("--output-tabs")},
+        std::pair{std::string_view("-i"), std::string_view("-i")}}) {
+    auto v = ctx.get<std::string>(name, "");
+    if (!v.empty()) {
+      output_tabs_raw = v;
+      output_tabs_label = label.data();
+      break;
+    }
   }
-  cfg.output_tabs = output_tabs_opt;
+  if (!output_tabs_raw.empty()) {
+    auto w = parse_tab_spec(output_tabs_label, output_tabs_raw);
+    if (!w) return std::unexpected(w.error());
+    cfg.output_tabs_width = *w;
+  }
 
   auto fln_opt = ctx.get<std::string>("--first-line-number", "");
   if (fln_opt.empty()) {
@@ -330,11 +432,9 @@ auto build_config(const CommandContext<PR_OPTIONS.size()>& ctx)
   auto pwidth_opt = ctx.get<std::string>("--page-width", "");
   if (pwidth_opt.empty()) pwidth_opt = ctx.get<std::string>("-W", "");
   if (!pwidth_opt.empty()) {
-    try {
-      cfg.page_width = std::stoi(pwidth_opt);
-    } catch (...) {
-      return std::unexpected("invalid page width");
-    }
+    auto v = parse_positive_number("-W PAGE_WIDTH", "characters", pwidth_opt);
+    if (!v) return std::unexpected(v.error());
+    cfg.page_width = *v;
   }
 
   return cfg;
@@ -648,13 +748,8 @@ auto run(const Config& cfg) -> int {
           std::string line = all_lines[idx];
 
           // Apply expand_tabs
-          if (!cfg.expand_tabs.empty()) {
-            int tab_width = 8;
-            try {
-              tab_width = std::stoi(cfg.expand_tabs);
-            } catch (...) {
-            }
-            line = expand_tabs(line, tab_width);
+          if (cfg.expand_set) {
+            line = expand_tabs(line, cfg.expand_width);
           }
 
           // Apply show_control_chars
@@ -668,13 +763,8 @@ auto run(const Config& cfg) -> int {
           }
 
           // Apply output_tabs
-          if (!cfg.output_tabs.empty()) {
-            int tab_width = 8;
-            try {
-              tab_width = std::stoi(cfg.output_tabs);
-            } catch (...) {
-            }
-            line = replace_spaces_with_tabs(line, tab_width);
+          if (cfg.output_tabs_set) {
+            line = replace_spaces_with_tabs(line, cfg.output_tabs_width);
           }
 
           output += line;
@@ -682,7 +772,7 @@ auto run(const Config& cfg) -> int {
       }
 
       // Add line numbers
-      if (!cfg.number_lines.empty()) {
+      if (cfg.number_lines_set) {
         char buf[32];
         snprintf(buf, sizeof(buf), "%6d  ", line_num++);
         output = indent_str + buf + output.substr(indent_str.size());
@@ -726,13 +816,8 @@ auto run(const Config& cfg) -> int {
       std::string processed = line;
 
       // Apply expand_tabs
-      if (!cfg.expand_tabs.empty()) {
-        int tab_width = 8;
-        try {
-          tab_width = std::stoi(cfg.expand_tabs);
-        } catch (...) {
-        }
-        processed = expand_tabs(processed, tab_width);
+      if (cfg.expand_set) {
+        processed = expand_tabs(processed, cfg.expand_width);
       }
 
       // Apply show_control_chars
@@ -746,19 +831,14 @@ auto run(const Config& cfg) -> int {
       }
 
       // Apply output_tabs
-      if (!cfg.output_tabs.empty()) {
-        int tab_width = 8;
-        try {
-          tab_width = std::stoi(cfg.output_tabs);
-        } catch (...) {
-        }
-        processed = replace_spaces_with_tabs(processed, tab_width);
+      if (cfg.output_tabs_set) {
+        processed = replace_spaces_with_tabs(processed, cfg.output_tabs_width);
       }
 
       std::string output = indent_str;
 
       // Add line numbers
-      if (!cfg.number_lines.empty()) {
+      if (cfg.number_lines_set) {
         char buf[32];
         snprintf(buf, sizeof(buf), "%6d  ", line_num++);
         output += buf;

--- a/src/commands/pr.cpp
+++ b/src/commands/pr.cpp
@@ -596,6 +596,21 @@ auto run(const Config& cfg) -> int {
   // Apply start_page: skip lines before the start page
   int lines_per_page = std::max(1, cfg.page_length);
 
+  // [GNU] a start page beyond the total page count is reported and nothing
+  // is printed (uutils #13557)
+  if (cfg.start_page > 1) {
+    const size_t total_lines = all_lines.size();
+    const int total_pages =
+        static_cast<int>((total_lines + lines_per_page - 1) / lines_per_page);
+    if (cfg.start_page > total_pages) {
+      safeErrorPrintLn(winux::i18n::format(
+          "command.pr.error.page_exceeds",
+          "pr: starting page number {} exceeds page count {}", cfg.start_page,
+          total_pages));
+      return 0;
+    }
+  }
+
   // Process lines with all options
   std::string indent_str(cfg.indent, ' ');
   std::string sep = get_separator(cfg);

--- a/src/commands/ptx.cpp
+++ b/src/commands/ptx.cpp
@@ -169,6 +169,12 @@ auto build_config(const CommandContext<PTX_OPTIONS.size()>& ctx)
   cfg.only_file = option_value(ctx, "--only-file", "-o");
 
   cfg.gap_size = std::max(0, ctx.get<int>("--gap-size", ctx.get<int>("-g", 3)));
+  if (cfg.gap_size < 1) {
+    // [GNU] ptx rejects a gap size below 1 (uutils #13794)
+    std::string raw = option_value(ctx, "--gap-size", "-g");
+    if (raw.empty()) raw = std::to_string(cfg.gap_size);
+    return std::unexpected(make_error("invalid gap width: '" + raw + "'"));
+  }
 
   cfg.width = std::max(1, ctx.get<int>("--width", ctx.get<int>("-w", 78)));
 

--- a/src/commands/readlink.cpp
+++ b/src/commands/readlink.cpp
@@ -241,6 +241,38 @@ auto canonicalize_existing(const std::filesystem::path& absolute)
   return path_from_handle(handle.get());
 }
 
+// [GNU] -f/-m still follow links for every component of the non-existing
+// suffix; a symlink loop must fail with exit 1 and no output
+// (uutils #10249).
+auto check_suffix_resolvable(const std::filesystem::path& prefix,
+                             const std::filesystem::path& suffix)
+    -> std::expected<void, std::string> {
+  if (suffix.empty()) {
+    return {};
+  }
+  std::filesystem::path current = prefix;
+  for (const auto& part : suffix) {
+    current /= part;
+    const DWORD attrs = GetFileAttributesW(current.c_str());
+    if (attrs != INVALID_FILE_ATTRIBUTES &&
+        (attrs & FILE_ATTRIBUTE_REPARSE_POINT) != 0) {
+      auto handle = open_path_handle(current.wstring(), true);
+      if (!handle) {
+        return std::unexpected(winux::i18n::format(
+            "command.readlink.error.too_many_symlinks",
+            "Too many levels of symbolic links"));
+      }
+      auto final_path = path_from_handle(handle.get());
+      if (!final_path) {
+        return std::unexpected(winux::i18n::format(
+            "command.readlink.error.too_many_symlinks",
+            "Too many levels of symbolic links"));
+      }
+    }
+  }
+  return {};
+}
+
 auto canonicalize_path(const std::wstring& original, Mode mode)
     -> std::expected<std::wstring, std::string> {
   auto full_path_result = get_full_path(original);
@@ -278,6 +310,9 @@ auto canonicalize_path(const std::wstring& original, Mode mode)
     }
 
     auto suffix = path_suffix(absolute, parent);
+    if (auto check = check_suffix_resolvable(parent, suffix); !check) {
+      return std::unexpected(check.error());
+    }
     return (std::filesystem::path(*parent_resolved) / suffix).wstring();
   }
 
@@ -301,6 +336,10 @@ auto canonicalize_path(const std::wstring& original, Mode mode)
   auto prefix_resolved = canonicalize_existing(prefix);
   if (!prefix_resolved) {
     return prefix_resolved;
+  }
+
+  if (auto check = check_suffix_resolvable(prefix, suffix); !check) {
+    return std::unexpected(check.error());
   }
 
   return absolute.wstring();

--- a/src/commands/shuf.cpp
+++ b/src/commands/shuf.cpp
@@ -635,6 +635,8 @@ auto build_config(const CommandContext<SHUF_OPTIONS.size()>& ctx)
 
 auto run(const Config& cfg) -> int {
   SmallVector<std::string, 1024> lines;
+  // Set when -n defers sampling from a huge -i range.
+  std::optional<std::pair<int64_t, int64_t>> deferred_range;
 
   if (cfg.echo_mode) {
     // Echo mode: treat each ARG as an input line
@@ -648,9 +650,17 @@ auto run(const Config& cfg) -> int {
       cp::report_error(range, L"shuf");
       return 1;
     }
-    for (int64_t i = range->first; i <= range->second; ++i) {
-      lines.push_back(std::to_string(i));
-      if (i == std::numeric_limits<int64_t>::max()) break;
+    // [GNU] With -n, huge ranges are sampled without materializing every
+    // number in between (uutils #11167). Only the default RNG path defers;
+    // the --random-source/--random-seed paths keep the eager behavior.
+    if (cfg.head_count && !cfg.repeat && cfg.random_source.empty() &&
+        cfg.random_seed.empty()) {
+      deferred_range = *range;
+    } else {
+      for (int64_t i = range->first; i <= range->second; ++i) {
+        lines.push_back(std::to_string(i));
+        if (i == std::numeric_limits<int64_t>::max()) break;
+      }
     }
   } else {
     // File mode: read from files
@@ -687,7 +697,7 @@ auto run(const Config& cfg) -> int {
     }
   }
 
-  if (lines.empty()) {
+  if (lines.empty() && !deferred_range) {
     return emit_output(cfg, std::string_view{});
   }
 
@@ -820,6 +830,26 @@ auto run(const Config& cfg) -> int {
   }
 
   // Shuffle using Fisher-Yates algorithm
+  // [GNU] Deferred -i range sampling with -n: pick COUNT distinct values
+  // from [LO, HI] without enumerating the range (uutils #11167).
+  if (deferred_range) {
+    const auto [lo, hi] = *deferred_range;
+    const uint64_t population =
+        static_cast<uint64_t>(hi - lo) + 1;
+    const size_t count = static_cast<size_t>(
+        std::min<uint64_t>(*cfg.head_count, population));
+    std::unordered_set<int64_t> picked;
+    std::uniform_int_distribution<uint64_t> sample_dist(0, population - 1);
+    while (picked.size() < count) {
+      picked.insert(static_cast<int64_t>(
+          lo + static_cast<int64_t>(sample_dist(g))));
+    }
+    for (const auto& value : picked) {
+      append_output_record(output, std::to_string(value), cfg.zero_terminated);
+    }
+    return emit_output(cfg, output);
+  }
+
   for (size_t i = lines.size(); i > 1; --i) {
     std::uniform_int_distribution<size_t> dist(0, i - 1);
     size_t j = dist(g);

--- a/src/commands/sort.cpp
+++ b/src/commands/sort.cpp
@@ -1329,7 +1329,9 @@ auto build_config(const CommandContext<SORT_OPTIONS.size()>& ctx)
   }
 
   if (ctx.has("--parallel") && !parse_parallel_hint(cfg.parallel_hint)) {
-    return std::unexpected("invalid parallel count");
+    // [GNU] reports the rejected operand (uutils #13016)
+    return std::unexpected("invalid --parallel argument '" + cfg.parallel_hint +
+                           "'");
   }
 
   if (ctx.has("--batch-size") && !parse_batch_size_hint(cfg.batch_size_hint)) {

--- a/src/commands/sort.cpp
+++ b/src/commands/sort.cpp
@@ -463,10 +463,20 @@ auto parse_key_position(std::string_view text)
   }
 
   auto field_text = text.substr(0, i);
-  auto [ptr, ec] = std::from_chars(
-      field_text.data(), field_text.data() + field_text.size(), pos.field);
-  if (ec != std::errc() || ptr != field_text.data() + field_text.size() ||
-      pos.field == 0) {
+  // [GNU] overflowing field/char numbers are accepted and clamp (the field is
+  // beyond every line, so the key is empty; uutils #7185).
+  unsigned long long field_big = 0;
+  auto [ptr, ec] = std::from_chars(field_text.data(),
+                                   field_text.data() + field_text.size(),
+                                   field_big);
+  if ((ec != std::errc() && ec != std::errc::result_out_of_range) ||
+      ptr != field_text.data() + field_text.size()) {
+    return std::unexpected("invalid key spec");
+  }
+  pos.field = ec == std::errc::result_out_of_range
+                  ? std::numeric_limits<size_t>::max()
+                  : static_cast<size_t>(field_big);
+  if (pos.field == 0) {
     return std::unexpected("invalid key spec");
   }
 
@@ -484,8 +494,11 @@ auto parse_key_position(std::string_view text)
     auto char_text = text.substr(char_start, i - char_start);
     auto [char_ptr, char_ec] = std::from_chars(
         char_text.data(), char_text.data() + char_text.size(), value);
-    if (char_ec != std::errc() ||
-        char_ptr != char_text.data() + char_text.size()) {
+    if (char_ec == std::errc::result_out_of_range) {
+      // [GNU] clamp overflowing character offsets like field numbers.
+      value = std::numeric_limits<size_t>::max();
+    } else if (char_ec != std::errc() ||
+               char_ptr != char_text.data() + char_text.size()) {
       return std::unexpected("invalid key spec");
     }
     pos.character = value;
@@ -1292,6 +1305,11 @@ auto build_config(const CommandContext<SORT_OPTIONS.size()>& ctx)
     cfg.mode = OperationMode::Check;
   }
   if (ctx.get<bool>("-C", false) || ctx.get<bool>("--check-silent", false)) {
+    // [GNU] -c and -C are mutually exclusive (GNU: options '-cC' are
+    // incompatible).
+    if (cfg.mode == OperationMode::Check) {
+      return std::unexpected("options '-cC' are incompatible");
+    }
     cfg.mode = OperationMode::CheckQuiet;
   }
   cfg.delimiter =
@@ -1299,6 +1317,11 @@ auto build_config(const CommandContext<SORT_OPTIONS.size()>& ctx)
           ? '\0'
           : '\n';
 
+  // [GNU] only the last -o would matter, but more than one output file is
+  // rejected outright ("multiple output files specified").
+  if (ctx.count({"-o", "--output"}) > 1) {
+    return std::unexpected("multiple output files specified");
+  }
   cfg.output_file = ctx.get<std::string>("--output", "");
   if (cfg.output_file.empty()) cfg.output_file = ctx.get<std::string>("-o", "");
   if (cfg.mode != OperationMode::Sort && !cfg.output_file.empty()) {

--- a/src/commands/split.cpp
+++ b/src/commands/split.cpp
@@ -663,6 +663,33 @@ auto run(const Config& cfg) -> int {
     } else {
       std::string record;
       char c = 0;
+      auto add_record = [&](const std::string& rec) -> bool {
+        const auto limit = static_cast<size_t>(cfg.chunk_size);
+        if (!chunk.empty() && chunk.size() + rec.size() > limit && !flush()) {
+          return false;
+        }
+        if (rec.size() <= limit) {
+          chunk += rec;
+          return true;
+        }
+        // [GNU] -C never emits a piece larger than LIMIT: a single line
+        // longer than LIMIT is split at exact LIMIT boundaries
+        // (uutils #7262).
+        size_t pos = 0;
+        if (!chunk.empty()) {
+          const size_t take = limit - chunk.size();
+          chunk.append(rec, 0, take);
+          pos = take;
+          if (!flush()) return false;
+        }
+        while (rec.size() - pos >= limit) {
+          chunk.append(rec, pos, limit);
+          pos += limit;
+          if (!flush()) return false;
+        }
+        chunk.append(rec, pos, rec.size() - pos);
+        return true;
+      };
       while (source.get(c)) {
         record.push_back(c);
         if (c != cfg.separator) continue;
@@ -673,23 +700,16 @@ auto run(const Config& cfg) -> int {
           ++records;
           if (records >= cfg.chunk_lines && !flush()) return 1;
         } else {
-          const auto limit = static_cast<size_t>(cfg.chunk_size);
-          if (!chunk.empty() && chunk.size() + record.size() > limit &&
-              !flush()) {
-            return 1;
-          }
-          chunk += record;
+          if (!add_record(record)) return 1;
           record.clear();
         }
       }
       if (!record.empty()) {
-        if (cfg.mode == Config::Mode::LineBytes && !chunk.empty() &&
-            chunk.size() + record.size() >
-                static_cast<size_t>(cfg.chunk_size) &&
-            !flush()) {
-          return 1;
+        if (cfg.mode == Config::Mode::LineBytes) {
+          if (!add_record(record)) return 1;
+        } else {
+          chunk += record;
         }
-        chunk += record;
       }
       if (!chunk.empty() && !flush()) return 1;
     }

--- a/src/commands/stat.cpp
+++ b/src/commands/stat.cpp
@@ -33,6 +33,8 @@
 
 #include "pch/pch.h"
 // include other header after pch.h
+#include <winioctl.h>
+
 #include "core/command_macros.h"
 
 import std;
@@ -42,6 +44,44 @@ import container;
 
 using cmd::meta::OptionMeta;
 using cmd::meta::OptionType;
+
+#ifndef IO_REPARSE_TAG_SYMLINK
+#define IO_REPARSE_TAG_SYMLINK (0xA000000CL)
+#endif
+
+#ifndef IO_REPARSE_TAG_MOUNT_POINT
+#define IO_REPARSE_TAG_MOUNT_POINT (0xA0000003L)
+#endif
+
+namespace stat_win32_compat {
+#pragma pack(push, 1)
+struct ReparseDataBuffer {
+  ULONG ReparseTag;
+  USHORT ReparseDataLength;
+  USHORT Reserved;
+  union {
+    struct {
+      USHORT SubstituteNameOffset;
+      USHORT SubstituteNameLength;
+      USHORT PrintNameOffset;
+      USHORT PrintNameLength;
+      ULONG Flags;
+      WCHAR PathBuffer[1];
+    } SymbolicLinkReparseBuffer;
+    struct {
+      USHORT SubstituteNameOffset;
+      USHORT SubstituteNameLength;
+      USHORT PrintNameOffset;
+      USHORT PrintNameLength;
+      WCHAR PathBuffer[1];
+    } MountPointReparseBuffer;
+    struct {
+      UCHAR DataBuffer[1];
+    } GenericReparseBuffer;
+  };
+};
+#pragma pack(pop)
+}  // namespace stat_win32_compat
 
 // [GNU] -L, --dereference: follow symbolic links
 // [GNU] -f, --file-system: display file system status
@@ -421,11 +461,55 @@ auto render_format(std::string_view format, const std::string& filename,
       case 'n':
         out += filename;
         break;
-      case 'N':
+      case 'N': {
         out += "'";
         out += filename;
         out += "'";
+        // [GNU] %N dereferences symlinks in the output: 'l' -> 'target'
+        // (uutils #8789).
+        const std::wstring wname = utf8_to_wstring(filename);
+        const DWORD link_attrs = GetFileAttributesW(wname.c_str());
+        if (link_attrs != INVALID_FILE_ATTRIBUTES &&
+            (link_attrs & FILE_ATTRIBUTE_REPARSE_POINT) != 0) {
+          HANDLE handle = CreateFileW(
+              wname.c_str(), 0,
+              FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, nullptr,
+              OPEN_EXISTING,
+              FILE_FLAG_BACKUP_SEMANTICS | FILE_FLAG_OPEN_REPARSE_POINT,
+              nullptr);
+          if (handle != INVALID_HANDLE_VALUE) {
+            std::array<std::byte, 16 * 1024> reparse_buffer{};
+            DWORD returned = 0;
+            if (DeviceIoControl(handle, FSCTL_GET_REPARSE_POINT, nullptr, 0,
+                                reparse_buffer.data(),
+                                static_cast<DWORD>(reparse_buffer.size()),
+                                &returned, nullptr)) {
+              auto* reparse = reinterpret_cast<
+                  stat_win32_compat::ReparseDataBuffer*>(
+                  reparse_buffer.data());
+              std::wstring target;
+              if (reparse->ReparseTag == IO_REPARSE_TAG_SYMLINK) {
+                const auto& sl = reparse->SymbolicLinkReparseBuffer;
+                target.assign(
+                    sl.PathBuffer + sl.PrintNameOffset / sizeof(wchar_t),
+                    sl.PrintNameLength / sizeof(wchar_t));
+              } else if (reparse->ReparseTag == IO_REPARSE_TAG_MOUNT_POINT) {
+                const auto& mp = reparse->MountPointReparseBuffer;
+                target.assign(
+                    mp.PathBuffer + mp.PrintNameOffset / sizeof(wchar_t),
+                    mp.PrintNameLength / sizeof(wchar_t));
+              }
+              if (!target.empty()) {
+                out += " -> '";
+                out += wstring_to_utf8(target);
+                out += "'";
+              }
+            }
+            CloseHandle(handle);
+          }
+        }
         break;
+      }
       case 's':
         out += std::to_string(stat.size);
         break;

--- a/src/commands/stat.cpp
+++ b/src/commands/stat.cpp
@@ -632,7 +632,8 @@ auto print_stat(const std::string& filename, const Config& cfg) -> int {
   std::filesystem::path p(filename);
 
   if (!std::filesystem::exists(p, ec)) {
-    safePrint("stat: cannot stat '");
+    // [GNU] modern GNU stat uses the statx verb (uutils #13012)
+    safePrint("stat: cannot statx '");
     safePrint(filename);
     safePrint("': No such file or directory\n");
     return 1;
@@ -662,9 +663,9 @@ auto print_stat(const std::string& filename, const Config& cfg) -> int {
 
   auto stat_result = load_file_stat(p);
   if (!stat_result) {
-    safePrint("stat: cannot stat '");
+    safePrint("stat: cannot statx '");
     safePrint(filename);
-    safePrint("': Access denied\n");
+    safePrint("': Permission denied\n");
     return 1;
   }
   const auto& stat = *stat_result;

--- a/src/commands/test.cpp
+++ b/src/commands/test.cpp
@@ -194,14 +194,64 @@ bool compare_strings(const std::string& op, const std::string& a,
   return false;
 }
 
-// Compare integers
-bool compare_integers(const std::string& op, long long a, long long b) {
-  if (op == "-eq") return a == b;
-  if (op == "-ne") return a != b;
-  if (op == "-lt") return a < b;
-  if (op == "-le") return a <= b;
-  if (op == "-gt") return a > b;
-  if (op == "-ge") return a >= b;
+// [GNU] test/compare.c accepts arbitrarily large decimal integers (the MSYS2
+// build compares them exactly instead of erroring on overflow), so parse
+// operands as sign + magnitude digit strings and compare bignum-style.
+// Returns false on any non-decimal operand ("invalid integer", exit 2).
+bool parse_decimal_bignum(const std::string& s, bool& negative,
+                          std::string& magnitude) {
+  size_t i = 0;
+  negative = false;
+  if (i < s.size() && (s[i] == '+' || s[i] == '-')) {
+    negative = (s[i] == '-');
+    ++i;
+  }
+  if (i >= s.size()) return false;
+  for (size_t j = i; j < s.size(); ++j) {
+    if (!std::isdigit(static_cast<unsigned char>(s[j]))) return false;
+  }
+  magnitude = s.substr(i);
+  // Normalize: strip leading zeros.
+  size_t nz = magnitude.find_first_not_of('0');
+  if (nz == std::string::npos) {
+    magnitude = "0";
+    negative = false;
+  } else {
+    magnitude = magnitude.substr(nz);
+  }
+  return true;
+}
+
+int compare_bignum(bool negative_a, const std::string& mag_a,
+                   bool negative_b, const std::string& mag_b) {
+  const bool zero_a = mag_a == "0";
+  const bool zero_b = mag_b == "0";
+  const bool neg_a = negative_a && !zero_a;
+  const bool neg_b = negative_b && !zero_b;
+  if (neg_a != neg_b) return neg_a ? -1 : 1;
+  int mag_cmp = 0;
+  if (mag_a.size() != mag_b.size()) {
+    mag_cmp = mag_a.size() < mag_b.size() ? -1 : 1;
+  } else if (mag_a != mag_b) {
+    mag_cmp = mag_a < mag_b ? -1 : 1;
+  }
+  if (neg_a) return -mag_cmp;
+  return mag_cmp;
+}
+
+bool compare_integer_strings(const std::string& op, const std::string& a,
+                             const std::string& b) {
+  bool neg_a = false, neg_b = false;
+  std::string mag_a, mag_b;
+  if (!parse_decimal_bignum(a, neg_a, mag_a)) return false;
+  if (!parse_decimal_bignum(b, neg_b, mag_b)) return false;
+  const int cmp = compare_bignum(neg_a, mag_a, neg_b, mag_b);
+  if (op == "-eq") return cmp == 0;
+  if (op == "-ne") return cmp != 0;
+  if (op == "-lt") return cmp < 0;
+  if (op == "-le") return cmp <= 0;
+  if (op == "-gt") return cmp > 0;
+  if (op == "-ge") return cmp >= 0;
   return false;
 }
 
@@ -273,21 +323,23 @@ int evaluate_binary(const std::string& a, const std::string& op,
 
   if (op == "-eq" || op == "-ne" || op == "-lt" || op == "-le" || op == "-gt" ||
       op == "-ge") {
-    long long va = 0;
-    long long vb = 0;
-    if (!string_to_int(a, va)) {
+    // [GNU] Operands are validated as decimal integers first; the comparison
+    // itself is exact even for values beyond 64-bit (uutils #12874).
+    bool neg_a = false, neg_b = false;
+    std::string mag_a, mag_b;
+    if (!parse_decimal_bignum(a, neg_a, mag_a)) {
       if (error_message != nullptr) {
         *error_message = "invalid integer '" + a + "'";
       }
       return 2;
     }
-    if (!string_to_int(b, vb)) {
+    if (!parse_decimal_bignum(b, neg_b, mag_b)) {
       if (error_message != nullptr) {
         *error_message = "invalid integer '" + b + "'";
       }
       return 2;
     }
-    return compare_integers(op, va, vb) ? 0 : 1;
+    return compare_integer_strings(op, a, b) ? 0 : 1;
   }
 
   if (op == "-nt" || op == "-ot" || op == "-ef") {

--- a/src/commands/touch.cpp
+++ b/src/commands/touch.cpp
@@ -256,6 +256,97 @@ auto parse_timezone_suffix(std::string& s) -> std::optional<int> {
   return std::nullopt;
 }
 
+// [GNU] touch honors the TZ environment variable when interpreting wall
+// clock times given via -t or -d (no explicit offset in the string).
+// Supported POSIX forms: "UTC", "GMT" and "NAME[+|-]hh[:mm[:ss]]" where the
+// offset counts WEST of the prime meridian (POSIX sign convention).
+// Named IANA zones (e.g. "Asia/Shanghai") are not resolvable without a
+// tz database, so they fall back to the system local zone. Returns the
+// offset EAST of UTC in minutes, or nullopt to use the system local zone.
+auto env_tz_offset_east() -> std::optional<int> {
+  const char* tz = std::getenv("TZ");
+  if (tz == nullptr || *tz == '\0') return std::nullopt;
+  std::string s = tz;
+  if (!s.empty() && s.front() == ':') s = s.substr(1);
+
+  size_t pos = 0;
+  if (!s.empty() && s.front() == '<') {
+    auto close = s.find('>');
+    if (close == std::string::npos) return std::nullopt;
+    pos = close + 1;
+  } else {
+    while (pos < s.size() &&
+           std::isalpha(static_cast<unsigned char>(s[pos]))) {
+      ++pos;
+    }
+  }
+  if (pos == s.size()) {
+    // Bare zone name: only UTC/GMT/UT/Z are unambiguous; anything else
+    // (IANA names) falls back to the system local zone.
+    std::string name = s;
+    for (auto& c : name) {
+      c = static_cast<char>(std::toupper(static_cast<unsigned char>(c)));
+    }
+    if (name == "UTC" || name == "GMT" || name == "UT" || name == "Z") {
+      return 0;
+    }
+    return std::nullopt;
+  }
+
+  int sign = 1;
+  if (s[pos] == '+' || s[pos] == '-') {
+    sign = s[pos] == '-' ? -1 : 1;
+    ++pos;
+  }
+
+  auto read_num = [&](int& out, size_t& i) -> bool {
+    size_t start = i;
+    while (i < s.size() && std::isdigit(static_cast<unsigned char>(s[i]))) {
+      ++i;
+    }
+    if (i == start) return false;
+    out = *parse_int(std::string_view(s).substr(start, i - start));
+    return true;
+  };
+
+  int hours = 0;
+  int minutes = 0;
+  int seconds = 0;
+  if (!read_num(hours, pos)) return std::nullopt;
+  if (pos < s.size() && s[pos] == ':') {
+    ++pos;
+    if (!read_num(minutes, pos)) return std::nullopt;
+    if (pos < s.size() && s[pos] == ':') {
+      ++pos;
+      if (!read_num(seconds, pos)) return std::nullopt;
+    }
+  }
+  if (pos != s.size() || hours > 24 || minutes > 59 || seconds > 59) {
+    return std::nullopt;
+  }
+
+  // POSIX: positive offset = west of UTC, so east offset negates it.
+  long long east_seconds =
+      -sign * (hours * 3600LL + minutes * 60LL + seconds);
+  return static_cast<int>((east_seconds + 30) / 60);
+}
+
+// Interpret a wall clock SYSTEMTIME in the zone selected by an explicit
+// UTC offset (from a "+hh:mm" suffix in the string), else the TZ
+// environment variable, else the system local zone.
+auto zone_time_to_filetime(const SYSTEMTIME& st,
+                           std::optional<int> explicit_east_offset)
+    -> std::optional<FILETIME> {
+  std::optional<int> east = explicit_east_offset;
+  if (!east) east = env_tz_offset_east();
+  if (east) {
+    auto ft = utc_system_time_to_filetime(st);
+    if (!ft) return std::nullopt;
+    return add_seconds(*ft, -static_cast<long long>(*east) * 60);
+  }
+  return local_system_time_to_filetime(st);
+}
+
 auto parse_fixed_date_time(std::string input) -> std::optional<FILETIME> {
   input = trim_copy(input);
   if (auto epoch = parse_epoch_time(input)) return epoch;
@@ -300,7 +391,31 @@ auto parse_fixed_date_time(std::string input) -> std::optional<FILETIME> {
       second = *parse_int(std::string_view(date_part).substr(12, 2));
     }
   } else {
-    return std::nullopt;
+    // [GNU] Loose ISO dates with single-digit fields are accepted
+    // ("2026-6-27"), so also try splitting on '-' with variable widths
+    // (uutils #13134).
+    if (date_part.size() >= 6 && date_part.find('-') != std::string::npos) {
+      auto first = date_part.find('-');
+      auto second = date_part.find('-', first + 1);
+      if (second != std::string::npos &&
+          date_part.find('-', second + 1) == std::string::npos) {
+        auto y = parse_int(std::string_view(date_part).substr(0, first));
+        auto m = parse_int(std::string_view(date_part).substr(
+            first + 1, second - first - 1));
+        auto d = parse_int(std::string_view(date_part).substr(second + 1));
+        if (y && m && d) {
+          year = *y;
+          month = *m;
+          day = *d;
+        } else {
+          return std::nullopt;
+        }
+      } else {
+        return std::nullopt;
+      }
+    } else {
+      return std::nullopt;
+    }
   }
 
   if (!time_part.empty()) {
@@ -336,7 +451,7 @@ auto parse_fixed_date_time(std::string input) -> std::optional<FILETIME> {
     if (!ft) return std::nullopt;
     return add_seconds(*ft, -static_cast<long long>(*tz_offset) * 60);
   }
-  return local_system_time_to_filetime(st);
+  return zone_time_to_filetime(st, std::nullopt);
 }
 
 auto parse_relative_date(std::string input, const FILETIME& base)
@@ -449,7 +564,7 @@ auto parse_touch_timestamp(const std::string& input)
   st.wHour = static_cast<WORD>(hour);
   st.wMinute = static_cast<WORD>(minute);
   st.wSecond = static_cast<WORD>(second);
-  return local_system_time_to_filetime(st);
+  return zone_time_to_filetime(st, std::nullopt);
 }
 
 auto file_open_flags(bool no_dereference) -> DWORD {

--- a/src/commands/true.cpp
+++ b/src/commands/true.cpp
@@ -43,7 +43,7 @@ using cmd::meta::OptionType;
 
 auto constexpr TRUE_OPTIONS =
     // [GNU] option
-    std::array{OPTION("", "", "do nothing, successfully", STRING_TYPE)};
+    std::array{OPTION("--help", "", "display this help and exit", BOOL_TYPE)};
 
 REGISTER_COMMAND(
     true_cmd,
@@ -62,6 +62,17 @@ REGISTER_COMMAND(
 
     /* see also */
     "false(1)", "WinuxCmd", "Copyright © 2026 WinuxCmd", TRUE_OPTIONS) {
+  // [GNU] true --help prints a usage summary and exits successfully
+  // (uutils #10279, #9117).
+  if (ctx.has("--help")) {
+    safePrint("Usage: true [ignored command line arguments]\n"
+              "  or:  true OPTION\n"
+              "Exit with a status code indicating success.\n"
+              "\n"
+              "      --help     display this help and exit\n"
+              "      --version  output version information and exit\n");
+    return 0;
+  }
   // Do nothing, just return 0 (success)
   return 0;
 }

--- a/src/commands/truncate.cpp
+++ b/src/commands/truncate.cpp
@@ -180,6 +180,10 @@ auto scale_size(int64_t value, long double multiplier) -> cp::Result<int64_t> {
 auto parse_size(const std::string& size_str) -> cp::Result<SizeSpec> {
   std::string s = size_str;
   SizeSpec spec;
+  // [GNU] every rejected size reports the raw operand (uutils #13576)
+  const auto invalid_number = [&size_str]() -> std::string {
+    return "Invalid number: '" + size_str + "'";
+  };
 
   if (!s.empty()) {
     switch (s[0]) {
@@ -213,18 +217,18 @@ auto parse_size(const std::string& size_str) -> cp::Result<SizeSpec> {
   }
 
   if (s.empty()) {
-    return std::unexpected("invalid size");
+    return std::unexpected(invalid_number());
   }
 
   long double multiplier = match_suffix(s);
   if (s.empty()) {
-    return std::unexpected("invalid size");
+    return std::unexpected(invalid_number());
   }
 
   int64_t base_value = 0;
   auto [ptr, ec] = std::from_chars(s.data(), s.data() + s.size(), base_value);
   if (ec != std::errc() || ptr != s.data() + s.size() || base_value < 0) {
-    return std::unexpected("invalid size format");
+    return std::unexpected(invalid_number());
   }
 
   auto scaled = scale_size(base_value, multiplier);
@@ -253,7 +257,15 @@ auto build_config(const CommandContext<TRUNCATE_OPTIONS.size()>& ctx)
     size_opt = ctx.get<std::string>("-s", "");
   }
 
-  if (size_opt.empty()) {
+  if (ctx.has("--size") || ctx.has("-s")) {
+    // [GNU] an explicitly empty -s value is a parse error, not a missing
+    // operand (uutils #13576)
+    auto size_result = parse_size(size_opt);
+    if (!size_result) {
+      return std::unexpected(size_result.error());
+    }
+    cfg.size = *size_result;
+  } else {
     auto ref_opt = ctx.get<std::string>("--reference", "");
     if (ref_opt.empty()) {
       ref_opt = ctx.get<std::string>("-r", "");
@@ -262,14 +274,8 @@ auto build_config(const CommandContext<TRUNCATE_OPTIONS.size()>& ctx)
     if (!ref_opt.empty()) {
       cfg.reference_file = ref_opt;
     } else {
-      return std::unexpected("specify --size or --reference");
+      return std::unexpected("you must specify either '--size' or '--reference'");
     }
-  } else {
-    auto size_result = parse_size(size_opt);
-    if (!size_result) {
-      return std::unexpected(size_result.error());
-    }
-    cfg.size = *size_result;
   }
 
   for (auto arg : ctx.positionals) {

--- a/src/commands/tsort.cpp
+++ b/src/commands/tsort.cpp
@@ -55,39 +55,109 @@ REGISTER_COMMAND(tsort,
     return 1;
   }
 
-  std::istringstream iss(input);
-  std::string line;
+  // [GNU] tsort reads whitespace-separated pairs; an odd token count is
+  // an error (uutils #7077).
+  std::vector<std::string> tokens;
+  std::istringstream tok_ss(input);
+  std::string tok;
+  while (tok_ss >> tok) tokens.push_back(tok);
+  if (tokens.size() % 2 != 0) {
+    safeErrorPrintLn(::winux::i18n::format(
+        "command.tsort.error.odd_tokens",
+        "tsort: input contains an odd number of tokens"));
+    return 1;
+  }
+
   std::set<std::string> nodes;
   std::map<std::string, std::vector<std::string>> graph;
+  std::set<std::pair<std::string, std::string>> seen_pairs;
+  const std::string input_name = ctx.positionals.empty()
+                                     ? "-"
+                                     : std::string(ctx.positionals[0]);
 
-  while (std::getline(iss, line)) {
-    std::istringstream line_ss(line);
-    std::string node, dep;
-    if (line_ss >> node >> dep) {
-      graph[node].push_back(dep);
-      nodes.insert(node);
-      nodes.insert(dep);
+  for (size_t i = 0; i + 1 < tokens.size(); i += 2) {
+    const std::string& node = tokens[i];
+    const std::string& dep = tokens[i + 1];
+    // [GNU] Duplicate pairs are ignored with a warning on stderr.
+    if (!seen_pairs.insert({node, dep}).second) {
+      safeErrorPrintLn("tsort: " + input_name + ": duplicate input pair");
+      continue;
     }
+    graph[node].push_back(dep);
+    nodes.insert(node);
+    nodes.insert(dep);
   }
 
   std::map<std::string, int> remaining;
-  for (const auto& n : nodes) remaining[n] = 0;
+  std::map<std::string, size_t> order_index;
+  size_t order = 0;
+  for (const auto& n : nodes) {
+    remaining[n] = 0;
+    order_index[n] = order++;
+  }
   for (const auto& [node, deps] : graph)
     for (const auto& dependency : deps) ++remaining[dependency];
   std::set<std::string> ready;
   for (const auto& [node, degree] : remaining)
     if (degree == 0) ready.insert(node);
   size_t emitted = 0;
-  while (!ready.empty()) {
+  bool had_loop = false;
+  while (emitted < nodes.size()) {
+    if (ready.empty()) {
+      // [GNU] Break the cycle: emit the earliest-mentioned remaining node
+      // and report the loop on stderr. Output continues with the partial
+      // order, but the exit status is 1 (uutils #7074).
+      had_loop = true;
+      std::string start;
+      size_t best = SIZE_MAX;
+      for (const auto& n : nodes) {
+        if (remaining[n] >= 0 && order_index[n] < best) {
+          best = order_index[n];
+          start = n;
+        }
+      }
+      if (start.empty()) break;
+      // Find the loop path from start (DFS) for the stderr report.
+      std::vector<std::string> loop{start};
+      std::set<std::string> visited{start};
+      std::string current = start;
+      while (true) {
+        const auto it = graph.find(current);
+        if (it == graph.end()) break;
+        bool advanced = false;
+        for (const auto& dependency : it->second) {
+          if (dependency == start) {
+            current = start;
+            advanced = true;
+            break;
+          }
+          if (nodes.contains(dependency) && !visited.contains(dependency)) {
+            visited.insert(dependency);
+            loop.push_back(dependency);
+            current = dependency;
+            advanced = true;
+            break;
+          }
+        }
+        if (!advanced || current == start) break;
+      }
+      safeErrorPrintLn("tsort: " + input_name + ": input contains a loop:");
+      for (const auto& member : loop) {
+        safeErrorPrintLn("tsort: " + member);
+      }
+      // Break the loop at the start node.
+      ready.insert(start);
+      remaining[start] = 0;
+    }
     auto node = *ready.begin();
     ready.erase(ready.begin());
     safePrintLn(node);
     ++emitted;
+    remaining[node] = -1;  // mark emitted
     for (const auto& dependency : graph[node])
       if (--remaining[dependency] == 0) ready.insert(dependency);
   }
-  if (emitted != nodes.size()) {
-    safeErrorPrintLn("tsort: input contains a loop");
+  if (had_loop) {
     return 1;
   }
 

--- a/src/commands/uptime.cpp
+++ b/src/commands/uptime.cpp
@@ -88,6 +88,29 @@ auto format_uptime(std::chrono::seconds uptime) -> std::string {
   return result;
 }
 
+// [GNU] the default uptime line renders the duration as a clock, e.g.
+// "up 22:03" / "up 2 days,  4:13", not "up 22 hours, 3 minutes"
+// (uutils #13027, #13453)
+auto format_uptime_clock(std::chrono::seconds uptime) -> std::string {
+  auto days = std::chrono::duration_cast<std::chrono::hours>(uptime) / 24;
+  auto hours = std::chrono::duration_cast<std::chrono::hours>(uptime) % 24;
+  auto minutes = std::chrono::duration_cast<std::chrono::minutes>(uptime) % 60;
+
+  char buf[64];
+  if (days.count() > 0) {
+    std::string day_part = std::to_string(days.count()) +
+                           (days.count() == 1 ? " day" : " days");
+    snprintf(buf, sizeof(buf), "%s, %2d:%02d", day_part.c_str(),
+             static_cast<int>(hours.count()),
+             static_cast<int>(minutes.count()));
+  } else {
+    snprintf(buf, sizeof(buf), "%2d:%02d",
+             static_cast<int>(hours.count()),
+             static_cast<int>(minutes.count()));
+  }
+  return std::string(buf);
+}
+
 auto run(const Config& cfg) -> int {
   // Get system uptime
   auto uptime = std::chrono::seconds(GetTickCount64() / 1000);
@@ -116,7 +139,7 @@ auto run(const Config& cfg) -> int {
     safePrint(" ");
     safePrint(time_ss.str());
     safePrint(" up ");
-    safePrint(format_uptime(uptime));
+    safePrint(format_uptime_clock(uptime));
     safePrint(",  ");
     safePrintLn("load average: N/A, N/A, N/A");
   }

--- a/src/commands/wpm.cpp
+++ b/src/commands/wpm.cpp
@@ -59,6 +59,8 @@ auto constexpr WPM_OPTIONS = std::array{
     // [EXT] option
     OPTION("-v", "--verbose", "print detailed progress"),
     // [EXT] option
+    OPTION("-y", "--yes", "assume yes for interactive prompts"),
+    // [EXT] option
     OPTION("", "--category", "filter list/search output by category",
            STRING_TYPE),
     // [EXT] option
@@ -145,6 +147,7 @@ struct Options {
   bool verbose = false;
   bool json = false;
   bool plain = false;
+  bool yes = false;
 };
 
 struct FileId {
@@ -892,17 +895,19 @@ auto collect_cleanup_files(const fs::path& root)
   return files;
 }
 
-auto print_cleanup_progress(std::string_view kind, size_t done, size_t total,
-                            unsigned long long bytes) -> void {
+auto print_cleanup_progress(std::string_view key, std::string_view kind,
+                            size_t done, size_t total, unsigned long long bytes)
+    -> void {
   const int percent = total == 0 ? 100 : static_cast<int>(done * 100 / total);
   safePrint(std::string("\r") +
-            wpm_text("command.wpm.status.clean_progress",
-                     "wpm: removing {}... {}% ({}/{} files, {})", kind, percent,
-                     done, total, human_size(bytes)));
+            wpm_text(key, "wpm: removing {}... {}% ({}/{} files, {})", kind,
+                     percent, done, total, human_size(bytes)));
 }
 
-auto remove_tree(const fs::path& target, std::string_view kind, bool verbose)
-    -> CleanupStats {
+auto remove_tree(const fs::path& target, std::string_view kind, bool verbose,
+                 bool show_progress = true,
+                 std::string_view progress_key =
+                     "command.wpm.status.clean_progress") -> CleanupStats {
   CleanupStats removed;
   const auto files = collect_cleanup_files(target);
   const size_t total = files.size();
@@ -920,8 +925,8 @@ auto remove_tree(const fs::path& target, std::string_view kind, bool verbose)
       ++removed.files;
     }
     ++done;
-    if (!verbose && (done % 16 == 0 || done == total)) {
-      print_cleanup_progress(kind, done, total, removed.bytes);
+    if (!verbose && show_progress && (done % 16 == 0 || done == total)) {
+      print_cleanup_progress(progress_key, kind, done, total, removed.bytes);
       progress_shown = true;
     }
   }
@@ -1565,13 +1570,16 @@ auto extract_archive(const fs::path& archive, const fs::path& dest,
                      std::string_view type) -> bool {
   std::error_code ec;
   fs::create_directories(dest, ec);
+  safePrintLn(wpm_text("command.wpm.status.extracting", "wpm: extracting {}",
+                       archive.filename().string()));
   std::wstring command =
       L"tar.exe -xf " + quote(archive) + L" -C " + quote(dest);
   int code = run_process(command);
   if (code != 0) {
-    safeErrorPrintLn("wpm: " + std::string(type) +
-                     " extraction failed; Windows tar.exe returned " +
-                     std::to_string(code));
+    safeErrorPrintLn(wpm_text("command.wpm.error.extract_failed",
+                              "wpm: {} extraction failed; Windows tar.exe "
+                              "returned {}",
+                              type, code));
     return false;
   }
   return true;
@@ -1839,9 +1847,13 @@ auto download_artifact(const fs::path& root, const std::string& package,
     -> std::optional<fs::path> {
   auto urls = artifact_urls(artifact);
   if (urls.empty()) {
-    safeErrorPrintLn("wpm: package '" + package +
-                     "' has no URLs in the local index");
-    safeErrorPrintLn("wpm: run 'wpm index update' or choose another source");
+    safeErrorPrintLn(wpm_text("command.wpm.error.no_urls",
+                              "wpm: package '{}' has no URLs in the local "
+                              "index",
+                              package));
+    safeErrorPrintLn(wpm_text("command.wpm.error.run_index_update_hint",
+                              "wpm: run 'wpm index update' or choose another "
+                              "source"));
     return std::nullopt;
   }
 
@@ -1850,7 +1862,9 @@ auto download_artifact(const fs::path& root, const std::string& package,
       cache_dir(root) / (package + "." + artifact_cache_extension(type));
   std::string expected_sha = artifact.value("sha256", "");
   if (cached_artifact_is_valid(out, expected_sha)) {
-    if (verbose) safePrintLn("wpm: using cached " + out.string());
+    if (verbose)
+      safePrintLn(wpm_text("command.wpm.status.using_cache",
+                           "wpm: using cached {}", out.string()));
     return out;
   }
   if (fs::exists(out)) {
@@ -1859,14 +1873,18 @@ auto download_artifact(const fs::path& root, const std::string& package,
   }
   for (const auto& url : urls) {
     if (verbose) safePrintLn("wpm: downloading " + url);
-    auto result = http_get(url, "wpm: downloading " + package);
+    auto result = http_get(url, wpm_text("command.wpm.status.downloading",
+                                         "wpm: downloading {}", package));
     if (!result.ok) {
-      safeErrorPrintLn("wpm: download failed from " + url + ": " +
-                       result.error);
+      safeErrorPrintLn(wpm_text("command.wpm.error.download_failed",
+                                "wpm: download failed from {}: {}", url,
+                                result.error));
       continue;
     }
     if (!write_bytes(out, result.data)) {
-      safeErrorPrintLn("wpm: failed to write cache file " + out.string());
+      safeErrorPrintLn(wpm_text("command.wpm.error.write_cache",
+                                "wpm: failed to write cache file {}",
+                                out.string()));
       continue;
     }
     if (!verify_sha256(out, expected_sha)) {
@@ -2229,13 +2247,16 @@ auto cleanup_legacy_flat_artifacts(const fs::path& root,
 auto update_index(const Options& opts) -> int;
 
 auto refresh_index_once(const Options& opts, std::string_view reason) -> bool {
-  safePrintLn("wpm: " + std::string(reason) +
-              "; updating index from configured sources");
+  safePrintLn(wpm_text("command.wpm.status.auto_index_update",
+                       "wpm: {}; updating index from configured sources",
+                       reason));
   if (update_index(opts) == 0) return true;
-  safeErrorPrintLn("wpm: automatic index update failed");
+  safeErrorPrintLn(wpm_text("command.wpm.error.auto_index_failed",
+                            "wpm: automatic index update failed"));
   safeErrorPrintLn(
-      "wpm: run 'wpm index update' to retry or 'wpm source list' "
-      "to inspect sources");
+      wpm_text("command.wpm.error.auto_index_hint",
+               "wpm: run 'wpm index update' to retry or 'wpm source list' "
+               "to inspect sources"));
   return false;
 }
 
@@ -2252,8 +2273,9 @@ auto install_package(const Options& opts, std::string_view package_name)
     }
   }
   if (!pkg) {
-    safeErrorPrintLn("wpm: package not found after index update: " +
-                     std::string(package_name));
+    safeErrorPrintLn(wpm_text("command.wpm.error.install_not_found",
+                              "wpm: package not found after index update: {}",
+                              package_name));
     return 1;
   }
 
@@ -2267,11 +2289,13 @@ auto install_package(const Options& opts, std::string_view package_name)
     }
   }
   if (state != "ready") {
-    safeErrorPrintLn("wpm: package is not installable for " +
-                     detect_arch_key() + ": " + state);
+    safeErrorPrintLn(wpm_text("command.wpm.error.not_installable",
+                              "wpm: package is not installable for {}: {}",
+                              detect_arch_key(), state));
     safeErrorPrintLn(
-        "wpm: update the source index artifact urls, sha256, and "
-        "files mapping");
+        wpm_text("command.wpm.error.fix_index_hint",
+                 "wpm: update the source index artifact urls, sha256, and "
+                 "files mapping"));
     return 1;
   }
 
@@ -2302,11 +2326,14 @@ auto install_package(const Options& opts, std::string_view package_name)
       return 1;
     }
   } else {
-    safeErrorPrintLn("wpm: unsupported artifact type: " + type);
+    safeErrorPrintLn(wpm_text("command.wpm.error.unsupported_type",
+                              "wpm: unsupported artifact type: {}", type));
     return 1;
   }
 
   const bool shim_layout = artifact_layout(*artifact) == "shim";
+  safePrintLn(wpm_text("command.wpm.status.installing_files",
+                       "wpm: installing files..."));
   if (!copy_artifact_files(extracted, opts.root, *artifact, opts.force,
                            opts.dry_run,
                            pkg->value("name", std::string(package_name)))) {
@@ -2324,11 +2351,12 @@ auto install_package(const Options& opts, std::string_view package_name)
     return 1;
   }
   if (opts.dry_run) {
-    safePrintLn("wpm: dry-run complete; would install " +
-                pkg->value("name", std::string(package_name)));
+    safePrintLn(wpm_text("command.wpm.status.install_dry_run",
+                         "wpm: dry-run complete; would install {}",
+                         pkg->value("name", std::string(package_name))));
   } else {
-    safePrintLn("wpm: installed " +
-                pkg->value("name", std::string(package_name)));
+    safePrintLn(wpm_text("command.wpm.status.installed", "wpm: installed {}",
+                         pkg->value("name", std::string(package_name))));
   }
   return 0;
 }
@@ -2377,14 +2405,17 @@ auto update_winuxcmd(const Options& opts) -> int {
   auto index = load_index(opts.root);
   auto pkg = find_package(index, "winuxcmd");
   if (!pkg) {
-    safeErrorPrintLn("wpm: winuxcmd package missing after index update");
+    safeErrorPrintLn(wpm_text("command.wpm.error.core_missing",
+                              "wpm: winuxcmd package missing after index "
+                              "update"));
     return 1;
   }
 
   auto state = artifact_install_state(*pkg);
   if (state != "ready") {
-    safeErrorPrintLn("wpm: winuxcmd is not installable for " +
-                     detect_arch_key() + ": " + state);
+    safeErrorPrintLn(wpm_text("command.wpm.error.not_installable",
+                              "wpm: package is not installable for {}: {}",
+                              detect_arch_key(), state));
     return 1;
   }
 
@@ -2406,29 +2437,37 @@ auto update_winuxcmd(const Options& opts) -> int {
     fs::copy_file(*downloaded, extracted / "winuxcmd.exe",
                   fs::copy_options::overwrite_existing, ec);
     if (ec) {
-      safeErrorPrintLn("wpm: failed to stage winuxcmd.exe: " + ec.message());
+      safeErrorPrintLn(wpm_text("command.wpm.error.stage_core",
+                                "wpm: failed to stage winuxcmd.exe: {}",
+                                ec.message()));
       return 1;
     }
   } else {
-    safeErrorPrintLn("wpm: unsupported artifact type: " + type);
+    safeErrorPrintLn(wpm_text("command.wpm.error.unsupported_type",
+                              "wpm: unsupported artifact type: {}", type));
     return 1;
   }
 
   auto staged_exe = find_file_recursive(extracted, "winuxcmd.exe");
   if (!staged_exe) {
-    safeErrorPrintLn("wpm: staged winuxcmd.exe not found");
+    safeErrorPrintLn(wpm_text("command.wpm.error.staged_missing",
+                              "wpm: staged winuxcmd.exe not found"));
     return 1;
   }
 
   if (opts.dry_run) {
-    safePrintLn("would apply update from " + staged_exe->string());
+    safePrintLn(wpm_text("command.wpm.status.update_dry_run",
+                         "wpm: dry-run: would apply update from {}",
+                         staged_exe->string()));
     return 0;
   }
 
   if (!launch_apply_update(*staged_exe, opts.root, GetCurrentProcessId())) {
     return 1;
   }
-  safePrintLn("wpm: update staged; helper will replace winuxcmd after exit");
+  safePrintLn(wpm_text("command.wpm.status.update_staged",
+                       "wpm: update staged; helper will replace winuxcmd "
+                       "after exit"));
   return 0;
 }
 
@@ -2517,7 +2556,9 @@ auto try_fetch_index(const Options& opts, std::string& used_source)
       if (!url_json.is_string()) continue;
       std::string url = url_json.get<std::string>();
       if (opts.verbose) safePrintLn("wpm: fetching index " + url);
-      auto result = http_get(url);
+      auto result =
+          http_get(url, wpm_text("command.wpm.status.fetching_index",
+                                 "wpm: fetching index from {}", name));
       if (!result.ok) {
         safeErrorPrintLn("wpm: index fetch failed from " + name + ": " +
                          result.error);
@@ -2541,17 +2582,20 @@ auto update_index(const Options& opts) -> int {
   std::string used_source;
   auto fetched = try_fetch_index(opts, used_source);
   if (!fetched) {
-    safeErrorPrintLn("wpm: no reachable index source");
+    safeErrorPrintLn(wpm_text("command.wpm.error.no_source",
+                              "wpm: no reachable index source"));
     return 1;
   }
   if (!write_text(local_index_path(opts.root), fetched->dump(2))) {
-    safeErrorPrintLn("wpm: failed to save index");
+    safeErrorPrintLn(
+        wpm_text("command.wpm.error.save_index", "wpm: failed to save index"));
     return 1;
   }
   auto config = load_config(opts.root);
   config["last_success_source"] = used_source;
   save_config(opts.root, config);
-  safePrintLn("wpm: index updated from " + used_source);
+  safePrintLn(wpm_text("command.wpm.status.index_updated",
+                       "wpm: index updated from {}", used_source));
   return 0;
 }
 
@@ -2879,11 +2923,11 @@ auto export_installed_packages_plain(const Options& opts) -> int {
 // Installation state is derived (no manifest), so removal targets are exactly
 // the destinations `package_is_installed` checks. Protected files — the
 // canonical winuxcmd.exe and the running executable — are never deleted.
-auto uninstall_remove_destination(const fs::path& root, const fs::path& dest,
+auto uninstall_remove_destination(const Options& opts, const fs::path& dest,
                                   bool directory,
                                   std::vector<std::string>& removed,
                                   std::vector<std::string>& errors) -> bool {
-  const fs::path core = canonical_winuxcmd_path(root);
+  const fs::path core = canonical_winuxcmd_path(opts.root);
   std::error_code ec;
   if (same_file(core, dest) || same_file(current_exe_path(), dest)) {
     errors.push_back(wpm_text("command.wpm.error.uninstall_protected",
@@ -2893,21 +2937,33 @@ auto uninstall_remove_destination(const fs::path& root, const fs::path& dest,
   }
   if (!fs::exists(dest, ec)) return true;
   if (directory) {
-    fs::remove_all(dest, ec);
+    // Trailing separators make filename() empty; fall back to the last
+    // non-empty component so the progress label names the package folder.
+    std::string kind = dest.filename().string();
+    if (kind.empty()) kind = dest.parent_path().filename().string();
+    if (kind.empty()) kind = "package files";
+    const auto stats = remove_tree(dest, kind, opts.verbose, !opts.json,
+                                   "command.wpm.status.uninstall_progress");
+    if (stats.ec) {
+      errors.push_back(wpm_text("command.wpm.error.uninstall_failed",
+                                "wpm: failed to remove '{}': {}", dest.string(),
+                                stats.ec.message()));
+      return false;
+    }
   } else {
     fs::remove(dest, ec);
-  }
-  if (ec) {
-    errors.push_back(wpm_text("command.wpm.error.uninstall_failed",
-                              "wpm: failed to remove '{}': {}", dest.string(),
-                              ec.message()));
-    return false;
+    if (ec) {
+      errors.push_back(wpm_text("command.wpm.error.uninstall_failed",
+                                "wpm: failed to remove '{}': {}", dest.string(),
+                                ec.message()));
+      return false;
+    }
   }
   removed.push_back(dest.string());
   // Prune now-empty parent directories up to usr/bin (never above root).
   fs::path parent = dest.parent_path();
-  const fs::path bin_dir = canonical_bin_dir(root);
-  while (parent != bin_dir && parent != root && !parent.empty()) {
+  const fs::path bin_dir = canonical_bin_dir(opts.root);
+  while (parent != bin_dir && parent != opts.root && !parent.empty()) {
     std::error_code empty_ec;
     if (!fs::is_empty(parent, empty_ec) || empty_ec) break;
     std::error_code rm_ec;
@@ -2965,7 +3021,7 @@ auto uninstall_package(const Options& opts, const nlohmann::json& pkg)
       if (fs::exists(*dest, ec)) removed.push_back(dest->string());
       continue;
     }
-    if (!uninstall_remove_destination(opts.root, *dest, directory, removed,
+    if (!uninstall_remove_destination(opts, *dest, directory, removed,
                                       errors)) {
       ok = false;
     }
@@ -2982,8 +3038,7 @@ auto uninstall_package(const Options& opts, const nlohmann::json& pkg)
       std::error_code ec;
       if (!fs::exists(shim, ec)) continue;
       if (same_file(self_exe, shim) || files_equal(self_exe, shim)) {
-        if (!uninstall_remove_destination(opts.root, shim, false, removed,
-                                          errors)) {
+        if (!uninstall_remove_destination(opts, shim, false, removed, errors)) {
           ok = false;
         }
       } else {
@@ -3010,8 +3065,8 @@ auto uninstall_package(const Options& opts, const nlohmann::json& pkg)
         std::error_code ec;
         if (!fs::exists(alias_path, ec)) continue;
         if (same_file(target, alias_path)) {
-          if (!uninstall_remove_destination(opts.root, alias_path, false,
-                                            removed, errors))
+          if (!uninstall_remove_destination(opts, alias_path, false, removed,
+                                            errors))
             ok = false;
         } else {
           errors.push_back(wpm_text("command.wpm.error.uninstall_protected",
@@ -3050,6 +3105,44 @@ auto uninstall_packages(const Options& opts,
   nlohmann::json results = nlohmann::json::array();
   int failed = 0;
   int removed_count = 0;
+
+  // Interactive confirmation. Skipped for --yes, --dry-run, and --json
+  // (non-interactive consumers). Only packages that are actually installed
+  // and removable are listed.
+  if (!opts.yes && !opts.dry_run && !opts.json) {
+    std::vector<std::string> targets;
+    for (const auto& name_view : names) {
+      const std::string name(name_view);
+      auto pkg = find_package(index, name);
+      if (!pkg || name == "winuxcmd") continue;
+      auto artifact = artifact_for_current_arch(*pkg);
+      if (!artifact || artifact_install_state(*pkg) != "ready") continue;
+      auto destinations =
+          artifact_destination_paths(opts.root, *artifact, name);
+      if (!destinations || destinations->empty()) continue;
+      targets.push_back(name);
+    }
+    if (!targets.empty()) {
+      std::string joined;
+      for (size_t i = 0; i < targets.size(); ++i) {
+        if (i > 0) joined += ", ";
+        joined += targets[i];
+      }
+      safePrintLn(wpm_text("command.wpm.status.uninstall_confirm",
+                           "wpm: the following packages will be removed: {}",
+                           joined));
+      safePrint(wpm_text("command.wpm.status.uninstall_prompt",
+                         "wpm: continue? [y/N] "));
+      std::string line;
+      std::getline(std::cin, line);
+      line = lower_ascii(trim_ascii(std::move(line)));
+      if (line != "y" && line != "yes") {
+        safePrintLn(wpm_text("command.wpm.status.uninstall_aborted",
+                             "wpm: aborted; nothing was removed"));
+        return 0;
+      }
+    }
+  }
 
   for (const auto& name_view : names) {
     const std::string name(name_view);
@@ -3348,6 +3441,8 @@ auto print_usage() -> int {
       "  -n, --dry-run                         show planned changes without "
       "writing\n"
       "  -v, --verbose                         print detailed progress\n"
+      "  -y, --yes                             assume yes for interactive "
+      "prompts\n"
       "      --category <name>                 filter list/search output by "
       "category\n"
       "      --json                            print machine-readable JSON\n"
@@ -3374,6 +3469,7 @@ auto build_options(const CommandContext<WPM_OPTIONS.size()>& ctx) -> Options {
       ctx.get<bool>("--dry-run", false) || ctx.get<bool>("-n", false);
   opts.verbose =
       ctx.get<bool>("--verbose", false) || ctx.get<bool>("-v", false);
+  opts.yes = ctx.get<bool>("--yes", false) || ctx.get<bool>("-y", false);
   opts.category = ctx.get<std::string>("--category", "");
   opts.json = ctx.get<bool>("--json", false);
   opts.plain = ctx.has("--plain");

--- a/src/commands/wpm.cpp
+++ b/src/commands/wpm.cpp
@@ -860,6 +860,7 @@ auto human_size(unsigned long long bytes) -> std::string {
 struct CleanupStats {
   unsigned long long bytes = 0;
   size_t files = 0;
+  std::error_code ec;
 };
 
 auto directory_stats(const fs::path& root) -> CleanupStats {
@@ -873,6 +874,64 @@ auto directory_stats(const fs::path& root) -> CleanupStats {
     if (!ec) ++stats.files;
   }
   return stats;
+}
+
+auto collect_cleanup_files(const fs::path& root)
+    -> std::vector<std::pair<fs::path, unsigned long long>> {
+  std::vector<std::pair<fs::path, unsigned long long>> files;
+  std::error_code ec;
+  fs::recursive_directory_iterator it{root, ec};
+  fs::recursive_directory_iterator end;
+  while (!ec && it != end) {
+    std::error_code file_ec;
+    if (it->is_regular_file(file_ec) && !file_ec) {
+      files.emplace_back(it->path(), it->file_size(file_ec));
+    }
+    it.increment(ec);
+  }
+  return files;
+}
+
+auto print_cleanup_progress(std::string_view kind, size_t done, size_t total,
+                            unsigned long long bytes) -> void {
+  const int percent = total == 0 ? 100 : static_cast<int>(done * 100 / total);
+  safePrint(std::string("\r") +
+            wpm_text("command.wpm.status.clean_progress",
+                     "wpm: removing {}... {}% ({}/{} files, {})", kind, percent,
+                     done, total, human_size(bytes)));
+}
+
+auto remove_tree(const fs::path& target, std::string_view kind, bool verbose)
+    -> CleanupStats {
+  CleanupStats removed;
+  const auto files = collect_cleanup_files(target);
+  const size_t total = files.size();
+  size_t done = 0;
+  bool progress_shown = false;
+  for (const auto& [path, size] : files) {
+    if (verbose) {
+      safePrintLn(wpm_text("command.wpm.status.clean_file", "wpm: - {}",
+                           path.string()));
+    }
+    std::error_code ec;
+    fs::remove(path, ec);
+    if (!ec) {
+      removed.bytes += size;
+      ++removed.files;
+    }
+    ++done;
+    if (!verbose && (done % 16 == 0 || done == total)) {
+      print_cleanup_progress(kind, done, total, removed.bytes);
+      progress_shown = true;
+    }
+  }
+  std::error_code ec;
+  fs::remove_all(target, ec);
+  if (ec) removed.ec = ec;
+  if (progress_shown) {
+    safePrint(std::string("\r") + std::string(72, ' ') + "\r");
+  }
+  return removed;
 }
 
 auto clean_state_directory(const fs::path& root, std::string_view kind,
@@ -892,18 +951,20 @@ auto clean_state_directory(const fs::path& root, std::string_view kind,
                          stats.files));
     return 0;
   }
-  fs::remove_all(target, ec);
-  if (ec) {
+  const auto started = std::chrono::steady_clock::now();
+  const auto removed = remove_tree(target, kind, verbose);
+  const std::chrono::duration<double> elapsed =
+      std::chrono::steady_clock::now() - started;
+  if (removed.ec) {
     safeErrorPrintLn(wpm_text("command.wpm.error.clean",
                               "wpm: failed to clean '{}': {}", target.string(),
-                              ec.message()));
+                              removed.ec.message()));
     return 1;
   }
-  if (verbose) {
-    safePrintLn(wpm_text("command.wpm.status.cleaned_detail",
-                         "wpm: cleaned {} ({} in {} files)", target.string(),
-                         human_size(stats.bytes), stats.files));
-  }
+  safePrintLn(wpm_text("command.wpm.status.clean_summary",
+                       "wpm: removed {} ({} in {} files) in {:.1f}s",
+                       target.string(), human_size(removed.bytes),
+                       removed.files, elapsed.count()));
   return 0;
 }
 
@@ -3245,43 +3306,56 @@ auto show_info(const Options& opts, std::string_view name) -> int {
 auto print_usage() -> int {
   const std::string help =
       "Winux Package Manager {}\n"
-      "Usage: wpm <command> [args] [options]\n\n"
+      "Usage: wpm <command> [args] [options]\n"
+      "\n"
       "Commands:\n"
-      "  links list|rebuild|remove     manage WinuxCmd hardlinks\n"
-      "  clean [cache|staging|all]     remove transient downloads and staging\n"
-      "  cache clean [cache|staging|all]\n"
-      "                                alias for clean\n"
-      "  index status|update           inspect or refresh local index\n"
-      "  update-index                  alias for index update\n"
-      "  source list|use|add|test      manage and test index sources\n"
-      "  list                          list indexed packages and install "
-      "state\n"
-      "  categories                    list package categories and counts\n"
-      "  search <query>                search names, commands, categories, "
-      "licenses\n"
-      "  info <package>                show package metadata\n"
-      "  install <package>...          install one or more packages\n"
-      "  installed                     list packages present in this root\n"
-      "  export [--plain]              print installed package names for "
-      "profiles\n"
-      "  restore <file>                install packages from a plain list\n"
-      "  outdated                      list installed packages with updates\n"
-      "  uninstall|remove|erase <package>...\n"
-      "                                uninstall one or more packages\n"
-      "  update|upgrade winuxcmd       update WinuxCmd from local index\n\n"
+      "  links list|rebuild|remove             manage WinuxCmd hardlinks\n"
+      "  clean [cache|staging|all]             remove transient downloads and "
+      "staging\n"
+      "  cache clean [cache|staging|all]       alias for clean\n"
+      "  index status|update                   inspect or refresh local index\n"
+      "  update-index                          alias for index update\n"
+      "  source list|use|add|test              manage and test index sources\n"
+      "  list                                  list indexed packages and "
+      "install state\n"
+      "  categories                            list package categories and "
+      "counts\n"
+      "  search <query>                        search names, commands, "
+      "categories, licenses\n"
+      "  info <package>                        show package metadata\n"
+      "  install <package>...                  install one or more packages\n"
+      "  installed                             list packages present in this "
+      "root\n"
+      "  export [--plain]                      print installed package names "
+      "for profiles\n"
+      "  restore <file>                        install packages from a plain "
+      "list\n"
+      "  outdated                              list installed packages with "
+      "updates\n"
+      "  uninstall|remove|erase <package>...   uninstall one or more packages\n"
+      "  update|upgrade winuxcmd               update WinuxCmd from local "
+      "index\n"
+      "\n"
       "Options:\n"
-      "  -r, --root <dir>              manage a specific WinuxCmd root\n"
-      "  -s, --source <name>           use a specific index source\n"
-      "  -a, --all                     show index-only packages in list "
+      "  -r, --root <dir>                      manage a specific WinuxCmd "
+      "root\n"
+      "  -s, --source <name>                   use a specific index source\n"
+      "  -a, --all                             show index-only packages in "
+      "list "
       "output\n"
-      "  -f, --force                   overwrite existing files when safe\n"
-      "  -n, --dry-run                 show planned changes without writing\n"
-      "  -v, --verbose                 print detailed progress\n"
-      "      --category <name>         filter list/search output by category\n"
-      "      --json                    print machine-readable JSON\n"
-      "      --plain                   print only package names for export\n"
-      "      --help                    display this help and exit\n"
-      "  -V, --version                 output version information and exit\n";
+      "  -f, --force                           overwrite existing files when "
+      "safe\n"
+      "  -n, --dry-run                         show planned changes without "
+      "writing\n"
+      "  -v, --verbose                         print detailed progress\n"
+      "      --category <name>                 filter list/search output by "
+      "category\n"
+      "      --json                            print machine-readable JSON\n"
+      "      --plain                           print only package names for "
+      "export\n"
+      "      --help                            display this help and exit\n"
+      "  -V, --version                         output version information and "
+      "exit\n";
   safePrint(cmd::meta::format_custom_help(
       "wpm", wpm_text("command.wpm.custom_help", help, kVersion)));
   return 0;

--- a/src/core/command_context.cppm
+++ b/src/core/command_context.cppm
@@ -31,7 +31,7 @@ export auto option_policy_for_command(std::string_view command)
   OptionParsePolicy policy;
   policy.allow_unknown_short_options_as_positionals =
       command == "printf" || command == "expr" || command == "test" ||
-      command == "[" || command == "stty";
+      command == "[" || command == "stty" || command == "kill";
   if (command == "timeout") {
     policy.stop_options_after_positionals = 2;
   }

--- a/src/core/opt.cppm
+++ b/src/core/opt.cppm
@@ -409,8 +409,27 @@ export ParseResultRuntime parse_command_runtime(
           }
         }
         if (!has_registered_short_name) {
-          result.positionals.push_back(arg);
-          continue;
+          // A token glued to a registered short option that takes a value
+          // (e.g. kill -lHUP) is an option with an attached value, not a
+          // positional operand (uutils #14177 regression guard).
+          bool glued_to_value_option = false;
+          if (arg.size() > 2) {
+            for (const auto& m : metas) {
+              if (m.short_name.size() == 2 && arg.starts_with(m.short_name)) {
+                if ((m.type == OptionType::String &&
+                     policy.allow_short_attached_values) ||
+                    (m.type == OptionType::OptionalString &&
+                     policy.allow_optional_short_attached_values)) {
+                  glued_to_value_option = true;
+                  break;
+                }
+              }
+            }
+          }
+          if (!glued_to_value_option) {
+            result.positionals.push_back(arg);
+            continue;
+          }
         }
       }
 

--- a/src/utils/i18n.cppm
+++ b/src/utils/i18n.cppm
@@ -209,7 +209,57 @@ export std::string translate_error(std::string_view error) {
     return ::winux::i18n::format("command.kill.error.multiple_signals",
                                  "'{}': multiple signals specified", value);
   }
-  constexpr std::array<std::pair<std::string_view, std::string_view>, 30> exact{
+  // sort: "options '-cC' are incompatible" — the flag cluster is quoted in
+  // the middle of the message.
+  constexpr std::string_view kIncompatibleSuffix = "' are incompatible";
+  if (error.starts_with("options '") && error.ends_with(kIncompatibleSuffix)) {
+    const auto value =
+        error.substr(9, error.size() - 9 - kIncompatibleSuffix.size());
+    return ::winux::i18n::format("common.error.options_incompatible",
+                                 "options '{}' are incompatible", value);
+  }
+  // pr: "'-l' invalid number of lines: '0'" — three dynamic parts (option
+  // label, unit, value).
+  {
+    constexpr std::string_view kPrNumberSep = "' invalid number of ";
+    if (error.size() > kPrNumberSep.size() + 2 && error.front() == '\'' &&
+        error.back() == '\'') {
+      const auto sep_pos = error.find(kPrNumberSep, 1);
+      if (sep_pos != std::string_view::npos) {
+        const auto label = error.substr(1, sep_pos - 1);
+        const auto rest = error.substr(sep_pos + kPrNumberSep.size());
+        constexpr std::string_view kPrValueSep = ": '";
+        const auto value_sep = rest.rfind(kPrValueSep);
+        if (value_sep != std::string_view::npos && value_sep > 0) {
+          const auto what = rest.substr(0, value_sep);
+          auto value = rest.substr(value_sep + kPrValueSep.size());
+          value.remove_suffix(1);
+          return ::winux::i18n::format(
+              "command.pr.error.invalid_number",
+              "'{}' invalid number of {}: '{}'", label, what, value);
+        }
+      }
+    }
+  }
+  // pr: "'-e' extra characters or invalid number in the argument: '0'".
+  {
+    constexpr std::string_view kPrExtraSep =
+        "' extra characters or invalid number in the argument: '";
+    if (error.size() > kPrExtraSep.size() && error.front() == '\'' &&
+        error.back() == '\'') {
+      const auto sep_pos = error.find(kPrExtraSep);
+      if (sep_pos != std::string_view::npos && sep_pos > 0) {
+        const auto label = error.substr(1, sep_pos - 1);
+        auto value = error.substr(sep_pos + kPrExtraSep.size());
+        value.remove_suffix(1);
+        return ::winux::i18n::format(
+            "command.pr.error.extra_characters",
+            "'{}' extra characters or invalid number in the argument: '{}'",
+            label, value);
+      }
+    }
+  }
+  constexpr std::array<std::pair<std::string_view, std::string_view>, 32> exact{
       {{"invalid input", "common.error.invalid_input"},
        {"error reading from file", "common.error.read_file"},
        {"error reading input", "common.error.read_input"},
@@ -241,7 +291,11 @@ export std::string translate_error(std::string_view error) {
        {"tab size cannot be 0", "common.error.tab_zero"},
        {"No such file or directory", "common.error.no_such_file"},
        {"you must specify either '--size' or '--reference'",
-        "common.error.size_or_reference"}}};
+        "common.error.size_or_reference"},
+       {"cannot both summarize and show all",
+        "common.error.summarize_and_show_all"},
+       {"multiple output files specified",
+        "common.error.multiple_output_files"}}};
   for (const auto [literal, key] : exact) {
     if (error == literal) return translate(key, error);
   }
@@ -273,7 +327,7 @@ export std::string translate_error(std::string_view error) {
     }
     return ::winux::i18n::format(key, "error reading '{}'", value);
   }
-  constexpr std::array<std::pair<std::string_view, std::string_view>, 39>
+  constexpr std::array<std::pair<std::string_view, std::string_view>, 41>
       quoted{
           {{"cannot open '", "common.error.cannot_open"},
            {"cannot access '", "common.error.cannot_access"},
@@ -316,7 +370,9 @@ export std::string translate_error(std::string_view error) {
            {"invalid --parallel argument '",
             "common.error.invalid_parallel_argument"},
            {"Invalid number: '", "common.error.invalid_number"},
-           {"invalid field number: '", "common.error.invalid_field_number"}}};
+           {"invalid field number: '", "common.error.invalid_field_number"},
+           {"invalid tab size: '", "common.error.invalid_tab_size"},
+           {"too few X's in template '", "common.error.too_few_xs"}}};
   for (const auto [prefix, key] : quoted) {
     if (!error.starts_with(prefix) || error.back() != '\'') continue;
     const auto value =
@@ -333,7 +389,7 @@ export std::string translate_error(std::string_view error) {
       return ::winux::i18n::format(key, "error writing '{}'", value);
     if (key == "common.error.invalid_mode")
       return ::winux::i18n::format(key, "invalid mode: '{}'", value);
-    constexpr std::array<std::pair<std::string_view, std::string_view>, 33>
+    constexpr std::array<std::pair<std::string_view, std::string_view>, 35>
         fallbacks{
             {{"common.error.invalid_group", "invalid group: '{}'"},
              {"common.error.invalid_user", "invalid user: '{}'"},
@@ -384,7 +440,9 @@ export std::string translate_error(std::string_view error) {
               "invalid --parallel argument '{}'"},
              {"common.error.invalid_number", "Invalid number: '{}'"},
              {"common.error.invalid_field_number",
-              "invalid field number: '{}'"}}};
+              "invalid field number: '{}'"},
+             {"common.error.invalid_tab_size", "invalid tab size: '{}'"},
+             {"common.error.too_few_xs", "too few X's in template '{}'"}}};
     for (const auto [fallback_key, fallback] : fallbacks) {
       if (key == fallback_key)
         return ::winux::i18n::format(key, fallback, value);

--- a/src/utils/i18n.cppm
+++ b/src/utils/i18n.cppm
@@ -143,10 +143,9 @@ export std::string translate_error(std::string_view error) {
   if (error.size() > kRepeatCountPrefix.size() + kRepeatCountSuffix.size() &&
       error.starts_with(kRepeatCountPrefix) &&
       error.ends_with(kRepeatCountSuffix)) {
-    const auto value =
-        error.substr(kRepeatCountPrefix.size(),
-                     error.size() - kRepeatCountPrefix.size() -
-                         kRepeatCountSuffix.size());
+    const auto value = error.substr(
+        kRepeatCountPrefix.size(),
+        error.size() - kRepeatCountPrefix.size() - kRepeatCountSuffix.size());
     return ::winux::i18n::format("command.tr.error.invalid_repeat_count",
                                  "invalid repeat count '{}' in [c*n] construct",
                                  value);
@@ -158,8 +157,9 @@ export std::string translate_error(std::string_view error) {
   if (error == "only one [c*] repeat construct may appear in string2") {
     return translate("command.tr.error.one_repeat_string2", error);
   }
-  if (error == "the [c*] construct may appear in string2 only when "
-               "translating") {
+  if (error ==
+      "the [c*] construct may appear in string2 only when "
+      "translating") {
     return translate("command.tr.error.repeat_only_translate", error);
   }
   // "'<token>': unary operator expected" — the value precedes the quote.
@@ -189,7 +189,27 @@ export std::string translate_error(std::string_view error) {
     return ::winux::i18n::format("command.csplit.error.match_not_found",
                                  "'{}': match not found", value);
   }
-  constexpr std::array<std::pair<std::string_view, std::string_view>, 29> exact{
+  // "'<spec>': invalid signal" / "'<spec>': multiple signals specified"
+  // (kill; [GNU] operand2sig wording, uutils #14177) — the spec precedes
+  // the quote-suffix.
+  constexpr std::string_view kInvalidSignalSuffix = "': invalid signal";
+  if (error.size() > kInvalidSignalSuffix.size() && error.starts_with('\'') &&
+      error.ends_with(kInvalidSignalSuffix)) {
+    const auto value =
+        error.substr(1, error.size() - 1 - kInvalidSignalSuffix.size());
+    return ::winux::i18n::format("command.kill.error.invalid_signal",
+                                 "'{}': invalid signal", value);
+  }
+  constexpr std::string_view kMultipleSignalsSuffix =
+      "': multiple signals specified";
+  if (error.size() > kMultipleSignalsSuffix.size() && error.starts_with('\'') &&
+      error.ends_with(kMultipleSignalsSuffix)) {
+    const auto value =
+        error.substr(1, error.size() - 1 - kMultipleSignalsSuffix.size());
+    return ::winux::i18n::format("command.kill.error.multiple_signals",
+                                 "'{}': multiple signals specified", value);
+  }
+  constexpr std::array<std::pair<std::string_view, std::string_view>, 30> exact{
       {{"invalid input", "common.error.invalid_input"},
        {"error reading from file", "common.error.read_file"},
        {"error reading input", "common.error.read_input"},
@@ -219,7 +239,9 @@ export std::string translate_error(std::string_view error) {
        {"failed to create hash object", "common.error.hash_object"},
        {"failed to get hash value", "common.error.hash_value"},
        {"tab size cannot be 0", "common.error.tab_zero"},
-       {"No such file or directory", "common.error.no_such_file"}}};
+       {"No such file or directory", "common.error.no_such_file"},
+       {"you must specify either '--size' or '--reference'",
+        "common.error.size_or_reference"}}};
   for (const auto [literal, key] : exact) {
     if (error == literal) return translate(key, error);
   }
@@ -251,7 +273,7 @@ export std::string translate_error(std::string_view error) {
     }
     return ::winux::i18n::format(key, "error reading '{}'", value);
   }
-  constexpr std::array<std::pair<std::string_view, std::string_view>, 35>
+  constexpr std::array<std::pair<std::string_view, std::string_view>, 39>
       quoted{
           {{"cannot open '", "common.error.cannot_open"},
            {"cannot access '", "common.error.cannot_access"},
@@ -289,7 +311,12 @@ export std::string translate_error(std::string_view error) {
            {"failed to access '", "common.error.failed_access"},
            {"failed to create symbolic link '", "common.error.create_symlink"},
            {"failed to remove '", "common.error.failed_remove"},
-           {"cannot open script file '", "common.error.open_script"}}};
+           {"cannot open script file '", "common.error.open_script"},
+           {"invalid gap width: '", "common.error.invalid_gap_width"},
+           {"invalid --parallel argument '",
+            "common.error.invalid_parallel_argument"},
+           {"Invalid number: '", "common.error.invalid_number"},
+           {"invalid field number: '", "common.error.invalid_field_number"}}};
   for (const auto [prefix, key] : quoted) {
     if (!error.starts_with(prefix) || error.back() != '\'') continue;
     const auto value =
@@ -306,7 +333,7 @@ export std::string translate_error(std::string_view error) {
       return ::winux::i18n::format(key, "error writing '{}'", value);
     if (key == "common.error.invalid_mode")
       return ::winux::i18n::format(key, "invalid mode: '{}'", value);
-    constexpr std::array<std::pair<std::string_view, std::string_view>, 29>
+    constexpr std::array<std::pair<std::string_view, std::string_view>, 33>
         fallbacks{
             {{"common.error.invalid_group", "invalid group: '{}'"},
              {"common.error.invalid_user", "invalid user: '{}'"},
@@ -324,8 +351,7 @@ export std::string translate_error(std::string_view error) {
              {"common.error.invalid_input_range", "invalid input range: '{}'"},
              {"common.error.invalid_line_count_value",
               "invalid line count: '{}'"},
-             {"common.error.invalid_wrap_value",
-              "invalid wrap size: '{}'"},
+             {"common.error.invalid_wrap_value", "invalid wrap size: '{}'"},
              {"common.error.invalid_num_bytes",
               "invalid number of bytes: '{}'"},
              {"common.error.invalid_num_columns",
@@ -352,7 +378,13 @@ export std::string translate_error(std::string_view error) {
              {"common.error.create_symlink",
               "failed to create symbolic link '{}'"},
              {"common.error.failed_remove", "failed to remove '{}'"},
-             {"common.error.open_script", "cannot open script file '{}'"}}};
+             {"common.error.open_script", "cannot open script file '{}'"},
+             {"common.error.invalid_gap_width", "invalid gap width: '{}'"},
+             {"common.error.invalid_parallel_argument",
+              "invalid --parallel argument '{}'"},
+             {"common.error.invalid_number", "Invalid number: '{}'"},
+             {"common.error.invalid_field_number",
+              "invalid field number: '{}'"}}};
     for (const auto [fallback_key, fallback] : fallbacks) {
       if (key == fallback_key)
         return ::winux::i18n::format(key, fallback, value);

--- a/tests/unit/ldd/ldd_unit_test.cpp
+++ b/tests/unit/ldd/ldd_unit_test.cpp
@@ -2,7 +2,7 @@
 
 TEST(ldd, lists_imports_for_winuxcmd_exe) {
   Pipeline p;
-  p.add(L"ldd.exe", {std::wstring(WINUXCMD_BIN_DIR) + L"/../winuxcmd.exe"});
+  p.add(L"ldd.exe", {std::wstring(WINUXCMD_BIN_DIR) + L"/winuxcmd.exe"});
 
   auto r = p.run();
 
@@ -15,7 +15,7 @@ TEST(ldd, lists_imports_for_winuxcmd_exe) {
 TEST(ldd, name_mode_prints_only_dll_names) {
   Pipeline p;
   p.add(L"ldd.exe",
-        {L"--name", std::wstring(WINUXCMD_BIN_DIR) + L"/../winuxcmd.exe"});
+        {L"--name", std::wstring(WINUXCMD_BIN_DIR) + L"/winuxcmd.exe"});
 
   auto r = p.run();
 
@@ -27,8 +27,7 @@ TEST(ldd, name_mode_prints_only_dll_names) {
 
 TEST(ldd, short_name_option_lists_imports) {
   Pipeline p;
-  p.add(L"ldd.exe",
-        {L"-n", std::wstring(WINUXCMD_BIN_DIR) + L"/../winuxcmd.exe"});
+  p.add(L"ldd.exe", {L"-n", std::wstring(WINUXCMD_BIN_DIR) + L"/winuxcmd.exe"});
 
   auto r = p.run();
 
@@ -41,7 +40,7 @@ TEST(ldd, short_name_option_lists_imports) {
 TEST(ldd, unused_option_lists_direct_dependencies) {
   Pipeline p;
   p.add(L"ldd.exe",
-        {L"--unused", std::wstring(WINUXCMD_BIN_DIR) + L"/../winuxcmd.exe"});
+        {L"--unused", std::wstring(WINUXCMD_BIN_DIR) + L"/winuxcmd.exe"});
 
   auto r = p.run();
 
@@ -54,7 +53,7 @@ TEST(ldd, unused_option_lists_direct_dependencies) {
 TEST(ldd, verbose_option_prints_version_heading) {
   Pipeline p;
   p.add(L"ldd.exe",
-        {L"--verbose", std::wstring(WINUXCMD_BIN_DIR) + L"/../winuxcmd.exe"});
+        {L"--verbose", std::wstring(WINUXCMD_BIN_DIR) + L"/winuxcmd.exe"});
 
   auto r = p.run();
 

--- a/tests/unit/sort/sort_unit_test.cpp
+++ b/tests/unit/sort/sort_unit_test.cpp
@@ -324,7 +324,7 @@ TEST(sort, sort_rejects_invalid_parallel_hint) {
   auto r = p.run();
 
   EXPECT_EQ(r.exit_code, 2);
-  EXPECT_TRUE(r.stderr_text.find("invalid parallel count") !=
+  EXPECT_TRUE(r.stderr_text.find("invalid --parallel argument '0'") !=
               std::string::npos);
 }
 


### PR DESCRIPTION
## Summary
- GNU parity fix batches: e51735d (pr/sort/ls/mktemp/kill/du) + 555821e (date/touch/numfmt/test/tsort/stat/readlink/shuf/split/du/true/false/hostname)
- Closed-issue differential audit now **112 PASS / 0 DIVERGE** (oracle: GNU 8.32)
- Notable fixes: touch honors TZ env for -t/-d (#7280), numfmt prepare-limit exits 1 (#12596), test bigint comparison (#12874), du hard-link dedup (#9202/#10241/#10312/#9871), shuf O(count) sampling for huge -i (#11167)
- i18n: new named keys (readlink/tsort/numfmt diagnostics); zh-CN catalog 0.6.2 in winuxcmd-i18n repo
- Contains merge with remote main (squash of 07c3ef4 via PR #194)

## Test plan
- [x] Differential audit 112/112 PASS
- [x] Unit tests 2408/2416 (8 env-related failures, same baseline as prior sessions)