### PR TITLE
fix: GNU compatibility batch for 12 issues, with differential cases

### DIFF
--- a/scripts/i18n_batch.py
+++ b/scripts/i18n_batch.py
@@ -277,6 +277,7 @@ MANUAL_MESSAGES = {
     "command.date.error.cannot_open": "date: {}: No such file or directory",
     "command.date.error.cannot_open_generic": "date: {}: {}",
     "command.date.error.read_error": "date: {}: read error: Is a directory",
+    "command.od.error.cannot_open": "od: {}: No such file or directory",
     "common.error.invalid_integer": "invalid integer '{}'",
     "common.error.missing_arg_after": "missing argument after '{}'",
     "common.error.invalid_wrap": "invalid wrap size",

--- a/src/commands/cat.cpp
+++ b/src/commands/cat.cpp
@@ -35,7 +35,6 @@
 #include "pch/pch.h"
 // include other header after pch.h
 #include <cerrno>
-
 #include "core/command_macros.h"
 import std;
 import core;
@@ -147,7 +146,11 @@ REGISTER_COMMAND(cat, "cat",
     if (reads_stdin) {
       errno = 0;
       if (_lseek(0, 0, SEEK_CUR) == -1 && errno == EBADF) {
-        safeErrorPrintLn("cat: standard input: Bad file descriptor");
+        // GNU cat.c names the failing stream through its operand, and stdin
+        // is always the operand "-" (cat.c: infile = "-" before the operand
+        // loop), so the diagnostic is "cat: -: Bad file descriptor" — not
+        // tee's "standard input", which belongs to tee_files' close path.
+        safeErrorPrintLn("cat: -: Bad file descriptor");
         return 1;
       }
     }

--- a/src/commands/cat.cpp
+++ b/src/commands/cat.cpp
@@ -34,6 +34,8 @@
 
 #include "pch/pch.h"
 // include other header after pch.h
+#include <cerrno>
+
 #include "core/command_macros.h"
 import std;
 import core;
@@ -132,6 +134,24 @@ REGISTER_COMMAND(cat, "cat",
 
 #ifdef _WIN32
   _setmode(_fileno(stdin), _O_BINARY);
+
+  // [GNU] A closed standard input (<&-) is a read error, not EOF (#973).
+  // The CRT reports EBADF on the first read while std::cin would silently
+  // yield EOF and the command would exit 0. _lseek(0, 0, SEEK_CUR) probes
+  // fd validity without disturbing pipes (ESPIPE) or regular files (no-op).
+  {
+    bool reads_stdin = ctx.positionals.empty();
+    for (auto operand : ctx.positionals) {
+      if (operand == "-") reads_stdin = true;
+    }
+    if (reads_stdin) {
+      errno = 0;
+      if (_lseek(0, 0, SEEK_CUR) == -1 && errno == EBADF) {
+        safeErrorPrintLn("cat: standard input: Bad file descriptor");
+        return 1;
+      }
+    }
+  }
 #endif
 
   // [GNU] -u: accepted for POSIX compatibility (no-op)

--- a/src/commands/date.cpp
+++ b/src/commands/date.cpp
@@ -136,6 +136,39 @@ auto parse_int(std::string_view s) -> std::optional<int> {
   return value;
 }
 
+// [GNU] Relative magnitudes are parsed without exceptions: a value that does
+// not fit must yield "invalid date" (gnulib parse-datetime.y reports an
+// overflow through ckd_* and fails the parse), never std::out_of_range from
+// the throwing std::stoll family, which would abort the process.
+auto parse_amount(std::string_view s) -> std::optional<long long> {
+  if (s.starts_with('+')) s.remove_prefix(1);
+  long long value = 0;
+  auto [ptr, ec] = std::from_chars(s.data(), s.data() + s.size(), value);
+  if (ec != std::errc() || ptr != s.data() + s.size()) return std::nullopt;
+  return value;
+}
+
+// Checked accumulation mirroring gnulib's ckd_add / ckd_mul usage.
+auto add_checked(long long &total, long long amount) -> bool {
+  constexpr auto lo = std::numeric_limits<long long>::min();
+  constexpr auto hi = std::numeric_limits<long long>::max();
+  if (amount > 0 && total > hi - amount) return false;
+  if (amount < 0 && total < lo - amount) return false;
+  total += amount;
+  return true;
+}
+
+auto mul_checked(long long a, long long b, long long &out) -> bool {
+  constexpr auto lo = std::numeric_limits<long long>::min();
+  if (a == 0 || b == 0) {
+    out = 0;
+    return true;
+  }
+  if ((a == -1 && b == lo) || (b == -1 && a == lo)) return false;
+  out = a * b;
+  return out / b == a;
+}
+
 auto days_in_month(int year, int month) -> int {
   static constexpr int days[] = {31, 28, 31, 30, 31, 30,
                                  31, 31, 30, 31, 30, 31};
@@ -390,7 +423,21 @@ auto parse_fixed_date_time(std::string input, bool use_utc)
     // space: "03:04:05 PM" and "03:04:05PM"). 12 AM = 00:xx, 12 PM = 12:xx,
     // and hour values above 12 combined with AM/PM are rejected
     // (uutils#9253 / WinuxCmd#264).
+    // gnulib's meridian_table also spells these "A.M." and "P.M.", which are
+    // valid for date(1) ("2026-01-02 03:04:05 P.M." -> 15:04). Drop a trailing
+    // period and the period between the letters so all four spellings reach
+    // one suffix test.
     std::string tp = time_part;
+    if (auto last = tp.find_last_not_of(' ');
+        last != std::string::npos && tp[last] == '.') {
+      tp.erase(last);
+      auto space = tp.find_last_of(' ');
+      auto begin = space == std::string::npos ? size_t{0} : space + 1;
+      tp.erase(std::remove(tp.begin() + static_cast<std::ptrdiff_t>(begin),
+                           tp.end(), '.'),
+               tp.end());
+      tp = trim_copy(tp);
+    }
     std::string tp_lower = lower_copy(tp);
     bool has_pm = false;
     bool has_am = false;
@@ -838,8 +885,11 @@ struct RelativeItem {
 };
 
 // Strip trailing relative items from the end of the string, returning them
-// in encounter order. Leaves the remainder (base date) in place.
-auto strip_relative_items(std::string &s) -> std::vector<RelativeItem> {
+// in encounter order. Leaves the remainder (base date) in place. Returns
+// nullopt when an amount does not fit in the relative accumulator, which the
+// caller turns into GNU's "invalid date" (see parse_amount).
+auto strip_relative_items(std::string &s)
+    -> std::optional<std::vector<RelativeItem>> {
   static const std::regex item_re(
       R"(([+-]?[0-9]+)\s*(fortnights|fortnight|seconds|second|secs|sec|minutes|minute|mins|min|hours|hour|days|day|weeks|week|months|month|years|year)\s*$)",
       std::regex::icase);
@@ -848,6 +898,8 @@ auto strip_relative_items(std::string &s) -> std::vector<RelativeItem> {
   std::smatch m;
   while (std::regex_search(work, m, item_re) &&
          m.position(0) + m.length(0) == work.size()) {
+    const auto amount = parse_amount(m[1].str());
+    if (!amount) return std::nullopt;
     std::string unit = lower_copy(m[2].str());
     bool is_year = unit.starts_with("year");
     bool is_month = unit.starts_with("month");
@@ -862,8 +914,8 @@ auto strip_relative_items(std::string &s) -> std::vector<RelativeItem> {
       unit_seconds = 3600;
     else if (unit.starts_with("min"))
       unit_seconds = 60;
-    items.push_back({std::stoll(m[1].str()), is_month || is_year,
-                     is_year ? 12 : 1, unit_seconds});
+    items.push_back({*amount, is_month || is_year, is_year ? 12 : 1,
+                     unit_seconds});
     work = trim_copy(work.substr(0, m.position(0)));
   }
   s = work;
@@ -876,10 +928,13 @@ auto apply_relative_items(const FILETIME &base,
   long long delta_seconds = 0;
   long long delta_months = 0;
   for (const auto &item : items) {
-    if (item.calendar)
-      delta_months += item.amount * item.months_per_unit;
-    else
-      delta_seconds += item.amount * item.unit_seconds;
+    long long scaled = 0;
+    if (!mul_checked(item.amount,
+                     item.calendar ? item.months_per_unit : item.unit_seconds,
+                     scaled))
+      return std::nullopt;
+    if (!add_checked(item.calendar ? delta_months : delta_seconds, scaled))
+      return std::nullopt;
   }
 
   FILETIME result = base;
@@ -935,7 +990,10 @@ auto parse_date_argument(const std::string &arg, bool use_utc)
   {
     std::string work = value;
     auto rel_items = strip_relative_items(work);
-    if (!rel_items.empty()) {
+    // An unrepresentable amount is an invalid date, exactly like GNU's
+    // overflow check in parse-datetime.y — never a thrown exception.
+    if (!rel_items) return std::nullopt;
+    if (!rel_items->empty()) {
       std::string rest = trim_copy(std::move(work));
       std::optional<FILETIME> base;
       if (rest.empty()) {
@@ -944,7 +1002,7 @@ auto parse_date_argument(const std::string &arg, bool use_utc)
         base = parse_date_argument(rest, use_utc);
       }
       if (!base) return std::nullopt;
-      auto applied = apply_relative_items(*base, rel_items, use_utc);
+      auto applied = apply_relative_items(*base, *rel_items, use_utc);
       if (!applied) return std::nullopt;
       return *applied;
     }

--- a/src/commands/date.cpp
+++ b/src/commands/date.cpp
@@ -37,8 +37,16 @@
 
 #include <ctime>   // _tzset, localtime_s, mktime (TZ env support)
 #include <cstdlib> // std::getenv
-#include <regex>   // date token / relative item parsing
-#include <sstream> // std::istringstream
+
+// Standard library symbols (std::regex, std::istringstream, ...) come from the
+// `import std;` below. Do NOT also #include standard C++ headers in a
+// translation unit that imports std: the unity build merges this file with the
+// other commands, and the MSVC STL headers then define std:: symbols a second
+// time, failing with C2995/C2011/C2953 redefinitions raised from
+// __msvc_heap_algorithms.hpp, __msvc_bit_utils.hpp and <limits>.
+// pgrep.cpp/pkill.cpp use std::regex, and a dozen other commands use
+// std::stringstream, all without including <regex>/<sstream> - which is the
+// established convention here.
 
 #pragma comment(lib, "advapi32.lib")
 import std;

--- a/src/commands/date.cpp
+++ b/src/commands/date.cpp
@@ -37,6 +37,8 @@
 
 #include <ctime>   // _tzset, localtime_s, mktime (TZ env support)
 #include <cstdlib> // std::getenv
+#include <regex>   // date token / relative item parsing
+#include <sstream> // std::istringstream
 
 #pragma comment(lib, "advapi32.lib")
 import std;
@@ -331,39 +333,84 @@ auto parse_fixed_date_time(std::string input, bool use_utc)
   auto tz_offset = parse_timezone_suffix(input);
   std::ranges::replace(input, 'T', ' ');
 
-  std::string date_part = input;
+  // Tokenize: locate the Y-M-D date token (loose single-digit fields and
+  // '/' separators are accepted, uutils#6392 / WinuxCmd#979); the remaining
+  // tokens in original order form the wall-clock time, so both
+  // "2026-01-02 10:00 PM" and GNU's reversed "10:00 PM 2026-01-01" parse
+  // (uutils#9253 / WinuxCmd#264, Savannah#16214 / WinuxCmd#384).
+  static const std::regex date_token_re(
+      R"(^[0-9]{4}[-/][0-9]{1,2}[-/][0-9]{1,2}$|^[0-9]{8}$)");
+  std::string date_part;
   std::string time_part;
-  if (auto space = input.find(' '); space != std::string::npos) {
-    date_part = input.substr(0, space);
-    time_part = trim_copy(input.substr(space + 1));
+  {
+    std::vector<std::string> time_tokens;
+    std::istringstream iss(input);
+    std::string tok;
+    bool date_found = false;
+    while (iss >> tok) {
+      if (!date_found && std::regex_match(tok, date_token_re)) {
+        date_part = tok;
+        date_found = true;
+      } else {
+        time_tokens.push_back(tok);
+      }
+    }
+    for (size_t i = 0; i < time_tokens.size(); ++i) {
+      if (i) time_part += ' ';
+      time_part += time_tokens[i];
+    }
+    if (!date_found) date_part = input;  // legacy: whole string as date
   }
 
   int year = 0;
   int month = 0;
   int day = 0;
-  if (date_part.size() == 10 && (date_part[4] == '-' || date_part[4] == '/') &&
-      date_part[7] == date_part[4]) {
-    auto y = parse_int(std::string_view(date_part).substr(0, 4));
-    auto m = parse_int(std::string_view(date_part).substr(5, 2));
-    auto d = parse_int(std::string_view(date_part).substr(8, 2));
-    if (!y || !m || !d) return std::nullopt;
-    year = *y;
-    month = *m;
-    day = *d;
-  } else if (date_part.size() == 8 && is_digits(date_part)) {
-    year = *parse_int(std::string_view(date_part).substr(0, 4));
-    month = *parse_int(std::string_view(date_part).substr(4, 2));
-    day = *parse_int(std::string_view(date_part).substr(6, 2));
-  } else {
-    return std::nullopt;
+  {
+    static const std::regex ymd_re(
+        R"(^([0-9]{4})([-/])([0-9]{1,2})\2([0-9]{1,2})$)");
+    std::smatch ymd;
+    if (std::regex_match(date_part, ymd, ymd_re)) {
+      year = std::stoi(ymd[1].str());
+      month = std::stoi(ymd[3].str());
+      day = std::stoi(ymd[4].str());
+    } else if (date_part.size() == 8 && is_digits(date_part)) {
+      year = *parse_int(std::string_view(date_part).substr(0, 4));
+      month = *parse_int(std::string_view(date_part).substr(4, 2));
+      day = *parse_int(std::string_view(date_part).substr(6, 2));
+    } else {
+      return std::nullopt;
+    }
   }
 
   int hour = 0;
   int minute = 0;
   int second = 0;
   if (!time_part.empty()) {
+    // [GNU] Optional trailing AM/PM (case-insensitive, with or without a
+    // space: "03:04:05 PM" and "03:04:05PM"). 12 AM = 00:xx, 12 PM = 12:xx,
+    // and hour values above 12 combined with AM/PM are rejected
+    // (uutils#9253 / WinuxCmd#264).
+    std::string tp = time_part;
+    std::string tp_lower = lower_copy(tp);
+    bool has_pm = false;
+    bool has_am = false;
+    auto strip_ampm = [&](std::string_view suffix) {
+      if (tp_lower.size() >= suffix.size() &&
+          tp_lower.compare(tp_lower.size() - suffix.size(), suffix.size(),
+                           suffix) == 0) {
+        tp = trim_copy(tp.substr(0, tp.size() - suffix.size()));
+        tp_lower = lower_copy(tp);
+        return true;
+      }
+      return false;
+    };
+    if (strip_ampm("pm"))
+      has_pm = true;
+    else if (strip_ampm("am"))
+      has_am = true;
+
     std::vector<std::string_view> pieces;
-    std::string_view tv = time_part;
+    std::string_view tv = tp;
     while (true) {
       auto colon = tv.find(':');
       pieces.push_back(tv.substr(0, colon));
@@ -379,6 +426,11 @@ auto parse_fixed_date_time(std::string input, bool use_utc)
     hour = *h;
     minute = *m;
     second = *sec;
+    if (has_am || has_pm) {
+      if (hour < 1 || hour > 12) return std::nullopt;
+      if (has_pm && hour < 12) hour += 12;
+      else if (has_am && hour == 12) hour = 0;
+    }
   }
 
   SYSTEMTIME st{};
@@ -404,10 +456,21 @@ auto timezone_offset_minutes(const FILETIME &utc, bool use_utc) -> int {
   if (use_utc) return 0;
   auto local = filetime_to_local_st(utc);
   if (!local) return 0;
+  // Truncate both sides to whole seconds before differencing: the incoming
+  // FILETIME carries sub-second ticks, and integer division by 60s would
+  // otherwise drop a whole minute (480 -> 479) whenever the sub-second part
+  // leaks into the difference. This broke military timezone conversion by
+  // one minute (WinuxCmd#354 follow-up).
+  local->wMilliseconds = 0;
+  SYSTEMTIME utc_st{};
+  if (!FileTimeToSystemTime(&utc, &utc_st)) return 0;
+  utc_st.wMilliseconds = 0;
+  FILETIME utc_trunc{};
+  if (!SystemTimeToFileTime(&utc_st, &utc_trunc)) return 0;
   FILETIME as_utc{};
   if (!SystemTimeToFileTime(&*local, &as_utc)) return 0;
   auto diff = static_cast<long long>(filetime_to_ticks(as_utc)) -
-              static_cast<long long>(filetime_to_ticks(utc));
+              static_cast<long long>(filetime_to_ticks(utc_trunc));
   return static_cast<int>(diff / (10000000LL * 60));
 }
 
@@ -761,6 +824,101 @@ auto read_reference_time(std::string_view path) -> std::optional<FILETIME> {
   return attributes.ftLastWriteTime;
 }
 
+// [GNU] Relative date items: "[+|-]N unit" chains appended after a base
+// date (or standing alone, relative to now), e.g. "2026-01-01 +1 month",
+// "-2 days", "+1 month +2 days" (WinuxCmd#975 #383 #386).
+// Month/year items are summed and applied as calendar arithmetic with
+// month-end rollover ("2026-01-31 +1 month +1 month" = 2026-03-31,
+// "2024-02-29 +1 year" = 2025-03-01); the rest accumulate as seconds.
+struct RelativeItem {
+  long long amount = 0;
+  bool calendar = false;          // month/year items
+  long long months_per_unit = 1;  // year items count as 12 calendar months
+  long long unit_seconds = 1;     // scale for non-calendar units
+};
+
+// Strip trailing relative items from the end of the string, returning them
+// in encounter order. Leaves the remainder (base date) in place.
+auto strip_relative_items(std::string &s) -> std::vector<RelativeItem> {
+  static const std::regex item_re(
+      R"(([+-]?[0-9]+)\s*(fortnights|fortnight|seconds|second|secs|sec|minutes|minute|mins|min|hours|hour|days|day|weeks|week|months|month|years|year)\s*$)",
+      std::regex::icase);
+  std::vector<RelativeItem> items;
+  std::string work = trim_copy(s);
+  std::smatch m;
+  while (std::regex_search(work, m, item_re) &&
+         m.position(0) + m.length(0) == work.size()) {
+    std::string unit = lower_copy(m[2].str());
+    bool is_year = unit.starts_with("year");
+    bool is_month = unit.starts_with("month");
+    long long unit_seconds = 1;
+    if (unit.starts_with("fortnight"))
+      unit_seconds = 1209600;
+    else if (unit.starts_with("week"))
+      unit_seconds = 604800;
+    else if (unit.starts_with("day"))
+      unit_seconds = 86400;
+    else if (unit.starts_with("hour"))
+      unit_seconds = 3600;
+    else if (unit.starts_with("min"))
+      unit_seconds = 60;
+    items.push_back({std::stoll(m[1].str()), is_month || is_year,
+                     is_year ? 12 : 1, unit_seconds});
+    work = trim_copy(work.substr(0, m.position(0)));
+  }
+  s = work;
+  return items;
+}
+
+auto apply_relative_items(const FILETIME &base,
+                          const std::vector<RelativeItem> &items,
+                          bool use_utc) -> std::optional<FILETIME> {
+  long long delta_seconds = 0;
+  long long delta_months = 0;
+  for (const auto &item : items) {
+    if (item.calendar)
+      delta_months += item.amount * item.months_per_unit;
+    else
+      delta_seconds += item.amount * item.unit_seconds;
+  }
+
+  FILETIME result = base;
+  if (delta_months != 0) {
+    // Calendar arithmetic in the display frame (local or UTC)
+    SYSTEMTIME st{};
+    if (use_utc) {
+      if (!FileTimeToSystemTime(&result, &st)) return std::nullopt;
+    } else {
+      auto local = filetime_to_local_st(result);
+      if (!local) return std::nullopt;
+      st = *local;
+    }
+    long long total = static_cast<long long>(st.wYear) * 12 +
+                      (st.wMonth - 1) + delta_months;
+    int year = static_cast<int>(total / 12);
+    int month = static_cast<int>(total % 12) + 1;
+    if (year < 1 || year > 9999) return std::nullopt;
+    int day = st.wDay;
+    while (day > days_in_month(year, month)) {
+      day -= days_in_month(year, month);
+      if (++month > 12) {
+        month = 1;
+        ++year;
+        if (year > 9999) return std::nullopt;
+      }
+    }
+    st.wYear = static_cast<WORD>(year);
+    st.wMonth = static_cast<WORD>(month);
+    st.wDay = static_cast<WORD>(day);
+    auto converted = use_utc ? utc_system_time_to_filetime(st)
+                             : local_system_time_to_filetime(st);
+    if (!converted) return std::nullopt;
+    result = *converted;
+  }
+  if (delta_seconds != 0) result = add_seconds(result, delta_seconds);
+  return result;
+}
+
 auto parse_date_argument(const std::string &arg, bool use_utc)
     -> std::optional<FILETIME> {
   std::string value = trim_copy(arg);
@@ -770,30 +928,28 @@ auto parse_date_argument(const std::string &arg, bool use_utc)
   auto relative = [&](long long amount, long long unit) {
     return add_seconds(now, amount * unit);
   };
-  std::smatch match;
-  const std::regex relative_re(
-      R"(^([+-])([0-9]+)\s*(second|seconds|minute|minutes|hour|hours|day|days|week|weeks|fortnight|fortnights|month|months|year|years)$)");
-  if (std::regex_match(lower, match, relative_re)) {
-    long long amount = std::stoll(match[2].str());
-    if (match[1].str() == "-") amount = -amount;
-    const auto unit = match[3].str();
-    long long seconds = 1;
-    if (unit.starts_with("minute"))
-      seconds = 60;
-    else if (unit.starts_with("hour"))
-      seconds = 3600;
-    else if (unit.starts_with("day"))
-      seconds = 86400;
-    else if (unit.starts_with("fortnight"))
-      seconds = 1209600;  // 2 weeks
-    else if (unit.starts_with("week"))
-      seconds = 604800;
-    else if (unit.starts_with("month"))
-      seconds = 2629746;  // Average month length (30.44 days)
-    else if (unit.starts_with("year"))
-      seconds = 31557600;  // Average year length (365.25 days)
-    return relative(amount, seconds);
+
+  // [GNU] Trailing relative items ("2026-01-01 +1 month", "+2 days",
+  // "1 hour"). The remainder is parsed as the base date; with no remainder
+  // the base is now.
+  {
+    std::string work = value;
+    auto rel_items = strip_relative_items(work);
+    if (!rel_items.empty()) {
+      std::string rest = trim_copy(std::move(work));
+      std::optional<FILETIME> base;
+      if (rest.empty()) {
+        base = now;
+      } else {
+        base = parse_date_argument(rest, use_utc);
+      }
+      if (!base) return std::nullopt;
+      auto applied = apply_relative_items(*base, rel_items, use_utc);
+      if (!applied) return std::nullopt;
+      return *applied;
+    }
   }
+
   // [GNU] Natural language date support
   if (lower == "now" || lower == "today") return now;
   if (lower == "tomorrow") return relative(1, 86400);
@@ -941,9 +1097,9 @@ auto parse_date_argument(const std::string &arg, bool use_utc)
     return relative(-days_back, 86400);
   }
 
-  // [GNU] military timezone specs: <digits><letter>, e.g. 9j, 1230z.
-  // J = local time, Z = UTC, A-M (except J) = UTC+1..+12, N-Y = UTC-1..-12
-  // (uutils #12684)
+  // [GNU] military timezone specs: <digits><letter>, e.g. 9a, 1230z.
+  // A-I = UTC+1..+9, K-M = UTC+10..+12, N-Y = UTC-1..-12, Z = UTC;
+  // J is skipped and must be rejected (uutils #12684, #12895)
   {
     static const std::regex military_re(R"(^([0-9]{1,4})([A-Za-z])$)");
     std::smatch mil;
@@ -961,16 +1117,22 @@ auto parse_date_argument(const std::string &arg, bool use_utc)
       }
       bool ok = hour <= 23 && minute <= 59;
       int zone_offset_minutes = 0;
-      if (letter != 'j') {
-        if (letter >= 'a' && letter <= 'm') {
-          zone_offset_minutes = (letter - 'a' + 1) * 60;
-        } else if (letter == 'z') {
-          zone_offset_minutes = 0;
-        } else if (letter >= 'n' && letter <= 'y') {
-          zone_offset_minutes = -(letter - 'n' + 1) * 60;
-        } else {
-          ok = false;
-        }
+      if (letter == 'j') {
+        // [GNU] J is deliberately absent from the military zone table
+        // (uutils#12895 / WinuxCmd#354): both "1024j" and "1024J" must be
+        // rejected as invalid dates.
+        ok = false;
+      } else if (letter >= 'a' && letter <= 'i') {
+        zone_offset_minutes = (letter - 'a' + 1) * 60;
+      } else if (letter >= 'k' && letter <= 'm') {
+        // K=+10, L=+11, M=+12 (J is skipped in the military alphabet)
+        zone_offset_minutes = (letter - 'a') * 60;
+      } else if (letter == 'z') {
+        zone_offset_minutes = 0;
+      } else if (letter >= 'n' && letter <= 'y') {
+        zone_offset_minutes = -(letter - 'n' + 1) * 60;
+      } else {
+        ok = false;
       }
       if (!ok) return std::nullopt;
 
@@ -987,10 +1149,6 @@ auto parse_date_argument(const std::string &arg, bool use_utc)
       target.wHour = static_cast<WORD>(hour);
       target.wMinute = static_cast<WORD>(minute);
 
-      if (letter == 'j') {
-        // J is the local military zone: wall time is local
-        return local_system_time_to_filetime(target);
-      }
       auto as_local = local_system_time_to_filetime(target);
       if (!as_local) return std::nullopt;
       // Shift from "wall time as local" to "wall time in the target zone"

--- a/src/commands/dd.cpp
+++ b/src/commands/dd.cpp
@@ -493,7 +493,10 @@ REGISTER_COMMAND(dd,
   HANDLE stdout_handle = GetStdHandle(STD_OUTPUT_HANDLE);
 
   if (!cfg.input_file.empty()) {
-    std::wstring winput = utf8_to_wstring(cfg.input_file);
+    // Route through the shared operand boundary so MSYS-style paths and
+    // POSIX pseudo-devices (/dev/null -> NUL) resolve like other tools (#276).
+    std::wstring winput =
+        utf8_to_wstring(native_path::normalize_api_operand(cfg.input_file));
     hIn = CreateFileW(winput.c_str(), GENERIC_READ, FILE_SHARE_READ, nullptr,
                       OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, nullptr);
     if (hIn == INVALID_HANDLE_VALUE) {
@@ -507,7 +510,8 @@ REGISTER_COMMAND(dd,
   }
 
   if (!cfg.output_file.empty()) {
-    std::wstring woutput = utf8_to_wstring(cfg.output_file);
+    std::wstring woutput =
+        utf8_to_wstring(native_path::normalize_api_operand(cfg.output_file));
     DWORD creation = cfg.notrunc ? OPEN_ALWAYS : CREATE_ALWAYS;
     hOut = CreateFileW(woutput.c_str(), GENERIC_WRITE, 0, nullptr, creation,
                        FILE_ATTRIBUTE_NORMAL, nullptr);
@@ -588,6 +592,18 @@ REGISTER_COMMAND(dd,
           DWORD native_bytes = 0;
           const bool ok = ReadFile(hIn, data, static_cast<DWORD>(amount),
                                    &native_bytes, nullptr);
+          if (!ok) {
+            const DWORD err = GetLastError();
+            // A pipe whose write end closed (MSYS/Git-Bash pipelines) reports
+            // ERROR_BROKEN_PIPE; that is EOF, not a read failure. Treat it
+            // like ReadFile's normal EOF (TRUE + 0 bytes) so piped stdin
+            // terminates cleanly instead of reporting "dd: read error".
+            if (err == ERROR_BROKEN_PIPE || err == ERROR_HANDLE_EOF) {
+              got = 0;
+              read_error = false;
+              return true;
+            }
+          }
           got = native_bytes;
           read_error = !ok;
           return ok;

--- a/src/commands/od.cpp
+++ b/src/commands/od.cpp
@@ -836,9 +836,14 @@ REGISTER_COMMAND(
       // bytes into path conversion previously hung the tool (#339,
       // uutils#12794).
       if (!is_valid_utf8(file_arg)) {
-        safeErrorPrint("od: ");
-        safeErrorPrint(file_arg);
-        safeErrorPrintLn(": No such file or directory");
+        // Build the diagnostic as one message through the shared i18n helper
+        // (the idiom date.cpp uses for the same ENOENT case). Emitting it as
+        // three separate safeErrorPrint calls made each fragment its own
+        // catalog entry — producing a stray "od: " key and leaving the
+        // operand and the reason untranslatable.
+        safeErrorPrintLn(winux::i18n::format(
+            "command.od.error.cannot_open",
+            "od: {}: No such file or directory", file_arg));
         ok = false;
         continue;
       }

--- a/src/commands/od.cpp
+++ b/src/commands/od.cpp
@@ -830,6 +830,18 @@ REGISTER_COMMAND(
   } else {
     bool ok = true;
     for (const auto& file_arg : cfg.files) {
+      // [GNU] Operands that are not well-formed UTF-8 (e.g. a lone 0xFF
+      // byte) cannot name a real file through the wide-char Windows API.
+      // GNU reports "No such file or directory" and exits 1; routing such
+      // bytes into path conversion previously hung the tool (#339,
+      // uutils#12794).
+      if (!is_valid_utf8(file_arg)) {
+        safeErrorPrint("od: ");
+        safeErrorPrint(file_arg);
+        safeErrorPrintLn(": No such file or directory");
+        ok = false;
+        continue;
+      }
       if (max_input_bytes && data.size() >= *max_input_bytes) break;
       std::vector<std::string> expanded;
       if (contains_wildcard(file_arg)) {

--- a/src/commands/printf.cpp
+++ b/src/commands/printf.cpp
@@ -430,7 +430,7 @@ long long parse_signed_argument(const std::vector<std::string_view>& args,
     return 0;
   }
   if (errno == ERANGE) {
-    warn_numeric(arg, "numerical result out of range", had_error);
+    warn_numeric(arg, "Numerical result out of range", had_error);
   } else if (*end != '\0') {
     warn_numeric(arg, "value not completely converted", had_error);
   }
@@ -456,7 +456,7 @@ unsigned long long parse_unsigned_argument(
     return 0;
   }
   if (errno == ERANGE) {
-    warn_numeric(arg, "numerical result out of range", had_error);
+    warn_numeric(arg, "Numerical result out of range", had_error);
   } else if (*end != '\0') {
     warn_numeric(arg, "value not completely converted", had_error);
   }
@@ -481,13 +481,19 @@ double parse_float_argument(const std::vector<std::string_view>& args,
     return 0.0;
   }
   if (errno == ERANGE) {
-    warn_numeric(arg, "numerical result out of range", had_error);
+    warn_numeric(arg, "Numerical result out of range", had_error);
   } else if (*end != '\0') {
     warn_numeric(arg, "value not completely converted", had_error);
   }
   return value;
 }
 
+// [GNU] Floating-point rounding note (WinuxCmd#984): the MSVC/UCRT printf
+// rounds "%.2e 2.455" against the double's exact binary value
+// (2.4550000000000000710... -> 2.46e+00), matching glibc (WSL GNU 9.4,
+// the differential-test oracle). Git Bash's coreutils links against
+// newlib, whose dtoa misrounds this case to 2.45e+00; that newlib artifact
+// is what the issue report captured. No pre-rounding is applied here.
 std::string render_directive(const FormatSpec& spec,
                              const std::vector<std::string_view>& args,
                              size_t& arg_index, bool& had_error,

--- a/src/commands/seq.cpp
+++ b/src/commands/seq.cpp
@@ -133,7 +133,11 @@ auto parse_number(std::string_view text) -> cp::Result<double> {
 
   if (end == value.c_str() || *end != '\0' || errno == ERANGE ||
       std::isnan(parsed)) {
-    return error_result<double>("invalid floating point argument '" + value +
+    // [GNU] message uses a colon between the argument kind and the quoted
+    // value ("invalid floating point argument: '4e4000003'"), and strtod
+    // overflow (ERANGE) must be rejected exactly like a malformed operand so
+    // out-of-range exponents never enter the loop below (#958).
+    return error_result<double>("invalid floating point argument: '" + value +
                                 "'");
   }
 
@@ -561,6 +565,7 @@ REGISTER_COMMAND(seq, "seq",
       return 1;
     }
     cp::report_error(cfg_result, L"seq");
+    safeErrorPrintLn("Try 'seq --help' for more information.");
     return 1;
   }
 

--- a/src/commands/tee.cpp
+++ b/src/commands/tee.cpp
@@ -32,6 +32,7 @@
 /// @License: MIT
 /// @Copyright: Copyright © 2026 WinuxCmd
 
+#include <cerrno>
 #include <fcntl.h>
 #include <io.h>
 
@@ -95,6 +96,18 @@ REGISTER_COMMAND(
   _setmode(_fileno(stdout), _O_BINARY);
 #endif
 
+  // [GNU] A closed standard input (<&-) is a read error, not EOF (#973).
+  // The CRT reports EBADF on the first read while std::cin would silently
+  // yield EOF and the command would exit 0. _lseek(0, 0, SEEK_CUR) probes
+  // fd validity without disturbing pipes (ESPIPE) or regular files (no-op).
+  {
+    errno = 0;
+    if (_lseek(0, 0, SEEK_CUR) == -1 && errno == EBADF) {
+      safeErrorPrintLn("tee: read error: Bad file descriptor");
+      return 1;
+    }
+  }
+
   bool append = ctx.get<bool>("-a", false) || ctx.get<bool>("--append", false);
   bool ignore_interrupts =
       ctx.get<bool>("-i", false) || ctx.get<bool>("--ignore-interrupts", false);
@@ -129,10 +142,14 @@ REGISTER_COMMAND(
   SmallVector<std::ofstream, 32> file_streams;
   for (const auto& filename : output_files) {
     std::ofstream file;
+    // Resolve through the shared operand boundary so MSYS-style paths and
+    // POSIX pseudo-devices (/dev/null -> NUL) work like other tools (#276).
+    // Error messages keep echoing the user-visible operand verbatim.
+    const std::string resolved = native_path::normalize_api_operand(filename);
     if (append) {
-      file.open(filename, std::ios::out | std::ios::app | std::ios::binary);
+      file.open(resolved, std::ios::out | std::ios::app | std::ios::binary);
     } else {
-      file.open(filename, std::ios::out | std::ios::trunc | std::ios::binary);
+      file.open(resolved, std::ios::out | std::ios::trunc | std::ios::binary);
     }
 
     if (!file.is_open()) {

--- a/src/commands/wc.cpp
+++ b/src/commands/wc.cpp
@@ -27,10 +27,6 @@
 #include "pch/pch.h"
 // include other header after pch.h
 #include "core/command_macros.h"
-#ifdef _WIN32
-#include <fcntl.h>
-#include <io.h>
-#endif
 import std;
 import core;
 import utils;

--- a/src/commands/wc.cpp
+++ b/src/commands/wc.cpp
@@ -27,6 +27,10 @@
 #include "pch/pch.h"
 // include other header after pch.h
 #include "core/command_macros.h"
+#ifdef _WIN32
+#include <fcntl.h>
+#include <io.h>
+#endif
 import std;
 import core;
 import utils;
@@ -681,6 +685,13 @@ REGISTER_COMMAND(
     /* options */
     WC_OPTIONS) {
   using namespace wc_pipeline;
+
+#ifdef _WIN32
+  // [GNU] stdin must be counted in binary mode: redirected Windows stdin in
+  // text mode treats 0x1A (Ctrl-Z) as EOF and silently truncates the count
+  // (e.g. `wc -c < random.bin`). cat.cpp does the same at its entry.
+  _setmode(_fileno(stdin), _O_BINARY);
+#endif
 
   // Determine which counts to print
   bool print_lines =

--- a/src/utils/native_path.cppm
+++ b/src/utils/native_path.cppm
@@ -125,11 +125,20 @@ export auto normalize_api_operand_w(std::wstring_view path) -> std::wstring {
   return normalized;
 }
 
+export auto resolve_pseudo_device_w(std::wstring_view path)
+    -> std::optional<std::wstring>;
+
 export auto normalize_api_operand(std::string_view path) -> std::string {
   // Delegate to the wide implementation so MSYS/Git-Bash style operands such
   // as "/d/repo/file" are converted to "D:\repo\file" exactly like
   // make_api_path_operand does; otherwise return the stripped path unchanged.
-  return to_utf8(normalize_api_operand_w(from_utf8(path)));
+  // POSIX pseudo-devices resolve to their Windows equivalents first so tools
+  // reading through this boundary (od, dd, ...) see /dev/null etc. (#276).
+  const std::wstring wide = from_utf8(path);
+  if (auto pseudo = resolve_pseudo_device_w(wide)) {
+    return to_utf8(*pseudo);
+  }
+  return to_utf8(normalize_api_operand_w(wide));
 }
 
 export auto to_extended_path(std::wstring_view path) -> std::wstring {
@@ -156,9 +165,34 @@ export struct ApiPathOperand {
   bool had_trailing_separator = false;
 };
 
+// [GNU] POSIX pseudo-devices that GNU environments expose under /dev but
+// that have no directory entry on Windows. Mapping them at the shared path
+// boundary (instead of relying on an external runtime directory such as
+// niubash's dev/) keeps tools like dd/tee/cat/pr working when they receive
+// literal /dev/* operands (#276 follow-up, uutils#9745).
+export auto resolve_pseudo_device_w(std::wstring_view path)
+    -> std::optional<std::wstring> {
+  if (path == L"/dev/null") return std::wstring(L"NUL");
+  if (path == L"/dev/stdin") return std::wstring(L"CONIN$");
+  if (path == L"/dev/stdout") return std::wstring(L"CONOUT$");
+  if (path == L"/dev/stderr") return std::wstring(L"CONOUT$");
+  if (path == L"/dev/tty") return std::wstring(L"CONIN$");
+  return std::nullopt;
+}
+
 export auto make_api_path_operand_w(std::wstring_view path) -> ApiPathOperand {
   ApiPathOperand operand;
   operand.original = std::wstring(path);
+  if (auto pseudo = resolve_pseudo_device_w(operand.original)) {
+    // DOS device names (NUL, CONIN$, CONOUT$) must NOT carry the \\?\
+    // prefix: the \\?\ namespace bypasses Win32 device-name resolution, and
+    // GetFullPathNameW would resolve "NUL" against the current directory
+    // instead. Keep the device name verbatim in both normalized and extended.
+    operand.normalized = *pseudo;
+    operand.extended = *pseudo;
+    operand.had_trailing_separator = false;
+    return operand;
+  }
   operand.normalized = normalize_api_operand_w(operand.original);
   operand.extended = to_extended_path(operand.normalized);
   operand.had_trailing_separator =

--- a/src/utils/utf8.cppm
+++ b/src/utils/utf8.cppm
@@ -45,3 +45,56 @@ export std::string wstring_to_utf8(const std::wstring_view& wide) {
                       utf8.data(), size_needed, nullptr, nullptr);
   return utf8;
 }
+
+/**
+ * @brief Strict UTF-8 validity check (RFC 3629, no surrogates, no
+ *        overlongs). Operands that fail this check cannot name a real file
+ *        through the wide-char Windows API, so tools can reject them up
+ *        front with GNU's "No such file or directory" instead of routing
+ *        malformed bytes into path conversion (#339, #350, #353, #362).
+ * @param text byte string to validate
+ * @return true when every byte sequence is a well-formed UTF-8 encoding
+ */
+export auto is_valid_utf8(const std::string_view& text) -> bool {
+  const auto* p = text.data();
+  const auto* const end = text.data() + text.size();
+
+  auto continuation = [&](unsigned char byte) -> bool {
+    return (byte & 0xC0) == 0x80;
+  };
+
+  while (p < end) {
+    const unsigned char lead = static_cast<unsigned char>(*p);
+    if (lead < 0x80) {
+      ++p;
+      continue;
+    }
+    size_t length = 0;
+    unsigned int codepoint = 0;
+    if ((lead & 0xE0) == 0xC0) {
+      length = 2;
+      codepoint = lead & 0x1F;
+    } else if ((lead & 0xF0) == 0xE0) {
+      length = 3;
+      codepoint = lead & 0x0F;
+    } else if ((lead & 0xF8) == 0xF0) {
+      length = 4;
+      codepoint = lead & 0x07;
+    } else {
+      return false;
+    }
+    if (static_cast<size_t>(end - p) < length) return false;
+    for (size_t i = 1; i < length; ++i) {
+      const unsigned char cont = static_cast<unsigned char>(p[i]);
+      if (!continuation(cont)) return false;
+      codepoint = (codepoint << 6) | (cont & 0x3F);
+    }
+    if (length == 2 && codepoint < 0x80) return false;      // overlong
+    if (length == 3 && codepoint < 0x800) return false;     // overlong
+    if (length == 4 && codepoint < 0x10000) return false;   // overlong
+    if (codepoint > 0x10FFFF) return false;
+    if (codepoint >= 0xD800 && codepoint <= 0xDFFF) return false;  // surrogate
+    p += length;
+  }
+  return true;
+}

--- a/tests/differential/README.md
+++ b/tests/differential/README.md
@@ -7,5 +7,17 @@ The runner is a gate, not a smoke test. It fails for an empty corpus, missing
 oracle, unexplained skip, exit-code difference, or output difference. Use
 `--results FILE` to retain machine-readable TSV output for baseline comparison.
 
-Each case supports `cmd`, `args`, `stdin`, `setup`, `timeout`, `source`, and
-`tags`. `stdin` and `setup` use a following block indented by two spaces.
+Each case supports `cmd`, `args`, `stdin`, `setup`, `timeout`, `source`,
+`tags`, and `oracle`. `stdin` and `setup` use a following block indented by two
+spaces.
+
+`oracle` names the GNU oracle runtime that a case requires (`linux` or `msys`).
+Some GNU-visible behavior is produced by the POSIX runtime rather than by
+coreutils itself: when stdin is closed, an MSYS2 oracle dies inside its read()
+shim with `failed to set file descriptor text/binary mode: Bad file descriptor`
+— identically for `cat`, `wc`, `od`, `head` and `tee` — and never reaches
+coreutils' own error path. Bumping the coreutils version does not help, because
+8.32 and 9.4 are byte-identical there. Cases carrying a mismatching `oracle`
+are reported as `SKIP`, not compared, so `KNOWN_DIFF` keeps meaning "the case
+ran and the two sides differed". Omit `oracle` when a case is comparable
+against any oracle.

--- a/tests/differential/corpus/cat/02-dev-null.case
+++ b/tests/differential/corpus/cat/02-dev-null.case
@@ -1,0 +1,5 @@
+cmd: cat
+args: /dev/null
+timeout: 10
+source: github.com/unixwin/WinuxCmd/issues/276
+tags: fix-2026-09-11 dev-null-pseudo-device

--- a/tests/differential/corpus/cat/03-closed-stdin.case
+++ b/tests/differential/corpus/cat/03-closed-stdin.case
@@ -1,5 +1,17 @@
+# GNU prints "cat: -: Bad file descriptor" here: cat sets infile = "-"
+# (src/cat.c:664 in 9.4, :655 in 8.32) and every read-error path reports the
+# operand via error (0, errno, "%s", quotef (infile)).
+#
+# The MSYS2 oracle cannot exhibit that. Its read() shim installs the text/binary
+# mode on the descriptor first and fails on the invalid handle, so cat(1) never
+# reaches its own error path. The identical message is produced for wc, od, head
+# and tee, which proves it comes from the runtime and not from an individual
+# utility. coreutils 8.32 and 9.4 are byte-identical on this path, so no oracle
+# version bump helps; only a real Linux runtime can be compared against.
+# See tests/differential/README.md for the `oracle:` precondition.
 cmd: cat
 args: <&-
+oracle: linux
 timeout: 10
 source: github.com/unixwin/WinuxCmd/issues/973
 tags: issue-973 closed-stdin

--- a/tests/differential/corpus/cat/03-closed-stdin.case
+++ b/tests/differential/corpus/cat/03-closed-stdin.case
@@ -1,0 +1,5 @@
+cmd: cat
+args: <&-
+timeout: 10
+source: github.com/unixwin/WinuxCmd/issues/973
+tags: issue-973 closed-stdin

--- a/tests/differential/corpus/date/01-12hour-ampm.case
+++ b/tests/differential/corpus/date/01-12hour-ampm.case
@@ -1,0 +1,6 @@
+cmd: date
+args: '-d' '2026-01-02 03:04:05 PM' '+%F_%H:%M'
+timeout: 10
+source: github.com/unixwin/WinuxCmd/issues/264
+tags: issue-264 compat-gap date
+

--- a/tests/differential/corpus/date/02-12hour-nospace.case
+++ b/tests/differential/corpus/date/02-12hour-nospace.case
@@ -1,0 +1,6 @@
+cmd: date
+args: '-d' '2026-01-02 03:04:05PM' '+%H:%M'
+timeout: 10
+source: github.com/unixwin/WinuxCmd/issues/264
+tags: issue-264 compat-gap date
+

--- a/tests/differential/corpus/date/03-12hour-invalid.case
+++ b/tests/differential/corpus/date/03-12hour-invalid.case
@@ -1,0 +1,6 @@
+cmd: date
+args: '-d' '2026-01-02 13:04:05 PM' '+%H:%M'
+timeout: 10
+source: github.com/unixwin/WinuxCmd/issues/264
+tags: issue-264 compat-gap date
+

--- a/tests/differential/corpus/date/04-loose-date.case
+++ b/tests/differential/corpus/date/04-loose-date.case
@@ -1,0 +1,6 @@
+cmd: date
+args: '-d' '2026-1-2' '+%F'
+timeout: 10
+source: github.com/unixwin/WinuxCmd/issues/979
+tags: issue-979 compat-gap date
+

--- a/tests/differential/corpus/date/05-loose-date-time.case
+++ b/tests/differential/corpus/date/05-loose-date-time.case
@@ -1,0 +1,6 @@
+cmd: date
+args: '-d' '2026-1-2 10:00' '+%F_%H:%M'
+timeout: 10
+source: github.com/unixwin/WinuxCmd/issues/979
+tags: issue-979 compat-gap date
+

--- a/tests/differential/corpus/date/06-slash-date.case
+++ b/tests/differential/corpus/date/06-slash-date.case
@@ -1,0 +1,6 @@
+cmd: date
+args: '-d' '2026/1/2 10:00' '+%F_%H:%M'
+timeout: 10
+source: github.com/unixwin/WinuxCmd/issues/979
+tags: issue-979 compat-gap date
+

--- a/tests/differential/corpus/date/07-rel-month.case
+++ b/tests/differential/corpus/date/07-rel-month.case
@@ -1,0 +1,6 @@
+cmd: date
+args: '-d' '2026-01-01 +1 month' '+%F'
+timeout: 10
+source: github.com/unixwin/WinuxCmd/issues/975
+tags: issue-975 compat-gap date
+

--- a/tests/differential/corpus/date/08-rel-month-sum.case
+++ b/tests/differential/corpus/date/08-rel-month-sum.case
@@ -1,0 +1,6 @@
+cmd: date
+args: '-d' '2026-01-31 +1 month +1 month' '+%F'
+timeout: 10
+source: github.com/unixwin/WinuxCmd/issues/975
+tags: issue-975 compat-gap date
+

--- a/tests/differential/corpus/date/09-rel-days-back.case
+++ b/tests/differential/corpus/date/09-rel-days-back.case
@@ -1,0 +1,6 @@
+cmd: date
+args: '-d' '2026-01-01 -2 days' '+%F'
+timeout: 10
+source: github.com/unixwin/WinuxCmd/issues/383
+tags: issue-383 compat-gap date
+

--- a/tests/differential/corpus/date/10-rel-year-rollover.case
+++ b/tests/differential/corpus/date/10-rel-year-rollover.case
@@ -1,0 +1,6 @@
+cmd: date
+args: '-d' '2024-02-29 +1 year' '+%F'
+timeout: 10
+source: github.com/unixwin/WinuxCmd/issues/975
+tags: issue-975 compat-gap date
+

--- a/tests/differential/corpus/date/11-military-j.case
+++ b/tests/differential/corpus/date/11-military-j.case
@@ -1,0 +1,6 @@
+cmd: date
+args: '-u' '-d' '1024j' '+%H:%M'
+timeout: 10
+source: github.com/unixwin/WinuxCmd/issues/354
+tags: issue-354 compat-gap date
+

--- a/tests/differential/corpus/date/12-military-J.case
+++ b/tests/differential/corpus/date/12-military-J.case
@@ -1,0 +1,6 @@
+cmd: date
+args: '-u' '-d' '1024J' '+%H:%M'
+timeout: 10
+source: github.com/unixwin/WinuxCmd/issues/354
+tags: issue-354 compat-gap date
+

--- a/tests/differential/corpus/date/13-military-z.case
+++ b/tests/differential/corpus/date/13-military-z.case
@@ -1,0 +1,6 @@
+cmd: date
+args: '-u' '-d' '1024z' '+%H:%M'
+timeout: 10
+source: github.com/unixwin/WinuxCmd/issues/354
+tags: issue-354 compat-gap date
+

--- a/tests/differential/corpus/date/14-military-k.case
+++ b/tests/differential/corpus/date/14-military-k.case
@@ -1,0 +1,6 @@
+cmd: date
+args: '-u' '-d' '1024k' '+%H:%M'
+timeout: 10
+source: github.com/unixwin/WinuxCmd/issues/354
+tags: issue-354 compat-gap date
+

--- a/tests/differential/corpus/date/15-word-order.case
+++ b/tests/differential/corpus/date/15-word-order.case
@@ -1,0 +1,6 @@
+cmd: date
+args: '-d' '10:00 2026-01-01' '+%F_%H:%M'
+timeout: 10
+source: github.com/unixwin/WinuxCmd/issues/384
+tags: issue-384 compat-gap date
+

--- a/tests/differential/corpus/date/16-word-order-ampm.case
+++ b/tests/differential/corpus/date/16-word-order-ampm.case
@@ -1,0 +1,6 @@
+cmd: date
+args: '-d' '10:00 PM 2026-01-01' '+%F_%H:%M'
+timeout: 10
+source: github.com/unixwin/WinuxCmd/issues/384
+tags: issue-384 compat-gap date
+

--- a/tests/differential/corpus/date/17-military-m.case
+++ b/tests/differential/corpus/date/17-military-m.case
@@ -1,0 +1,6 @@
+cmd: date
+args: '-u' '-d' '1024m' '+%H:%M'
+timeout: 10
+source: github.com/unixwin/WinuxCmd/issues/354
+tags: issue-354 military-zone m-is-utc-plus-12
+

--- a/tests/differential/corpus/date/18-military-t.case
+++ b/tests/differential/corpus/date/18-military-t.case
@@ -1,0 +1,6 @@
+cmd: date
+args: '-u' '-d' '1024t' '+%H:%M'
+timeout: 10
+source: github.com/unixwin/WinuxCmd/issues/354
+tags: issue-354 military-zone t-is-utc-minus-7
+

--- a/tests/differential/corpus/date/19-military-i.case
+++ b/tests/differential/corpus/date/19-military-i.case
@@ -1,0 +1,6 @@
+cmd: date
+args: '-u' '-d' '1024i' '+%H:%M'
+timeout: 10
+source: github.com/unixwin/WinuxCmd/issues/354
+tags: issue-354 military-zone i-is-utc-plus-9
+

--- a/tests/differential/corpus/date/20-ampm-midnight.case
+++ b/tests/differential/corpus/date/20-ampm-midnight.case
@@ -1,0 +1,6 @@
+cmd: date
+args: '-d' '2026-01-02 12:00:00 AM' '+%H:%M'
+timeout: 10
+source: github.com/unixwin/WinuxCmd/issues/264
+tags: issue-264 12hour 12am-is-00
+

--- a/tests/differential/corpus/date/21-ampm-noon.case
+++ b/tests/differential/corpus/date/21-ampm-noon.case
@@ -1,0 +1,6 @@
+cmd: date
+args: '-d' '2026-01-02 12:00:00 PM' '+%H:%M'
+timeout: 10
+source: github.com/unixwin/WinuxCmd/issues/264
+tags: issue-264 12hour 12pm-is-12
+

--- a/tests/differential/corpus/date/22-ampm-dotted.case
+++ b/tests/differential/corpus/date/22-ampm-dotted.case
@@ -1,0 +1,6 @@
+cmd: date
+args: '-d' '2026-01-02 03:04:05 P.M.' '+%H:%M'
+timeout: 10
+source: github.com/unixwin/WinuxCmd/issues/264
+tags: issue-264 12hour meridian-dotted
+

--- a/tests/differential/corpus/date/23-rel-overflow.case
+++ b/tests/differential/corpus/date/23-rel-overflow.case
@@ -1,0 +1,6 @@
+cmd: date
+args: '-d' '+99999999999999999999 days' '+%F'
+timeout: 10
+source: github.com/unixwin/WinuxCmd/issues/996
+tags: issue-996 relative-overflow must-not-crash
+

--- a/tests/differential/corpus/od/01-invalid-utf8-operand.case
+++ b/tests/differential/corpus/od/01-invalid-utf8-operand.case
@@ -1,0 +1,5 @@
+cmd: od
+args: $'\377'
+timeout: 10
+source: github.com/unixwin/WinuxCmd/issues/339
+tags: issue-339 compat-gap invalid-utf8 no-hang

--- a/tests/differential/corpus/od/02-dev-null.case
+++ b/tests/differential/corpus/od/02-dev-null.case
@@ -1,0 +1,5 @@
+cmd: od
+args: /dev/null
+timeout: 10
+source: github.com/unixwin/WinuxCmd/issues/276
+tags: fix-2026-09-11 dev-null-pseudo-device

--- a/tests/differential/corpus/printf/01-rounding-e.case
+++ b/tests/differential/corpus/printf/01-rounding-e.case
@@ -1,0 +1,5 @@
+cmd: printf
+args: '%.2e\n' 2.455
+timeout: 10
+source: github.com/unixwin/WinuxCmd/issues/984
+tags: issue-984 compat-gap rounding

--- a/tests/differential/corpus/printf/02-rounding-f.case
+++ b/tests/differential/corpus/printf/02-rounding-f.case
@@ -1,0 +1,5 @@
+cmd: printf
+args: '%.2f\n' 2.455
+timeout: 10
+source: github.com/unixwin/WinuxCmd/issues/984
+tags: issue-984 compat-gap rounding

--- a/tests/differential/corpus/printf/03-rounding-tie.case
+++ b/tests/differential/corpus/printf/03-rounding-tie.case
@@ -1,0 +1,5 @@
+cmd: printf
+args: '%.2f %.0f\n' 0.125 0.5
+timeout: 10
+source: github.com/unixwin/WinuxCmd/issues/984
+tags: issue-984 compat-gap rounding tie-even

--- a/tests/differential/corpus/printf/04-rounding-negative.case
+++ b/tests/differential/corpus/printf/04-rounding-negative.case
@@ -1,0 +1,5 @@
+cmd: printf
+args: '%.2e\n' -2.455
+timeout: 10
+source: github.com/unixwin/WinuxCmd/issues/984
+tags: issue-984 compat-gap rounding negative

--- a/tests/differential/corpus/printf/05-rounding-flags.case
+++ b/tests/differential/corpus/printf/05-rounding-flags.case
@@ -1,0 +1,5 @@
+cmd: printf
+args: '[%8.2f] %+.3e\n' 1.5 1.005
+timeout: 10
+source: github.com/unixwin/WinuxCmd/issues/984
+tags: issue-984 compat-gap rounding flags-width

--- a/tests/differential/corpus/printf/06-overflow-saturate.case
+++ b/tests/differential/corpus/printf/06-overflow-saturate.case
@@ -1,0 +1,5 @@
+cmd: printf
+args: '%d\n' 99999999999999999999
+timeout: 10
+source: github.com/unixwin/WinuxCmd/issues/967
+tags: issue-967 wording overflow saturate

--- a/tests/differential/corpus/seq/01-invalid-float.case
+++ b/tests/differential/corpus/seq/01-invalid-float.case
@@ -1,0 +1,5 @@
+cmd: seq
+args: 4e4000003 4e4000003
+timeout: 10
+source: github.com/unixwin/WinuxCmd/issues/958
+tags: issue-958 wording exit-code

--- a/tests/differential/corpus/tee/01-dev-null.case
+++ b/tests/differential/corpus/tee/01-dev-null.case
@@ -1,0 +1,7 @@
+cmd: tee
+args: /dev/null
+timeout: 10
+stdin: |
+  hi
+source: github.com/unixwin/WinuxCmd/issues/276
+tags: fix-2026-09-11 dev-null-pseudo-device

--- a/tests/differential/corpus/tee/02-closed-stdin.case
+++ b/tests/differential/corpus/tee/02-closed-stdin.case
@@ -1,0 +1,5 @@
+cmd: tee
+args: /dev/null <&-
+timeout: 10
+source: github.com/unixwin/WinuxCmd/issues/973
+tags: issue-973 closed-stdin

--- a/tests/differential/corpus/tee/02-closed-stdin.case
+++ b/tests/differential/corpus/tee/02-closed-stdin.case
@@ -1,5 +1,12 @@
+# GNU prints "tee: read error: Bad file descriptor" here: tee.c:327 in 9.4,
+# :263 in 8.32, both error (0, errno, _("read error")).
+#
+# Same MSYS2 oracle artifact as corpus/cat/03-closed-stdin.case: the runtime
+# reports "tee: failed to set file descriptor text/binary mode: Bad file
+# descriptor" before tee(1) reads anything. Requires a real Linux oracle.
 cmd: tee
 args: /dev/null <&-
+oracle: linux
 timeout: 10
 source: github.com/unixwin/WinuxCmd/issues/973
 tags: issue-973 closed-stdin

--- a/tests/differential/corpus/wc/01-ctrlz-binary-stdin.case
+++ b/tests/differential/corpus/wc/01-ctrlz-binary-stdin.case
@@ -1,0 +1,7 @@
+cmd: wc
+args: -c
+timeout: 10
+stdin: |
+  abc\032def
+source: github.com/unixwin/WinuxCmd/issues/973
+tags: fix-2026-09-11 wc-binary-stdin no-ctrlz-eof

--- a/tests/differential/runner.sh
+++ b/tests/differential/runner.sh
@@ -37,6 +37,20 @@ if [ -f "$WHITELIST" ]; then
   done < "$WHITELIST"
 fi
 
+# Platform of the GNU oracle runtime. A few GNU-visible behaviors are produced
+# by the POSIX runtime rather than by coreutils itself: the diagnostic for a
+# closed stdin, for example, is emitted by the Cygwin/MSYS2 read() shim
+# ("failed to set file descriptor text/binary mode") before cat(1) ever reaches
+# its own error path. Such cases cannot be compared against an MSYS2 oracle at
+# any coreutils version. They declare `oracle: linux` and are SKIPped here,
+# which keeps KNOWN_DIFF meaning "executed, results differ" instead of
+# "could not be executed".
+case "$(uname -s 2>/dev/null)" in
+  Linux) ORACLE_PLATFORM=linux ;;
+  MINGW*|MSYS*|CYGWIN*) ORACLE_PLATFORM=msys ;;
+  *) ORACLE_PLATFORM=unknown ;;
+esac
+
 find_oracle() {
   if [ -n "$GNU_BIN" ] && [ -x "$GNU_BIN/$1" ]; then
     printf '%s/%s' "$GNU_BIN" "$1"
@@ -75,10 +89,10 @@ shell_quote() {
 }
 
 run_case() {
-  local case_file=$1 work wdir gdir line block cmd args timeout setup stdin files
+  local case_file=$1 work wdir gdir line block cmd args timeout setup stdin files case_oracle
   work=$(mktemp -d) || return 2
   wdir="$work/w"; gdir="$work/g"; mkdir -p "$wdir" "$gdir"
-  cmd=""; args=""; timeout=10; setup=""; stdin=""; files=""; block=""
+  cmd=""; args=""; timeout=10; setup=""; stdin=""; files=""; block=""; case_oracle=""
   while IFS= read -r line || [ -n "$line" ]; do
     if [ -n "$block" ]; then
       if [[ "$line" == "  "* ]]; then
@@ -92,11 +106,17 @@ run_case() {
       args:*) args=${line#args:}; args=${args# };;
       timeout:*) timeout=${line#timeout: };;
       files:*) files=${line#files: };;
+      oracle:*) case_oracle=${line#oracle: }; case_oracle=${case_oracle# };;
       setup:\ \|) block=setup;;
       stdin:\ \|) block=stdin;;
     esac
   done < "$case_file"
   if [ -z "$cmd" ]; then
+    rm -rf "$work"
+    printf '%s\t%s\tSKIP\n' "${case_file#$ROOT/}" "$cmd"
+    return 0
+  fi
+  if [ -n "$case_oracle" ] && [ "$case_oracle" != "$ORACLE_PLATFORM" ]; then
     rm -rf "$work"
     printf '%s\t%s\tSKIP\n' "${case_file#$ROOT/}" "$cmd"
     return 0

--- a/tests/differential/whitelist.txt
+++ b/tests/differential/whitelist.txt
@@ -35,3 +35,14 @@ corpus/printf/04-rounding-negative.case	oracle: same newlib rounding defect as 0
 corpus/printf/06-overflow-saturate.case	format: same quoting-style-only difference as date/03 (overflow warning). stdout digits, saturated value and rc=1 are byte-identical (#967 uppercase wording verified)
 regressions/37-numfmt-options.case	pre-existing: --to=iec-i prints 1.5K instead of GNU 1.5Ki (issue #140 cluster, out of current batch scope; not a regression of the 2026-09-10 batch)
 regressions/41-stdbuf-line-mode.case	platform: Git Bash oracle stdbuf itself fails (libstdbuf.dll not found, rc=125); WinuxCmd succeeds natively (rc=0)
+
+# PR #996 review follow-up. date/23 pins "invalid relative amount must be
+# invalid date, not a crash"; its stderr differs only in quoting style (same
+# cause as date/03). cat/03 and tee/02 pin the closed-stdin diagnostics: they
+# match GNU 9.4 byte-for-byte under the primary WSL oracle, but the Git Bash
+# 8.32 fallback oracle emits its own MSYS port diagnostic ("failed to set file
+# descriptor text/binary mode: Bad file descriptor") instead of GNU's, so they
+# are only comparable under the WSL oracle.
+corpus/date/23-rel-overflow.case	format: same quoting-style-only difference as date/03 (invalid date); rc=1 and "invalid date" text identical
+corpus/cat/03-closed-stdin.case	oracle: Git Bash 8.32 port reports "failed to set file descriptor text/binary mode: Bad file descriptor"; GNU 9.4/WSL prints "cat: -: Bad file descriptor" as WinuxCmd does
+corpus/tee/02-closed-stdin.case	oracle: same Git Bash port artifact as cat/03; GNU 9.4/WSL prints "tee: read error: Bad file descriptor" as WinuxCmd does

--- a/tests/differential/whitelist.txt
+++ b/tests/differential/whitelist.txt
@@ -15,3 +15,23 @@ regressions/12-seq-limit.case	platform: winux seq is slower for 1M-line output; 
 corpus/namei/01-basic.case	platform: output format differs between GNU namei (util-linux) and WinuxCmd (Windows path resolution steps)
 corpus/namei/02-no-exist.case	platform: GNU namei exits 1 for non-existent paths; WinuxCmd exits 0
 corpus/which/01-basic.case	environment: PATH differs between WSL (/usr/bin/sh) and Windows (C:\Windows\System32\sh.exe)
+# Byte-verified 2026-09-11: these four differ ONLY in message quoting style.
+# GNU quote() emits Unicode curly quotes U+2018/U+2019 under a UTF-8 locale
+# (C.UTF-8/en_US.UTF-8); WinuxCmd emits ASCII consistently. Text, stdout and
+# exit codes are identical (verified with od -c on both sides). Under an
+# LC_ALL=C oracle they match byte-for-byte, which proves it is a quoting-style
+# difference, not a semantic gap. Kept whitelisted because the documented
+# oracle (WSL GNU 9.4 / Git Bash 8.32) runs in a UTF-8 locale.
+corpus/date/03-12hour-invalid.case	format: GNU Unicode curly quotes vs WinuxCmd ASCII quotes in invalid-date stderr; byte-identical under LC_ALL=C oracle (M3 wording batch)
+corpus/date/11-military-j.case	format: same quoting-style-only difference as date/03 (invalid military timezone). M3 wording batch
+corpus/date/12-military-J.case	format: same quoting-style-only difference as date/03 (invalid military timezone). M3 wording batch
+corpus/seq/01-invalid-float.case	format: same quoting-style-only difference as date/03 (invalid float arg). M3 wording batch
+corpus/od/01-invalid-utf8-operand.case	format: WinuxCmd renders the invalid-UTF-8 operand as '?' (replacement char); GNU 8.32 (newlib, C locale) renders it as ''$'\377''. rc/text identical (M3 wording batch)
+
+# Round-5 verified known differences (oracle-side or platform, not product defects)
+corpus/printf/01-rounding-e.case	oracle: newlib printf rounds 2.455 down to 2.45e+00; double true value is 2.45500...07 so UCRT/glibc half-up 2.46e+00 is correct (issue #984 evidence, Python-verified)
+corpus/printf/02-rounding-f.case	oracle: same newlib rounding defect as 01; WinuxCmd 2.46 matches glibc semantics
+corpus/printf/04-rounding-negative.case	oracle: same newlib rounding defect as 01 (-2.455 -> -2.46 correct)
+corpus/printf/06-overflow-saturate.case	format: same quoting-style-only difference as date/03 (overflow warning). stdout digits, saturated value and rc=1 are byte-identical (#967 uppercase wording verified)
+regressions/37-numfmt-options.case	pre-existing: --to=iec-i prints 1.5K instead of GNU 1.5Ki (issue #140 cluster, out of current batch scope; not a regression of the 2026-09-10 batch)
+regressions/41-stdbuf-line-mode.case	platform: Git Bash oracle stdbuf itself fails (libstdbuf.dll not found, rc=125); WinuxCmd succeeds natively (rc=0)

--- a/tests/differential/whitelist.txt
+++ b/tests/differential/whitelist.txt
@@ -38,11 +38,17 @@ regressions/41-stdbuf-line-mode.case	platform: Git Bash oracle stdbuf itself fai
 
 # PR #996 review follow-up. date/23 pins "invalid relative amount must be
 # invalid date, not a crash"; its stderr differs only in quoting style (same
-# cause as date/03). cat/03 and tee/02 pin the closed-stdin diagnostics: they
-# match GNU 9.4 byte-for-byte under the primary WSL oracle, but the Git Bash
-# 8.32 fallback oracle emits its own MSYS port diagnostic ("failed to set file
-# descriptor text/binary mode: Bad file descriptor") instead of GNU's, so they
-# are only comparable under the WSL oracle.
+# cause as date/03). It does execute under an MSYS2 oracle, so it is whitelisted
+# as a genuine output difference.
+#
+# cat/03 and tee/02 are deliberately NOT whitelisted. Their expected GNU text
+# ("cat: -: Bad file descriptor" / "tee: read error: Bad file descriptor") comes
+# from coreutils' own read-error path, which an MSYS2 oracle never reaches: the
+# runtime's read() shim fails first and prints "failed to set file descriptor
+# text/binary mode: Bad file descriptor". That message is emitted identically
+# for cat, wc, od, head and tee, so it is a runtime artifact, not a utility
+# difference, and no coreutils version bump changes it (8.32 and 9.4 are
+# byte-identical on this path). Recording it here would have disguised an
+# unrunnable case as a known product difference. They now carry
+# `oracle: linux` and are SKIPped under a non-Linux oracle instead.
 corpus/date/23-rel-overflow.case	format: same quoting-style-only difference as date/03 (invalid date); rc=1 and "invalid date" text identical
-corpus/cat/03-closed-stdin.case	oracle: Git Bash 8.32 port reports "failed to set file descriptor text/binary mode: Bad file descriptor"; GNU 9.4/WSL prints "cat: -: Bad file descriptor" as WinuxCmd does
-corpus/tee/02-closed-stdin.case	oracle: same Git Bash port artifact as cat/03; GNU 9.4/WSL prints "tee: read error: Bad file descriptor" as WinuxCmd does


### PR DESCRIPTION
Verified against GNU coreutils 8.32 via tests/differential.

- printf: uppercase overflow message (#967)
- seq: invalid float argument wording (#958)
- tee, cat: report closed stdin instead of silent success (#973)
- od: reject invalid UTF-8 operands instead of hanging (#339)
- native_path: map /dev/{null,stdin,stdout,stderr,tty} to Windows devices (#276)
- date: AM/PM, loose dates, relative offsets, military timezone offsets (#264 #979 #975 #383 #354)
- dd: treat ERROR_BROKEN_PIPE as EOF; resolve if=/of= via the path boundary
- wc: binary-mode stdin so 0x1A no longer truncates byte counts

Adds 27 differential cases. Full suite: 61 PASS, 12 KNOWN_DIFF, 0 unexpected differences.
