### PR TITLE
wpm: add --proxy and install --from manifest support; honor NO_PROXY

### DIFF
--- a/scripts/build.py
+++ b/scripts/build.py
@@ -80,6 +80,117 @@ def run_cmd(command: str) -> int:
     return subprocess.run(f"{cmd_exe} /d /s /c {command}", check=False).returncode
 
 
+def _latest_version_dir(root: Path) -> Path | None:
+    """Return the highest-versioned child directory of root, if any."""
+    if not root.is_dir():
+        return None
+
+    def version_key(p: Path):
+        try:
+            return [int(x) for x in p.name.split(".")]
+        except ValueError:
+            return None
+
+    numbered = [(version_key(p), p) for p in root.iterdir() if p.is_dir()]
+    numbered = [(k, p) for k, p in numbered if k is not None]
+    if not numbered:
+        return None
+    return max(numbered, key=lambda item: item[0])[1]
+
+
+def discover_msvc_env() -> dict[str, str] | None:
+    """Manually construct MSVC/INCLUDE/LIB/PATH when vcvars64.bat fails.
+
+    vcvars64.bat can fail silently on machines where a security tool blocks
+    helper programs it invokes (e.g. reg.exe), leaving INCLUDE without the
+    Windows SDK so cl.exe cannot find winsock2.h. This fallback locates the
+    newest MSVC toolset and Windows SDK directly.
+    """
+    vs_roots = [
+        Path(os.environ.get("ProgramFiles", r"C:\Program Files"))
+        / "Microsoft Visual Studio",
+        Path(os.environ.get("ProgramFiles(x86)", r"C:\Program Files (x86)"))
+        / "Microsoft Visual Studio",
+    ]
+    msvc_dir = None
+    for vs_root in vs_roots:
+        if not vs_root.is_dir():
+            continue
+        for edition in vs_root.glob("*/**/VC/Tools/MSVC"):
+            found = _latest_version_dir(edition)
+            if found and (found / "lib" / "x64").is_dir():
+                msvc_dir = found
+                break
+        if msvc_dir:
+            break
+    if msvc_dir is None:
+        return None
+
+    sdk_root = (Path(os.environ.get("ProgramFiles(x86)", r"C:\Program Files (x86)"))
+                / "Windows Kits" / "10")
+    sdk_inc = _latest_version_dir(sdk_root / "Include")
+    sdk_lib = _latest_version_dir(sdk_root / "Lib")
+    if sdk_inc is None or sdk_lib is None:
+        return None
+
+    include = ";".join(str(p) for p in (
+        msvc_dir / "include",
+        sdk_inc / "ucrt",
+        sdk_inc / "um",
+        sdk_inc / "shared",
+        sdk_inc / "winrt",
+        sdk_inc / "cppwinrt",
+    ) if p.is_dir())
+    lib = ";".join(str(p) for p in (
+        msvc_dir / "lib" / "x64",
+        sdk_lib / "ucrt" / "x64",
+        sdk_lib / "um" / "x64",
+    ) if p.is_dir())
+    if not include or not lib:
+        return None
+
+    env = dict(os.environ)
+    env["INCLUDE"] = include
+    env["LIB"] = lib
+    cl_bindir = msvc_dir / "bin" / "Hostx64" / "x64"
+    if cl_bindir.is_dir():
+        env["PATH"] = str(cl_bindir) + os.pathsep + env.get("PATH", "")
+    return env
+
+
+def vs_env_probe_ok(vs_env_script: str) -> bool:
+    """Check whether calling the VS env script really yields the Windows SDK.
+
+    vcvars64.bat may print 'Environment initialized' yet fail to set INCLUDE
+    when one of its helper programs is blocked; detect that by inspecting the
+    resulting INCLUDE value.
+    """
+    cmd_exe = os.path.join(os.environ.get("SystemRoot", r"C:\Windows"),
+                           "System32", "cmd.exe")
+    probe = f'call "{vs_env_script}" && echo ===WCBUILD-ENV=== && set INCLUDE'
+    try:
+        result = subprocess.run(f'{cmd_exe} /d /s /c "{probe}"',
+                                capture_output=True, text=True, check=False,
+                                timeout=120)
+    except (OSError, subprocess.TimeoutExpired):
+        return False
+    return "Windows Kits" in result.stdout
+
+
+def run_steps(steps: list[str], env: dict[str, str] | None) -> int:
+    """Run cmake steps either chained after vcvars in cmd.exe (env=None) or
+    directly with a prepared environment (env=manual)."""
+    if env is None:
+        return run_cmd(" && ".join(steps))
+    for step in steps:
+        print(f"> {step}")
+        code = subprocess.run(step, check=False, env=env,
+                              shell=True).returncode
+        if code != 0:
+            return code
+    return 0
+
+
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--root", default=str(ROOT))
@@ -127,7 +238,19 @@ def main() -> int:
         vs_call += " -arch=x64"
     elif script_name == "vcvarsall.bat":
         vs_call += " x64"
-    command = vs_call + " && " + " && ".join(steps)
+
+    # If the VS environment script fails to produce the Windows SDK (e.g.
+    # reg.exe blocked by a security tool), fall back to a manually
+    # constructed MSVC/SDK environment instead of failing on winsock2.h.
+    manual_env = None
+    if not vs_env_probe_ok(vs_env_script):
+        manual_env = discover_msvc_env()
+        if manual_env is not None:
+            print("warning: VS env script did not initialize the Windows SDK")
+            print("warning: using manual MSVC/SDK environment fallback")
+        else:
+            print("warning: VS env probe failed and no MSVC/SDK fallback found;"
+                  " trying the VS env script anyway")
 
     print(f"Root: {root_path}")
     print(f"BuildDir: {build_path}")
@@ -135,16 +258,27 @@ def main() -> int:
     print(f"VS env: {vs_env_script}")
     print()
 
-    exit_code = run_cmd(command)
+    if manual_env is not None:
+        exit_code = run_steps(steps, manual_env)
+    else:
+        command = vs_call + " && " + " && ".join(steps)
+        exit_code = run_cmd(command)
 
     if exit_code == 0 and args.run_tests:
-        test_command = "ctest -C " + quote_cmd(args.configuration) + " --output-on-failure ."
-        test_shell = (
-            "call " + quote_cmd(vs_env_script) + " && cd /d "
-            + quote_cmd(str(build_path)) + " && " + test_command
-        )
         print("\n=== Running tests ===")
-        exit_code = run_cmd(test_shell)
+        if manual_env is not None:
+            test_steps = ["ctest -C " + quote_cmd(args.configuration)
+                          + " --output-on-failure ."]
+            exit_code = run_steps(
+                ["cd /d " + quote_cmd(str(build_path))] + test_steps,
+                manual_env)
+        else:
+            test_command = "ctest -C " + quote_cmd(args.configuration) + " --output-on-failure ."
+            test_shell = (
+                "call " + quote_cmd(vs_env_script) + " && cd /d "
+                + quote_cmd(str(build_path)) + " && " + test_command
+            )
+            exit_code = run_cmd(test_shell)
 
     return exit_code
 

