### PR TITLE
fix(ls): GNU coreutils compare_qsort files-before-dirs grouping

### DIFF
--- a/src/commands/ls.cpp
+++ b/src/commands/ls.cpp
@@ -3333,6 +3333,33 @@ auto process_paths(const std::vector<std::string> &paths,
     if (ctx.get<bool>("-r", false) || ctx.get<bool>("--reverse", false)) {
       std::reverse(expanded_paths.begin(), expanded_paths.end());
     }
+  } else if (expanded_paths.size() > 1) {
+    // [GNU coreutils] compare_qsort: non-directory operands are sorted and
+    // printed first, then directory operands are sorted and printed after.
+    // This matches `ls lib/**` where glob expands to a mix of files and
+    // directories: GNU prints all files up front, then each directory block.
+    std::vector<std::string> file_operands;
+    std::vector<std::string> dir_operands;
+    for (const auto &path : expanded_paths) {
+      auto probe = probe_path(utf8_to_wstring(path));
+      if (probe.attributes_valid &&
+          (probe.attributes & FILE_ATTRIBUTE_DIRECTORY) != 0) {
+        dir_operands.push_back(path);
+      } else {
+        file_operands.push_back(path);
+      }
+    }
+    std::sort(file_operands.begin(), file_operands.end());
+    std::sort(dir_operands.begin(), dir_operands.end());
+    if (ctx.get<bool>("-r", false) || ctx.get<bool>("--reverse", false)) {
+      std::reverse(file_operands.begin(), file_operands.end());
+      std::reverse(dir_operands.begin(), dir_operands.end());
+    }
+    expanded_paths.clear();
+    expanded_paths.insert(expanded_paths.end(), file_operands.begin(),
+                          file_operands.end());
+    expanded_paths.insert(expanded_paths.end(), dir_operands.begin(),
+                          dir_operands.end());
   }
 
   for (const auto &path : expanded_paths) {


### PR DESCRIPTION
## Summary

- Fix `ls` to group non-directory operands before directory operands, matching GNU coreutils `compare_qsort` behavior.
- Without this fix, `ls file_a dir_a file_b dir_b` prints `file_a, dir_a contents, file_b, dir_b contents` instead of `file_a, file_b, dir_a contents, dir_b contents`.
- This was the root cause of the `globstar` suite diff in rubash compatibility testing.

## Verification

- Local build + manual test confirms files-before-dirs ordering matches GNU coreutils 9.4.
- CI build passes on the parent PR #996 branch.

Generated with [Devin](https://devin.ai)