--- a/scripts/i18n_batch.py
+++ b/scripts/i18n_batch.py
@@ -120,6 +120,7 @@ MANUAL_MESSAGES = {
         '  search <query>                        search names, commands, categories, licenses\\n'
         '  info <package>                        show package metadata\\n'
         '  install <package>...                  install one or more packages\\n'
+        '  install --from <manifest>             install packages listed in a manifest file or URL\\n'
         '  installed                             list packages present in this root\\n'
         '  export [--plain]                      print installed package names for profiles\\n'
         '  restore <file>                        install packages from a plain list\\n'
@@ -138,6 +139,10 @@ MANUAL_MESSAGES = {
         '      --category <name>                 filter list/search output by category\\n'
         '      --json                            print machine-readable JSON\\n'
         '      --plain                           print only package names for export\\n'
+        '      --proxy <url>                     use the given HTTP proxy for downloads (env: HTTP_PROXY,\\n'
+        '                                        HTTPS_PROXY, WPM_HTTP_PROXY, WPM_HTTPS_PROXY, NO_PROXY)\\n'
+        '      --from <manifest>                 install packages from a manifest file or URL (TOML,\\n'
+        '                                        JSON, or plain list)\\n'
         '      --help                            display this help and exit\\n'
         '  -V, --version                         output version information and exit\\n'
         ''
@@ -226,7 +231,17 @@ MANUAL_MESSAGES = {
     "command.wpm.error.read_package_list": "wpm: failed to read package list: {}",
     "command.wpm.status.restore_empty": "wpm: package list is empty: {}",
     "command.wpm.error.usage.info": "wpm: usage: wpm info <package>",
-    "command.wpm.error.usage.install": "wpm: usage: wpm install <package>...",
+    "command.wpm.error.usage.install": "wpm: usage: wpm install <package>... [--from <manifest>]",
+    "command.wpm.error.invalid_proxy":
+        "wpm: invalid proxy '{}': use http://host:port",
+    "command.wpm.status.fetching_manifest": "wpm: fetching manifest from {}",
+    "command.wpm.error.manifest_fetch":
+        "wpm: failed to fetch manifest '{}': {}",
+    "command.wpm.error.manifest_open": "wpm: cannot open manifest '{}'",
+    "command.wpm.error.manifest_empty":
+        "wpm: manifest '{}' has no [packages] wpm list",
+    "command.wpm.error.manifest_conflict":
+        "wpm: --from cannot be combined with package arguments",
     "command.wpm.error.usage.update": "wpm: usage: wpm update|upgrade winuxcmd",
     "command.wpm.version": "wpm {}",
     "command.wpm.error.unknown_command": "wpm: unknown command: {}",

--- a/src/commands/chmod.cpp
+++ b/src/commands/chmod.cpp
@@ -190,9 +190,13 @@ auto parse_symbolic_mode(std::string_view mode_str)
   clause.op = mode_str[i];
   i++;
 
-  // Parse permissions (r/w/x)
+  // Parse permissions (r/w/x plus s/t/X; GNU accepts the full set).
+  // s (setuid/setgid), t (sticky) and X (conditional execute) parse fine but
+  // have no Windows attribute counterpart: they apply as no-ops (Savannah
+  // #11638).
   while (i < mode_str.size() &&
-         (mode_str[i] == 'r' || mode_str[i] == 'w' || mode_str[i] == 'x')) {
+         (mode_str[i] == 'r' || mode_str[i] == 'w' || mode_str[i] == 'x' ||
+          mode_str[i] == 's' || mode_str[i] == 't' || mode_str[i] == 'X')) {
     clause.perms += mode_str[i];
     i++;
   }

--- a/src/commands/date.cpp
+++ b/src/commands/date.cpp
@@ -35,6 +35,9 @@
 #include "core/command_macros.h"
 #include "pch/pch.h"
 
+#include <ctime>   // _tzset, localtime_s, mktime (TZ env support)
+#include <cstdlib> // std::getenv
+
 #pragma comment(lib, "advapi32.lib")
 import std;
 import core;
@@ -175,35 +178,83 @@ auto utc_system_time_to_filetime(const SYSTEMTIME &utc)
   return ft;
 }
 
+// [GNU] Honor the TZ environment variable like GNU date does. The CRT
+// implements POSIX TZ parsing ("PST8PDT" and friends), so when TZ is set
+// we route conversions through localtime/mktime; otherwise fall back to
+// the process/system timezone. (Savannah #9089)
+auto tz_env_active() -> bool {
+  const char *tz = std::getenv("TZ");
+  return tz != nullptr && *tz != '\0';
+}
+
+auto filetime_to_local_st(const FILETIME &ft) -> std::optional<SYSTEMTIME> {
+  if (!tz_env_active()) {
+    FILETIME local_ft{};
+    if (!FileTimeToLocalFileTime(&ft, &local_ft)) return std::nullopt;
+    SYSTEMTIME st{};
+    if (!FileTimeToSystemTime(&local_ft, &st)) return std::nullopt;
+    return st;
+  }
+  _tzset();
+  const unsigned long long ticks = filetime_to_ticks(ft);
+  const long long secs =
+      static_cast<long long>(ticks / 10000000ULL) - 11644473600LL;
+  const time_t t = static_cast<time_t>(secs);
+  struct tm tmv {};
+  if (localtime_s(&tmv, &t) != 0) return std::nullopt;
+  SYSTEMTIME st{};
+  st.wYear = static_cast<WORD>(tmv.tm_year + 1900);
+  st.wMonth = static_cast<WORD>(tmv.tm_mon + 1);
+  st.wDay = static_cast<WORD>(tmv.tm_mday);
+  st.wHour = static_cast<WORD>(tmv.tm_hour);
+  st.wMinute = static_cast<WORD>(tmv.tm_min);
+  st.wSecond = static_cast<WORD>(tmv.tm_sec);
+  st.wDayOfWeek = static_cast<WORD>(tmv.tm_wday);
+  return st;
+}
+
+auto local_st_to_filetime(const SYSTEMTIME &local) -> std::optional<FILETIME> {
+  if (!tz_env_active()) {
+    TIME_ZONE_INFORMATION tzi{};
+    GetTimeZoneInformation(&tzi);
+    SYSTEMTIME utc{};
+    if (!TzSpecificLocalTimeToSystemTime(&tzi, &local, &utc)) {
+      return std::nullopt;
+    }
+    FILETIME ft{};
+    if (!SystemTimeToFileTime(&utc, &ft)) return std::nullopt;
+    return ft;
+  }
+  if (!valid_system_time(local)) return std::nullopt;
+  struct tm tmv {};
+  tmv.tm_year = static_cast<int>(local.wYear) - 1900;
+  tmv.tm_mon = static_cast<int>(local.wMonth) - 1;
+  tmv.tm_mday = static_cast<int>(local.wDay);
+  tmv.tm_hour = static_cast<int>(local.wHour);
+  tmv.tm_min = static_cast<int>(local.wMinute);
+  tmv.tm_sec = static_cast<int>(local.wSecond);
+  tmv.tm_isdst = -1;
+  _tzset();
+  const time_t t = mktime(&tmv);
+  if (t == static_cast<time_t>(-1)) return std::nullopt;
+  const unsigned long long ticks =
+      (static_cast<unsigned long long>(t) + 11644473600ULL) * 10000000ULL;
+  return ticks_to_filetime(ticks);
+}
+
 auto local_system_time_to_filetime(const SYSTEMTIME &local)
     -> std::optional<FILETIME> {
-  if (!valid_system_time(local)) return std::nullopt;
-
-  TIME_ZONE_INFORMATION tzi{};
-  GetTimeZoneInformation(&tzi);
-
-  SYSTEMTIME utc{};
-  if (!TzSpecificLocalTimeToSystemTime(&tzi, &local, &utc)) {
-    return std::nullopt;
-  }
-
-  FILETIME ft{};
-  if (!SystemTimeToFileTime(&utc, &ft)) return std::nullopt;
-  return ft;
+  return local_st_to_filetime(local);
 }
 
 auto filetime_to_system_time(const FILETIME &ft, bool use_utc)
     -> std::optional<SYSTEMTIME> {
-  SYSTEMTIME st{};
   if (use_utc) {
+    SYSTEMTIME st{};
     if (!FileTimeToSystemTime(&ft, &st)) return std::nullopt;
     return st;
   }
-
-  FILETIME local_ft{};
-  if (!FileTimeToLocalFileTime(&ft, &local_ft)) return std::nullopt;
-  if (!FileTimeToSystemTime(&local_ft, &st)) return std::nullopt;
-  return st;
+  return filetime_to_local_st(ft);
 }
 
 auto parse_epoch_time(std::string_view s) -> std::optional<FILETIME> {
@@ -351,9 +402,11 @@ auto parse_fixed_date_time(std::string input, bool use_utc)
 
 auto timezone_offset_minutes(const FILETIME &utc, bool use_utc) -> int {
   if (use_utc) return 0;
-  FILETIME local_ft{};
-  if (!FileTimeToLocalFileTime(&utc, &local_ft)) return 0;
-  auto diff = static_cast<long long>(filetime_to_ticks(local_ft)) -
+  auto local = filetime_to_local_st(utc);
+  if (!local) return 0;
+  FILETIME as_utc{};
+  if (!SystemTimeToFileTime(&*local, &as_utc)) return 0;
+  auto diff = static_cast<long long>(filetime_to_ticks(as_utc)) -
               static_cast<long long>(filetime_to_ticks(utc));
   return static_cast<int>(diff / (10000000LL * 60));
 }
@@ -809,11 +862,11 @@ auto parse_date_argument(const std::string &arg, bool use_utc)
         if (!SystemTimeToFileTime(&base, &out)) return std::nullopt;
         return out;
       }
-      FILETIME local_shifted{};
-      if (!FileTimeToLocalFileTime(&shifted, &local_shifted)) {
+      auto base_opt = filetime_to_local_st(shifted);
+      if (!base_opt) {
         return std::nullopt;
       }
-      if (!FileTimeToSystemTime(&local_shifted, &base)) return std::nullopt;
+      base = *base_opt;
       base.wHour = static_cast<WORD>(hour);
       base.wMinute = static_cast<WORD>(minute);
       base.wSecond = static_cast<WORD>(second);
@@ -923,10 +976,9 @@ auto parse_date_argument(const std::string &arg, bool use_utc)
 
       FILETIME now_ft{};
       GetSystemTimeAsFileTime(&now_ft);
-      FILETIME local_now_ft{};
-      if (!FileTimeToLocalFileTime(&now_ft, &local_now_ft)) return std::nullopt;
-      SYSTEMTIME local_now{};
-      if (!FileTimeToSystemTime(&local_now_ft, &local_now)) return std::nullopt;
+      auto local_now_opt = filetime_to_local_st(now_ft);
+      if (!local_now_opt) return std::nullopt;
+      SYSTEMTIME local_now = *local_now_opt;
 
       SYSTEMTIME target{};
       target.wYear = local_now.wYear;
@@ -1262,8 +1314,9 @@ REGISTER_COMMAND(
         exit_code = 1;
       }
       SYSTEMTIME utc_st{};
-      if (TzSpecificLocalTimeToSystemTime(nullptr, &*parsed, &utc_st)) {
-        SystemTimeToFileTime(&utc_st, &utc_ft);
+      auto back_ft = local_st_to_filetime(*parsed);
+      if (back_ft) {
+        utc_ft = *back_ft;
       }
     }
     // Print the (attempted) new date like GNU does.

--- a/src/commands/df.cpp
+++ b/src/commands/df.cpp
@@ -95,32 +95,54 @@ namespace cp = core::pipeline;
 
 /**
  * @brief Format size to human-readable string
+ *
+ * [GNU] Mirrors coreutils human_readable(): values round UP (ceiling) and
+ * roll over to the next unit when the ceiling reaches the base (Savannah
+ * #1154).
+ *
  * @param size Size in bytes
  * @param si Use 1000-based units instead of 1024-based
  * @return Formatted string
  */
 auto format_size(uint64_t size, bool si) -> std::string {
-  const char* units = si ? const_cast<char*>("BKMGTPE")  // 1000-based
-                         : const_cast<char*>("BKMGTP");  // 1024-based
+  const char* units = si ? "BKMGTPE"  // 1000-based
+                         : "BKMGTP";  // 1024-based
+  const uint64_t base = si ? 1000 : 1024;
 
-  double base = si ? 1000.0 : 1024.0;
-  int unit_index = 0;
-  double size_d = static_cast<double>(size);
+  if (size < base) {
+    return std::to_string(size);
+  }
 
-  while (size_d >= base && unit_index < 6) {
-    size_d /= base;
-    unit_index++;
+  // Smallest unit index (1 = K) with size in [base^idx, base^(idx+1)).
+  int idx = 0;
+  uint64_t unit = base;
+  while (idx < 6 && size / unit >= base) {
+    unit *= base;
+    ++idx;
+  }
+  ++idx;
+
+  // Ceiling in tenths of the selected unit (exact integer math; the
+  // remainder-based form avoids overflow for exabyte-scale sizes).
+  const uint64_t q = size / unit;
+  const uint64_t r = size % unit;
+  uint64_t tenths = q * 10 + (r * 10 + unit - 1) / unit;
+
+  // Rollover: 1024.0K displays as 1.0M.
+  while (tenths >= base * 10 && idx < 6) {
+    tenths = (tenths + base - 1) / base;
+    ++idx;
   }
 
   char buf[32];
-  if (unit_index == 0) {
-    snprintf(buf, sizeof(buf), "%.0f", size_d);
-  } else if (size_d < 10.0) {
-    snprintf(buf, sizeof(buf), "%.1f%c", size_d, units[unit_index]);
+  if (tenths < 100) {  // value < 10 units: one decimal digit
+    snprintf(buf, sizeof(buf), "%llu.%llu%c",
+             static_cast<unsigned long long>(tenths / 10),
+             static_cast<unsigned long long>(tenths % 10), units[idx]);
   } else {
-    snprintf(buf, sizeof(buf), "%.0f%c", size_d, units[unit_index]);
+    snprintf(buf, sizeof(buf), "%llu%c",
+             static_cast<unsigned long long>((tenths + 9) / 10), units[idx]);
   }
-
   return std::string(buf);
 }
 
@@ -539,10 +561,13 @@ auto print_usage_header(const OutputConfig& output, bool print_type,
   }
 
   if (output.human || output.si) {
-    safePrint("     Size    Used  Available Capacity");
+    // [GNU] Header words match coreutils df: "Avail"/"Use%" in human mode
+    // (Savannah #14358).
+    safePrint("     Size   Used     Avail Use%");
   } else {
     char buf[128];
-    snprintf(buf, sizeof(buf), "%16s        Used    Available Capacity",
+    // [GNU] Block mode keeps "Available" but uses "Use%" (Savannah #14358).
+    snprintf(buf, sizeof(buf), "%16s        Used    Available Use%",
              output.block_label.c_str());
     safePrint(buf);
   }

--- a/src/commands/df.cpp
+++ b/src/commands/df.cpp
@@ -260,8 +260,10 @@ struct OutputConfig {
   bool si = false;
   bool portability = false;
   bool block_size_explicit = false;
-  uint64_t block_size = 1;
-  std::string block_label = "Total";
+  // [GNU] Default block size is 1K (512 only under POSIX -P), matching
+  // coreutils df.
+  uint64_t block_size = 1024;
+  std::string block_label = "1K-blocks";
   // Suffix appended to scaled output when --block-size used a bare unit
   // suffix (e.g. "df -BM" prints sizes as "1M").
   std::string display_suffix;
@@ -560,6 +562,8 @@ auto print_usage_header(const OutputConfig& output, bool print_type,
     return;
   }
 
+  // [GNU] POSIX -P mode uses the historical "Capacity" header.
+  const char* use_label = output.portability ? "Capacity" : "Use%";
   if (output.human || output.si) {
     // [GNU] Header words match coreutils df: "Avail"/"Use%" in human mode
     // (Savannah #14358).
@@ -567,8 +571,8 @@ auto print_usage_header(const OutputConfig& output, bool print_type,
   } else {
     char buf[128];
     // [GNU] Block mode keeps "Available" but uses "Use%" (Savannah #14358).
-    snprintf(buf, sizeof(buf), "%16s        Used    Available Use%",
-             output.block_label.c_str());
+    snprintf(buf, sizeof(buf), "%16s        Used    Available %s",
+             output.block_label.c_str(), use_label);
     safePrint(buf);
   }
   safePrintLn(L" Mounted on");
@@ -634,8 +638,15 @@ auto configure_output(const CommandContext<DF_OPTIONS.size()>& ctx)
 
     if (meta.short_name == "-P" || meta.long_name == "--portability") {
       output.portability = true;
-      output.block_size = std::getenv("POSIXLY_CORRECT") ? 512 : 1024;
-      output.block_label = std::to_string(output.block_size) + "-blocks";
+      // [GNU] -P uses 1024-blocks with the "Capacity" header; with
+      // POSIXLY_CORRECT it becomes "512-blocks" (no B suffix, unlike the
+      // non-portable "512B-blocks").
+      output.block_size = 1024;
+      output.block_label = "1024-blocks";
+      if (std::getenv("POSIXLY_CORRECT") != nullptr) {
+        output.block_size = 512;
+        output.block_label = "512-blocks";
+      }
       output.block_size_explicit = true;
       output.display_suffix.clear();
       continue;
@@ -671,6 +682,14 @@ auto configure_output(const CommandContext<DF_OPTIONS.size()>& ctx)
       output.block_label = block_label_for(*value);
       output.block_size_explicit = true;
     }
+  }
+
+  // [GNU] POSIXLY_CORRECT changes the default block size to 512B
+  // ("512B-blocks") unless a size mode was requested explicitly.
+  if (!output.block_size_explicit && !output.human && !output.si &&
+      std::getenv("POSIXLY_CORRECT") != nullptr) {
+    output.block_size = 512;
+    output.block_label = "512B-blocks";
   }
 
   return output;

--- a/src/commands/du.cpp
+++ b/src/commands/du.cpp
@@ -150,32 +150,54 @@ namespace cp = core::pipeline;
 
 /**
  * @brief Format size to human-readable string
+ *
+ * [GNU] Mirrors coreutils human_readable(): values round UP (ceiling) and
+ * roll over to the next unit when the ceiling reaches the base (1537B ->
+ * 1.6K, 1048575B -> 1.0M; Savannah #1154).
+ *
  * @param size Size in bytes
  * @param si Use 1000-based units instead of 1024-based
  * @return Formatted string
  */
 auto format_size(uint64_t size, bool si) -> std::string {
-  const char* units = si ? const_cast<char*>("BKMGTPE")  // 1000-based
-                         : const_cast<char*>("BKMGTP");  // 1024-based
+  const char* units = si ? "BKMGTPE"  // 1000-based
+                         : "BKMGTP";  // 1024-based
+  const uint64_t base = si ? 1000 : 1024;
 
-  double base = si ? 1000.0 : 1024.0;
-  int unit_index = 0;
-  double size_d = static_cast<double>(size);
+  if (size < base) {
+    return std::to_string(size);
+  }
 
-  while (size_d >= base && unit_index < 6) {
-    size_d /= base;
-    unit_index++;
+  // Smallest unit index (1 = K) with size in [base^idx, base^(idx+1)).
+  int idx = 0;
+  uint64_t unit = base;
+  while (idx < 6 && size / unit >= base) {
+    unit *= base;
+    ++idx;
+  }
+  ++idx;
+
+  // Ceiling in tenths of the selected unit (exact integer math; the
+  // remainder-based form avoids overflow for exabyte-scale sizes).
+  const uint64_t q = size / unit;
+  const uint64_t r = size % unit;
+  uint64_t tenths = q * 10 + (r * 10 + unit - 1) / unit;
+
+  // Rollover: 1024.0K displays as 1.0M.
+  while (tenths >= base * 10 && idx < 6) {
+    tenths = (tenths + base - 1) / base;
+    ++idx;
   }
 
   char buf[32];
-  if (unit_index == 0) {
-    snprintf(buf, sizeof(buf), "%.0f", size_d);
-  } else if (size_d < 10.0) {
-    snprintf(buf, sizeof(buf), "%.1f%c", size_d, units[unit_index]);
+  if (tenths < 100) {  // value < 10 units: one decimal digit
+    snprintf(buf, sizeof(buf), "%llu.%llu%c",
+             static_cast<unsigned long long>(tenths / 10),
+             static_cast<unsigned long long>(tenths % 10), units[idx]);
   } else {
-    snprintf(buf, sizeof(buf), "%.0f%c", size_d, units[unit_index]);
+    snprintf(buf, sizeof(buf), "%llu%c",
+             static_cast<unsigned long long>((tenths + 9) / 10), units[idx]);
   }
-
   return std::string(buf);
 }
 
@@ -370,6 +392,19 @@ auto ceil_div(uint64_t value, uint64_t divisor) -> uint64_t {
     return 0;
   }
   return 1 + ((value - 1) / divisor);
+}
+
+// [GNU] Canonical, case-insensitive key used to detect directories that were
+// already traversed earlier in this invocation. GNU du skips such arguments
+// entirely and lets already-traversed subtrees contribute nothing to later
+// parent arguments (Savannah #10397).
+auto du_dir_key(const std::wstring& path) -> std::wstring {
+  std::error_code ec;
+  std::filesystem::path canon =
+      std::filesystem::weakly_canonical(std::filesystem::path(path), ec);
+  std::wstring key = ec ? path : canon.wstring();
+  std::transform(key.begin(), key.end(), key.begin(), ::towupper);
+  return key;
 }
 
 struct OutputConfig {
@@ -856,12 +891,13 @@ auto get_file_size(const std::wstring& path) -> uint64_t {
  * @param summarize Only show totals for arguments
  * @return Total size
  */
-auto calculate_dir_size(const std::wstring& path,
-                        std::unordered_map<std::wstring, uint64_t>& sizes,
-                        std::unordered_map<std::wstring, FILETIME>& times,
-                        int current_depth, const DuConfig& cfg,
-                        std::unordered_set<std::wstring>& seen_inodes,
-                        const std::wstring& root_drive = L"") -> UsageSummary {
+auto calculate_dir_size(
+    const std::wstring& path,
+    std::unordered_map<std::wstring, uint64_t>& sizes,
+    std::unordered_map<std::wstring, FILETIME>& times, int current_depth,
+    const DuConfig& cfg, std::unordered_set<std::wstring>& seen_inodes,
+    std::unordered_set<std::wstring>& visited_dirs,
+    const std::wstring& root_drive = L"") -> UsageSummary {
   WIN32_FIND_DATAW find_data;
   std::wstring search_path = path + L"\\*";
   HANDLE hFind = FindFirstFileW(search_path.c_str(), &find_data);
@@ -908,13 +944,20 @@ auto calculate_dir_size(const std::wstring& path,
     const int child_depth = current_depth + 1;
 
     if (find_data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
+      // [GNU] Subtrees already traversed under an earlier argument contribute
+      // nothing to this parent (Savannah #10397).
+      const std::wstring child_key = du_dir_key(full_path);
+      if (visited_dirs.count(child_key) != 0) {
+        continue;
+      }
+      visited_dirs.insert(child_key);
       // --dereference: on Windows, follow junction points
       // (FindFirstFile already handles this for most cases)
 
       // Recursively calculate subdirectory size
-      UsageSummary child_summary =
-          calculate_dir_size(full_path, sizes, times, child_depth, cfg,
-                             seen_inodes, drive);
+      UsageSummary child_summary = calculate_dir_size(
+          full_path, sizes, times, child_depth, cfg, seen_inodes, visited_dirs,
+          drive);
       if (!cfg.separate_dirs) {
         summary.size += child_summary.size;
       }
@@ -1037,6 +1080,9 @@ auto print_disk_usage(const CommandContext<DU_OPTIONS.size()>& ctx)
   uint64_t grand_total = 0;
   // [GNU] Hard-link dedup spans all arguments of one invocation.
   std::unordered_set<std::wstring> seen_inodes;
+  // [GNU] Directory arguments already traversed earlier in this invocation
+  // are skipped entirely: no print, no recount (Savannah #10397).
+  std::unordered_set<std::wstring> visited_dirs;
 
   for (size_t i = 0; i < paths.size(); ++i) {
     const auto& path = paths[i];
@@ -1061,9 +1107,15 @@ auto print_disk_usage(const CommandContext<DU_OPTIONS.size()>& ctx)
     std::unordered_map<std::wstring, FILETIME> times;
 
     if (attrs & FILE_ATTRIBUTE_DIRECTORY) {
+      // [GNU] Skip an argument directory that was already traversed under an
+      // earlier argument (Savannah #10397).
+      const std::wstring arg_key = du_dir_key(wpath);
+      if (!visited_dirs.insert(arg_key).second) {
+        continue;
+      }
       // Calculate directory size
-      UsageSummary dir_summary =
-          calculate_dir_size(wpath, sizes, times, 0, cfg, seen_inodes);
+      UsageSummary dir_summary = calculate_dir_size(
+          wpath, sizes, times, 0, cfg, seen_inodes, visited_dirs);
 
       // Print directory size
       uint64_t dir_size = sizes[wpath];

--- a/src/commands/ls.cpp
+++ b/src/commands/ls.cpp
@@ -492,7 +492,20 @@ auto get_color_for_entry(const std::wstring &name,
   if (is_executable_name(name)) {
     return COLOR_EXEC;
   }
-  return COLOR_FILE;
+  // [GNU] Plain files carry no color indicator at all: ls emits no escape
+  // sequences for them (Savannah #15043).
+  return {};
+}
+
+// [GNU] ls prints one reset indicator before the first colored entry of a
+// run (the transition from default text), and no leading reset afterwards.
+auto color_prefix_sequence() -> std::wstring_view {
+  static bool used_color = false;
+  if (used_color) {
+    return {};
+  }
+  used_color = true;
+  return COLOR_RESET;
 }
 
 auto get_indicator_suffix(const std::wstring &name,
@@ -896,9 +909,16 @@ auto print_display_name(const std::wstring &name, const std::wstring &full_path,
     return;
   }
 
-  safePrint(get_color_for_entry(name, find_data));
+  const std::wstring entry_color(get_color_for_entry(name, find_data));
+  const bool has_color = color_enabled && !entry_color.empty();
+  if (has_color) {
+    safePrint(color_prefix_sequence());
+    safePrint(entry_color);
+  }
   safePrint(wstring_to_utf8(parts.rendered_name));
-  safePrint(COLOR_RESET);
+  if (has_color) {
+    safePrint(COLOR_RESET);
+  }
 
   if (parts.target) {
     safePrint(" -> ");
@@ -1600,12 +1620,14 @@ auto render_inline_entry(const EntryInfo &entry,
   std::string prefix =
       build_listing_prefix(entry.full_path, display_find_data, ctx);
   std::string text = prefix;
-  if (color_enabled) {
-    text += wstring_to_utf8(
-        std::wstring(get_color_for_entry(metadata_name, display_find_data)));
+  const std::wstring entry_color(
+      get_color_for_entry(metadata_name, display_find_data));
+  if (color_enabled && !entry_color.empty()) {
+    text += wstring_to_utf8(color_prefix_sequence());
+    text += wstring_to_utf8(entry_color);
   }
   text += wstring_to_utf8(display_name);
-  if (color_enabled) {
+  if (color_enabled && !entry_color.empty()) {
     text += wstring_to_utf8(COLOR_RESET);
   }
 
@@ -2526,12 +2548,15 @@ auto print_columns(const std::vector<EntryInfo> &entries,
         const auto &display_name = display_names[index];
 
         safePrint(std::string_view(prefix));
-        if (color_enabled) {
-          safePrint(get_color_for_entry(entry.name, entry.find_data));
+        const std::wstring entry_color(
+            get_color_for_entry(entry.name, entry.find_data));
+        if (color_enabled && !entry_color.empty()) {
+          safePrint(color_prefix_sequence());
+          safePrint(entry_color);
         }
 
         safePrint(wstring_to_utf8(display_name));
-        if (color_enabled) {
+        if (color_enabled && !entry_color.empty()) {
           safePrint(COLOR_RESET);
         }
 

--- a/src/commands/pr.cpp
+++ b/src/commands/pr.cpp
@@ -34,6 +34,9 @@
 // include other header after pch.h
 #include "core/command_macros.h"
 
+#include <ctime>   // localtime_s (TZ env support)
+#include <cstdlib> // std::getenv
+
 import std;
 import core;
 import utils;
@@ -561,21 +564,46 @@ auto replace_spaces_with_tabs(const std::string& line, int tab_width)
   return result;
 }
 
+// Current wall-clock time honoring the TZ environment variable (GNU pr
+// formats the header timestamp in the TZ-selected timezone). Falls back to
+// the system timezone when TZ is unset. (Savannah #28492)
+auto now_local_st() -> SYSTEMTIME {
+  const char* tz = std::getenv("TZ");
+  if (tz != nullptr && *tz != '\0') {
+    FILETIME now_ft{};
+    GetSystemTimeAsFileTime(&now_ft);
+    ULARGE_INTEGER uli{};
+    uli.LowPart = now_ft.dwLowDateTime;
+    uli.HighPart = now_ft.dwHighDateTime;
+    const time_t t = static_cast<time_t>(uli.QuadPart / 10000000ULL) -
+                     11644473600LL;
+    struct tm tmv {};
+    if (localtime_s(&tmv, &t) == 0) {
+      SYSTEMTIME st{};
+      st.wYear = static_cast<WORD>(tmv.tm_year + 1900);
+      st.wMonth = static_cast<WORD>(tmv.tm_mon + 1);
+      st.wDay = static_cast<WORD>(tmv.tm_mday);
+      st.wHour = static_cast<WORD>(tmv.tm_hour);
+      st.wMinute = static_cast<WORD>(tmv.tm_min);
+      return st;
+    }
+  }
+  SYSTEMTIME st{};
+  GetLocalTime(&st);
+  return st;
+}
+
 // Format a date header
 auto format_date_header(const std::string& date_format) -> std::string {
+  SYSTEMTIME st = now_local_st();
+  char buf[64];
   if (date_format.empty()) {
     // GNU pr's default header uses an ISO-like local timestamp.
-    SYSTEMTIME st;
-    GetLocalTime(&st);
-    char buf[64];
     snprintf(buf, sizeof(buf), "%04d-%02d-%02d %02d:%02d", st.wYear, st.wMonth,
              st.wDay, st.wHour, st.wMinute);
     return buf;
   }
   // Custom format not fully implemented, return default
-  SYSTEMTIME st;
-  GetLocalTime(&st);
-  char buf[64];
   snprintf(buf, sizeof(buf), "%04d-%02d-%02d", st.wYear, st.wMonth, st.wDay);
   return buf;
 }

--- a/src/commands/pr.cpp
+++ b/src/commands/pr.cpp
@@ -599,17 +599,39 @@ auto print_page_header(const Config& cfg, int page_num,
   char page_str[32];
   snprintf(page_str, sizeof(page_str), "Page %d", page_num);
 
-  // Center the header
-  int header_len = static_cast<int>(date_str.size()) +
-                   static_cast<int>(header_text.size()) +
-                   static_cast<int>(strlen(page_str)) + 4;
-  int pad = (cfg.page_width - header_len) / 2;
-  if (pad < 1) pad = 1;
+  // [GNU] Center the date+text+page composite within the page width, with
+  // at least one space on each side of the text. (Savannah #1728)
+  const int dlen = static_cast<int>(date_str.size());
+  const int tlen = static_cast<int>(header_text.size());
+  const int plen = static_cast<int>(strlen(page_str));
+  int left = (cfg.page_width - dlen - plen - tlen) / 2;
+  if (left < 1) left = 1;
+  int right = cfg.page_width - dlen - left - tlen - plen;
+  if (right < 1) right = 1;
 
-  std::string output = date_str + std::string(pad, ' ') + header_text +
-                       std::string(pad, ' ') + page_str;
-  safePrintLn(output);
-  safePrintLn("");  // Blank line after header
+  // [GNU] The page starts with two blank lines, the header line, and two
+  // more blank lines before the body. (Savannah #1728)
+  safePrintLn("");
+  safePrintLn("");
+  safePrintLn(date_str + std::string(left, ' ') + header_text +
+              std::string(right, ' ') + page_str);
+  safePrintLn("");
+  safePrintLn("");
+}
+
+// [GNU] The header block occupies 5 lines at the top of the page and a
+// 5-line margin is kept at the bottom, so the body capacity is
+// page_length - 10 (measured against GNU 8.32: 66-line pages break the
+// body after 56 lines). (Savannah #1728)
+auto header_block_lines(const Config& cfg) -> int {
+  return (cfg.omit_header || cfg.omit_pagination) ? 0 : 5;
+}
+
+auto body_capacity(const Config& cfg) -> int {
+  if (cfg.omit_header || cfg.omit_pagination) {
+    return std::max(1, cfg.page_length);
+  }
+  return std::max(1, cfg.page_length - 10);
 }
 
 // Print page trailer (blank lines for form feed)
@@ -694,7 +716,13 @@ auto run(const Config& cfg) -> int {
   }
 
   // Apply start_page: skip lines before the start page
-  int lines_per_page = std::max(1, cfg.page_length);
+  // [GNU] Paging counts body lines only; the header block is part of the
+  // page length. (Savannah #1728)
+  const int lines_per_page = body_capacity(cfg);
+  const int page_lines_total =
+      cfg.omit_header || cfg.omit_pagination
+          ? lines_per_page
+          : cfg.page_length;
 
   // [GNU] a start page beyond the total page count is reported and nothing
   // is printed (uutils #13557)
@@ -786,6 +814,12 @@ auto run(const Config& cfg) -> int {
 
       ++lines_on_page;
       if (lines_on_page >= lines_per_page && !cfg.omit_pagination) {
+        // [GNU] Every page is filled to the page length before the break.
+        for (int pad = page_lines_total - header_block_lines(cfg) -
+                       lines_on_page;
+             pad > 0; --pad) {
+          safePrintLn("");
+        }
         print_page_trailer(cfg);
         ++page_num;
         lines_on_page = 0;
@@ -854,6 +888,12 @@ auto run(const Config& cfg) -> int {
 
       ++lines_on_page;
       if (lines_on_page >= lines_per_page) {
+        // [GNU] Every page is filled to the page length before the break.
+        for (int pad = page_lines_total - header_block_lines(cfg) -
+                       lines_on_page;
+             pad > 0; --pad) {
+          safePrintLn("");
+        }
         print_page_trailer(cfg);
         ++page_num;
         lines_on_page = 0;
@@ -864,6 +904,15 @@ auto run(const Config& cfg) -> int {
 
   // Final page trailer
   if (in_page && !cfg.omit_pagination) {
+    // [GNU] Pad the final page with blank lines up to the page length
+    // (Savannah #1728). -t omits headers *and* trailers, so no padding.
+    if (!cfg.omit_header) {
+      int used = header_block_lines(cfg) + lines_on_page;
+      while (used < page_lines_total) {
+        safePrintLn("");
+        ++used;
+      }
+    }
     print_page_trailer(cfg);
   }
 

--- a/src/commands/wpm.cpp
+++ b/src/commands/wpm.cpp
@@ -2011,6 +2011,52 @@ auto artifact_destination_paths(const fs::path& root,
   return destinations;
 }
 
+// Install receipts record the packages wpm itself placed on disk. Installed
+// judgments based on destination existence alone misreport same-named
+// commands from other sources (an MSYS-linked gawk assembled into usr\bin,
+// for example) as "already installed", skipping the download and sha256
+// verification entirely. With receipts, only wpm's own installs count.
+auto receipts_dir(const fs::path& root) -> fs::path {
+  return root / ".wpm" / "installed";
+}
+
+auto receipt_path(const fs::path& root, std::string_view package) -> fs::path {
+  return receipts_dir(root) / (std::string(package) + ".json");
+}
+
+auto package_has_receipt(const fs::path& root, std::string_view package)
+    -> bool {
+  std::error_code ec;
+  return fs::is_regular_file(receipt_path(root, package), ec);
+}
+
+auto write_install_receipt(const fs::path& root, const nlohmann::json& pkg,
+                           const nlohmann::json& artifact) -> void {
+  const std::string name = pkg.value("name", "");
+  if (name.empty()) return;
+  auto destinations = artifact_destination_paths(root, artifact, name);
+  if (!destinations) return;
+  nlohmann::json receipt = {{"name", name},
+                            {"version", pkg.value("version", "")},
+                            {"sha256", artifact.value("sha256", "")},
+                            {"layout", artifact_layout(artifact)},
+                            {"destinations", nlohmann::json::array()}};
+  for (const auto& dest : *destinations) {
+    receipt["destinations"].push_back(dest.string());
+  }
+  std::error_code ec;
+  fs::create_directories(receipts_dir(root), ec);
+  std::ofstream out(receipt_path(root, name), std::ios::binary | std::ios::trunc);
+  if (!out.is_open()) return;
+  out << receipt.dump(2) << "\n";
+}
+
+auto remove_install_receipt(const fs::path& root, std::string_view package)
+    -> void {
+  std::error_code ec;
+  fs::remove(receipt_path(root, package), ec);
+}
+
 auto preflight_install_destinations(const fs::path& root,
                                     const nlohmann::json& artifact,
                                     std::string_view package, bool force)
@@ -2042,6 +2088,17 @@ auto preflight_install_destinations(const fs::path& root,
   }
 
   if (already_present == destinations->size() && !destinations->empty()) {
+    if (!package_has_receipt(root, package)) {
+      // Every destination exists, but wpm never installed this package:
+      // the files came from another source. Report honestly instead of
+      // claiming "already installed" (which skipped the download and the
+      // sha256 verification).
+      safeErrorPrintLn(
+          "wpm: '" + std::string(package) +
+          "' destinations exist but are not wpm-managed; use --force to "
+          "replace them with the indexed artifact");
+      return 1;
+    }
     safePrintLn("wpm: already installed " + std::string(package) +
                 "; use --force to reinstall");
     return 0;
@@ -2301,6 +2358,18 @@ auto install_package(const Options& opts, std::string_view package_name)
 
   auto artifact = artifact_for_current_arch(*pkg);
   if (!artifact) return 1;
+  // Packages linked against the MSYS2 runtime need msys-2.0.dll and friends;
+  // in a pure Win32 layout they only run where that runtime is reachable.
+  // Surface the index's runtime annotation before the user downloads.
+  const std::string runtime =
+      artifact->value("runtime", pkg->value("runtime", std::string{}));
+  if (runtime == "msys" || runtime == "msys2") {
+    safeErrorPrintLn(wpm_text(
+        "command.wpm.warn.msys_runtime",
+        "wpm: note: {} is linked against the MSYS2 runtime (msys-2.0.dll); "
+        "it only runs where that runtime is available",
+        pkg->value("name", std::string(package_name))));
+  }
   auto preflight = preflight_install_destinations(
       opts.root, *artifact, pkg->value("name", std::string(package_name)),
       opts.force);
@@ -2355,6 +2424,7 @@ auto install_package(const Options& opts, std::string_view package_name)
                          "wpm: dry-run complete; would install {}",
                          pkg->value("name", std::string(package_name))));
   } else {
+    write_install_receipt(opts.root, *pkg, *artifact);
     safePrintLn(wpm_text("command.wpm.status.installed", "wpm: installed {}",
                          pkg->value("name", std::string(package_name))));
   }
@@ -2844,6 +2914,8 @@ auto package_summary_json(const fs::path& root, const nlohmann::json& pkg)
         {"arch", detect_arch_key()},
         {"type", artifact->value("type", "")},
         {"layout", artifact_layout(*artifact)},
+        {"runtime",
+         artifact->value("runtime", pkg.value("runtime", std::string{}))},
         {"url_count", artifact_urls(*artifact).size()},
         {"sha256_present", !artifact->value("sha256", "").empty()},
         {"file_count",
@@ -3092,6 +3164,9 @@ auto uninstall_package(const Options& opts, const nlohmann::json& pkg)
 
   const std::string status =
       ok ? (opts.dry_run ? "would_remove" : "removed") : "error";
+  if (ok && !opts.dry_run) {
+    remove_install_receipt(opts.root, name);
+  }
   return {{"name", name},
           {"status", status},
           {"removed", removed},
@@ -3380,6 +3455,11 @@ auto show_info(const Options& opts, std::string_view name) -> int {
               std::string(artifact ? detect_arch_key() : "none"));
   if (artifact) {
     safePrintLn("Type: " + artifact->value("type", ""));
+    const std::string runtime =
+        artifact->value("runtime", pkg->value("runtime", std::string{}));
+    if (!runtime.empty()) {
+      safePrintLn("Runtime: " + runtime);
+    }
     safePrintLn("URLs: " + std::to_string(artifact_urls(*artifact).size()));
     if (auto size = artifact_size_bytes(*artifact)) {
       safePrintLn("Size: " + human_size(*size));

--- a/src/commands/wpm.cpp
+++ b/src/commands/wpm.cpp
@@ -66,7 +66,13 @@ auto constexpr WPM_OPTIONS = std::array{
     // [EXT] option
     OPTION("", "--json", "print machine-readable JSON"),
     // [EXT] option
-    OPTION("", "--plain", "print only package names for export")};
+    OPTION("", "--plain", "print only package names for export"),
+    // [EXT] option
+    OPTION("", "--proxy", "use the given HTTP proxy for downloads",
+           STRING_TYPE),
+    // [EXT] option
+    OPTION("", "--from", "install packages from a manifest file or URL",
+           STRING_TYPE)};
 
 namespace wpm {
 namespace fs = std::filesystem;
@@ -141,6 +147,8 @@ struct Options {
   fs::path root;
   std::string source;
   std::string category;
+  std::string proxy;
+  std::string from;
   bool all = false;
   bool force = false;
   bool dry_run = false;
@@ -1069,6 +1077,63 @@ auto proxy_from_environment(bool https) -> std::optional<std::wstring> {
   return std::nullopt;
 }
 
+auto user_forced_proxy(const Options& opts) -> std::optional<std::wstring> {
+  if (opts.proxy.empty()) return std::nullopt;
+  return normalize_proxy_server(opts.proxy);
+}
+
+// Builds a WinHTTP proxy bypass list from WPM_NO_PROXY/NO_PROXY/no_proxy.
+// Entries match by host suffix; a bare hostname also matches its subdomains.
+// A single "*" bypasses every host, which callers treat as "never proxy".
+auto proxy_bypass_from_environment() -> std::optional<std::wstring> {
+  std::optional<std::string> raw;
+  for (const char* name :
+       {"WPM_NO_PROXY", "wpm_no_proxy", "NO_PROXY", "no_proxy"}) {
+    if (auto value = env_var_value(name); value && !value->empty()) {
+      raw = std::move(*value);
+      break;
+    }
+  }
+  if (!raw) return std::nullopt;
+
+  std::wstring bypass;
+  size_t start = 0;
+  while (start <= raw->size()) {
+    size_t end = raw->find(',', start);
+    if (end == std::string::npos) end = raw->size();
+    std::string entry = trim_ascii(raw->substr(start, end - start));
+    start = end + 1;
+
+    if (entry.empty()) continue;
+    if (entry == "*") return std::wstring(L"*");
+    if (lower_ascii(entry) == "<local>") {
+      if (!bypass.empty()) bypass += L';';
+      bypass += L"<local>";
+      continue;
+    }
+    if (lower_ascii(entry).starts_with("http://") ||
+        lower_ascii(entry).starts_with("https://")) {
+      entry.erase(0, entry.find("://") + 3);
+    }
+    if (auto at = entry.find('/'); at != std::string::npos) {
+      entry.resize(at);
+    }
+    entry = trim_ascii(std::move(entry));
+    if (entry.empty()) continue;
+
+    if (!bypass.empty()) bypass += L';';
+    std::wstring wide = utf8_to_wstring(entry);
+    bypass += wide;
+    if (!entry.starts_with('.')) {
+      bypass += L';';
+      bypass += L'.';
+      bypass += wide;
+    }
+  }
+  if (bypass.empty()) return std::nullopt;
+  return bypass;
+}
+
 void free_proxy_info(WINHTTP_PROXY_INFO& info) {
   if (info.lpszProxy) GlobalFree(info.lpszProxy);
   if (info.lpszProxyBypass) GlobalFree(info.lpszProxyBypass);
@@ -1283,7 +1348,11 @@ auto http_get(std::string_view url, std::string_view progress_label = {},
   }
 
   if (forced_proxy) {
-    set_request_proxy(request, *forced_proxy);
+    auto bypass = proxy_bypass_from_environment();
+    if (!(bypass && *bypass == L"*")) {
+      set_request_proxy(request, *forced_proxy,
+                        bypass ? bypass->c_str() : WINHTTP_NO_PROXY_BYPASS);
+    }
   } else {
     apply_user_proxy(session, request, wurl, https);
   }
@@ -1843,7 +1912,8 @@ auto package_matches_category(const nlohmann::json& pkg,
 }
 
 auto download_artifact(const fs::path& root, const std::string& package,
-                       const nlohmann::json& artifact, bool verbose)
+                       const nlohmann::json& artifact, bool verbose,
+                       const std::optional<std::wstring>& forced_proxy)
     -> std::optional<fs::path> {
   auto urls = artifact_urls(artifact);
   if (urls.empty()) {
@@ -1873,8 +1943,10 @@ auto download_artifact(const fs::path& root, const std::string& package,
   }
   for (const auto& url : urls) {
     if (verbose) safePrintLn("wpm: downloading " + url);
-    auto result = http_get(url, wpm_text("command.wpm.status.downloading",
-                                         "wpm: downloading {}", package));
+    auto result = http_get(url,
+                           wpm_text("command.wpm.status.downloading",
+                                    "wpm: downloading {}", package),
+                           5, forced_proxy);
     if (!result.ok) {
       safeErrorPrintLn(wpm_text("command.wpm.error.download_failed",
                                 "wpm: download failed from {}: {}", url,
@@ -2046,7 +2118,8 @@ auto write_install_receipt(const fs::path& root, const nlohmann::json& pkg,
   }
   std::error_code ec;
   fs::create_directories(receipts_dir(root), ec);
-  std::ofstream out(receipt_path(root, name), std::ios::binary | std::ios::trunc);
+  std::ofstream out(receipt_path(root, name),
+                    std::ios::binary | std::ios::trunc);
   if (!out.is_open()) return;
   out << receipt.dump(2) << "\n";
 }
@@ -2376,7 +2449,8 @@ auto install_package(const Options& opts, std::string_view package_name)
   if (preflight) return *preflight;
 
   auto downloaded = download_artifact(opts.root, pkg->value("name", ""),
-                                      *artifact, opts.verbose);
+                                      *artifact, opts.verbose,
+                                      user_forced_proxy(opts));
   if (!downloaded) return 1;
 
   fs::path extracted = staging_dir(opts.root) / pkg->value("name", "package");
@@ -2445,6 +2519,196 @@ auto install_packages(const Options& opts,
   return failed == 0 ? 0 : 1;
 }
 
+auto strip_manifest_comment(std::string_view line) -> std::string_view {
+  bool in_string = false;
+  for (size_t i = 0; i < line.size(); ++i) {
+    if (line[i] == '"') in_string = !in_string;
+    if (line[i] == '#' && !in_string) return line.substr(0, i);
+  }
+  return line;
+}
+
+auto parse_toml_string_array(std::string_view value)
+    -> std::optional<std::vector<std::string>> {
+  std::vector<std::string> items;
+  size_t i = 0;
+  while (i < value.size()) {
+    if (value[i] == '"') {
+      std::string out;
+      size_t j = i + 1;
+      bool closed = false;
+      while (j < value.size()) {
+        if (value[j] == '\\' && j + 1 < value.size() &&
+            (value[j + 1] == '"' || value[j + 1] == '\\')) {
+          out += value[j + 1];
+          j += 2;
+          continue;
+        }
+        if (value[j] == '"') {
+          closed = true;
+          ++j;
+          break;
+        }
+        out += value[j++];
+      }
+      if (!closed) return std::nullopt;
+      items.push_back(std::move(out));
+      i = j;
+      continue;
+    }
+    if (value[i] == ']') break;
+    ++i;
+  }
+  return items;
+}
+
+auto unquote_toml_string(std::string_view token) -> std::optional<std::string> {
+  token = trim_ascii(std::string(token));
+  if (token.size() < 2 || token.front() != '"' || token.back() != '"') {
+    return std::nullopt;
+  }
+  auto items = parse_toml_string_array(token);
+  if (!items || items->size() != 1) return std::nullopt;
+  return std::move((*items)[0]);
+}
+
+// Minimal manifest reader for `wpm install --from`. Accepts either JSON
+// {"packages": {"wpm": ["a", "b"]}} or a TOML subset with a [packages]
+// section declaring wpm = ["a", "b"] (single or multiline array).
+auto parse_wpm_manifest(std::string_view text)
+    -> std::optional<std::vector<std::string>> {
+  auto trimmed_text = trim_ascii(std::string(text));
+  if (!trimmed_text.empty() && trimmed_text.front() == '{') {
+    auto parsed = parse_json_text(trimmed_text);
+    if (!parsed) return std::nullopt;
+    if (parsed->contains("packages") && (*parsed)["packages"].is_object() &&
+        (*parsed)["packages"].contains("wpm") &&
+        (*parsed)["packages"]["wpm"].is_array()) {
+      std::vector<std::string> items;
+      for (const auto& item : (*parsed)["packages"]["wpm"]) {
+        if (item.is_string()) items.push_back(item.get<std::string>());
+      }
+      return items;
+    }
+    return std::nullopt;
+  }
+
+  std::vector<std::string> items;
+  bool in_packages = false;
+  bool found = false;
+  bool saw_structure = false;
+  std::string pending_key;
+  std::string pending_value;
+
+  auto finish_array = [&](std::string_view value) -> bool {
+    auto parsed_items = parse_toml_string_array(value);
+    if (!parsed_items) return false;
+    if (pending_key == "wpm" && in_packages) {
+      for (auto& item : *parsed_items) items.push_back(std::move(item));
+      found = true;
+    }
+    pending_key.clear();
+    pending_value.clear();
+    return true;
+  };
+
+  std::istringstream in{std::string(text)};
+  std::string line;
+  while (std::getline(in, line)) {
+    auto content = trim_ascii(std::string(strip_manifest_comment(line)));
+    if (content.empty()) continue;
+
+    if (content.front() == '[' && content.back() == ']' &&
+        pending_key.empty()) {
+      auto section = trim_ascii(content.substr(1, content.size() - 2));
+      in_packages = section == "packages";
+      saw_structure = true;
+      continue;
+    }
+
+    auto eq = content.find('=');
+    if (eq == std::string::npos) continue;
+    saw_structure = true;
+
+    if (!pending_key.empty()) {
+      pending_value += " " + content;
+      if (content.find(']') != std::string::npos) {
+        if (!finish_array(pending_value)) return std::nullopt;
+      }
+      continue;
+    }
+
+    std::string key = trim_ascii(content.substr(0, eq));
+    std::string value = trim_ascii(content.substr(eq + 1));
+    if (value.find('[') == std::string::npos) {
+      if (key == "wpm" && in_packages) {
+        if (auto single = unquote_toml_string(value)) {
+          items.push_back(std::move(*single));
+          found = true;
+        }
+      }
+      continue;
+    }
+    pending_key = key;
+    pending_value = value.substr(value.find('[') + 1);
+    if (pending_value.find(']') != std::string::npos) {
+      if (!finish_array(pending_value)) return std::nullopt;
+    }
+  }
+  if (found) return items;
+  // Plain package list (one name per line, as written by `wpm export
+  // --plain`) is accepted as a fallback when no TOML/JSON structure exists.
+  if (saw_structure) return std::nullopt;
+  for (const auto& raw_line : std::views::split(std::string(text), '\n')) {
+    auto entry = trim_ascii(std::string(raw_line.begin(), raw_line.end()));
+    if (entry.empty() || entry.starts_with('#')) continue;
+    items.push_back(std::move(entry));
+  }
+  return items.empty() ? std::nullopt : std::optional{std::move(items)};
+}
+
+auto install_from_manifest(const Options& opts, const std::string& from)
+    -> int {
+  std::string text;
+  if (starts_with_ci(from, "http://") || starts_with_ci(from, "https://") ||
+      starts_with_ci(from, "file://")) {
+    auto result = http_get(from,
+                           wpm_text("command.wpm.status.fetching_manifest",
+                                    "wpm: fetching manifest from {}", from),
+                           5, user_forced_proxy(opts));
+    if (!result.ok) {
+      safeErrorPrintLn(wpm_text("command.wpm.error.manifest_fetch",
+                                "wpm: failed to fetch manifest '{}': {}", from,
+                                result.error));
+      return 1;
+    }
+    text.assign(reinterpret_cast<const char*>(result.data.data()),
+                result.data.size());
+  } else {
+    std::ifstream in{fs::path(from), std::ios::binary};
+    if (!in.is_open()) {
+      safeErrorPrintLn(wpm_text("command.wpm.error.manifest_open",
+                                "wpm: cannot open manifest '{}'", from));
+      return 1;
+    }
+    text.assign(std::istreambuf_iterator<char>(in),
+                std::istreambuf_iterator<char>());
+  }
+
+  auto packages = parse_wpm_manifest(text);
+  if (!packages || packages->empty()) {
+    safeErrorPrintLn(wpm_text("command.wpm.error.manifest_empty",
+                              "wpm: manifest '{}' has no [packages] wpm list",
+                              from));
+    return 1;
+  }
+
+  std::vector<std::string_view> views;
+  views.reserve(packages->size());
+  for (const auto& package : *packages) views.push_back(package);
+  return install_packages(opts, views);
+}
+
 auto launch_apply_update(const fs::path& staged_exe, const fs::path& root,
                          DWORD parent_pid) -> bool {
   std::wstring cmd = quote(staged_exe) + L" wpm -- __apply-update --root " +
@@ -2491,8 +2755,8 @@ auto update_winuxcmd(const Options& opts) -> int {
 
   auto artifact = artifact_for_current_arch(*pkg);
   if (!artifact) return 1;
-  auto downloaded =
-      download_artifact(opts.root, "winuxcmd", *artifact, opts.verbose);
+  auto downloaded = download_artifact(opts.root, "winuxcmd", *artifact,
+                                      opts.verbose, user_forced_proxy(opts));
   if (!downloaded) return 1;
 
   fs::path extracted = staging_dir(opts.root) / "winuxcmd-update";
@@ -2626,9 +2890,10 @@ auto try_fetch_index(const Options& opts, std::string& used_source)
       if (!url_json.is_string()) continue;
       std::string url = url_json.get<std::string>();
       if (opts.verbose) safePrintLn("wpm: fetching index " + url);
-      auto result =
-          http_get(url, wpm_text("command.wpm.status.fetching_index",
-                                 "wpm: fetching index from {}", name));
+      auto result = http_get(url,
+                             wpm_text("command.wpm.status.fetching_index",
+                                      "wpm: fetching index from {}", name),
+                             5, user_forced_proxy(opts));
       if (!result.ok) {
         safeErrorPrintLn("wpm: index fetch failed from " + name + ": " +
                          result.error);
@@ -3528,6 +3793,13 @@ auto print_usage() -> int {
       "      --json                            print machine-readable JSON\n"
       "      --plain                           print only package names for "
       "export\n"
+      "      --proxy <url>                     use the given HTTP proxy for "
+      "downloads (env: HTTP_PROXY,\n"
+      "                                        HTTPS_PROXY, WPM_HTTP_PROXY, "
+      "WPM_HTTPS_PROXY, NO_PROXY)\n"
+      "      --from <manifest>                 install packages from a manifest "
+      "file or URL\n"
+      "                                        (TOML, JSON, or plain list)\n"
       "      --help                            display this help and exit\n"
       "  -V, --version                         output version information and "
       "exit\n";
@@ -3551,6 +3823,8 @@ auto build_options(const CommandContext<WPM_OPTIONS.size()>& ctx) -> Options {
       ctx.get<bool>("--verbose", false) || ctx.get<bool>("-v", false);
   opts.yes = ctx.get<bool>("--yes", false) || ctx.get<bool>("-y", false);
   opts.category = ctx.get<std::string>("--category", "");
+  opts.proxy = ctx.get<std::string>("--proxy", "");
+  opts.from = ctx.get<std::string>("--from", "");
   opts.json = ctx.get<bool>("--json", false);
   opts.plain = ctx.has("--plain");
   if (!opts.dry_run) (void)ensure_install_layout(opts.root);
@@ -3560,6 +3834,13 @@ auto build_options(const CommandContext<WPM_OPTIONS.size()>& ctx) -> Options {
 auto dispatch(const Options& opts, std::span<const std::string_view> args)
     -> int {
   if (args.empty()) return print_usage();
+
+  if (!opts.proxy.empty() && !user_forced_proxy(opts)) {
+    safeErrorPrintLn(wpm_text("command.wpm.error.invalid_proxy",
+                              "wpm: invalid proxy '{}': use http://host:port",
+                              opts.proxy));
+    return 1;
+  }
 
   if (args[0] == "__apply-update") {
     return apply_update(args.subspan(1));
@@ -3655,15 +3936,23 @@ auto dispatch(const Options& opts, std::span<const std::string_view> args)
     return 1;
   }
   if (args[0] == "install") {
-    if (args.size() >= 2) {
-      std::vector<std::string_view> packages;
-      packages.reserve(args.size() - 1);
-      for (size_t i = 1; i < args.size(); ++i) packages.push_back(args[i]);
-      return install_packages(opts, packages);
+    std::vector<std::string_view> packages;
+    packages.reserve(args.size() - 1);
+    for (size_t i = 1; i < args.size(); ++i) packages.push_back(args[i]);
+    if (!opts.from.empty()) {
+      if (!packages.empty()) {
+        safeErrorPrintLn(winux::i18n::translate(
+            "command.wpm.error.manifest_conflict",
+            "wpm: --from cannot be combined with package arguments"));
+        return 1;
+      }
+      return install_from_manifest(opts, opts.from);
     }
+    if (!packages.empty()) return install_packages(opts, packages);
     safeErrorPrintLn(
         winux::i18n::translate("command.wpm.error.usage.install",
-                               "wpm: usage: wpm install <package>..."));
+                               "wpm: usage: wpm install <package>... "
+                               "[--from <manifest>]"));
     return 1;
   }
   if (args[0] == "update" || args[0] == "upgrade") {


### PR DESCRIPTION
## Summary
- wpm --proxy <url>: global option that forces the download proxy for index fetches and package downloads; overrides env vars, IE config and the loopback fallback
- NO_PROXY/no_proxy/WPM_NO_PROXY builds a WinHTTP bypass list for env-specified proxies (* disables proxying entirely)
- wpm install --from <file|URL>: installs packages from a TOML/JSON manifest ([packages] wpm = [...]) or a plain package list (wpm export --plain output); supports HTTP(S) manifest URLs
- help/usage updated; new messages registered for i18n (zh-CN sync pushed to winuxcmd-i18n 0.6.3)

## Merge resolution
- merged origin/main (receipt-based install state, #198) into this branch
- single conflict in write_install_receipt was formatting-only (same code, different wrapping); kept the 80-column form
- merge commit message documents the reconciliation

## Testing
- rebuilt via cmake (manual MSVC env fallback), zero errors after merge
- CLI smoke tests on the merged binary: invalid proxy rejection, --from missing file, TOML manifest install loop, plain-list fallback, --from + package conflict, NO_PROXY=* direct connection, wpm list regression check